### PR TITLE
Use a more unique name for upstreams

### DIFF
--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -270,7 +270,7 @@ func (lbc *LoadBalancerController) updateNGINX(name string, ing *extensions.Ingr
 		}
 
 		for _, path := range rule.HTTP.Paths {
-			name := ing.Name + "-" + path.Backend.ServiceName
+			name := path.Backend.ServiceName + "-Ingress-" + rule.Host + "-" + strings.Replace(path.Path, "/", "-", -1)
 			ups := nginx.NewUpstreamWithDefaultServer(name)
 
 			svcKey := ing.Namespace + "/" + path.Backend.ServiceName

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -263,11 +263,22 @@ func (lbc *LoadBalancerController) updateNGINX(name string, ing *extensions.Ingr
 	}
 
 	var upstreams []nginx.Upstream
+	var servers []nginx.Server
 
 	for _, rule := range ing.Spec.Rules {
 		if rule.IngressRuleValue.HTTP == nil {
 			continue
 		}
+
+		server := nginx.Server{Name: rule.Host}
+
+		if pemFile, ok := pems[rule.Host]; ok {
+			server.SSL = true
+			server.SSLCertificate = pemFile
+			server.SSLCertificateKey = pemFile
+		}
+
+		var locations []nginx.Location
 
 		for _, path := range rule.HTTP.Paths {
 			name := path.Backend.ServiceName + "-Ingress-" + rule.Host + "-" + strings.Replace(path.Path, "/", "-", -1)
@@ -297,32 +308,9 @@ func (lbc *LoadBalancerController) updateNGINX(name string, ing *extensions.Ingr
 				}
 			}
 
-			upstreams = append(upstreams, ups)
-		}
-	}
-
-	var servers []nginx.Server
-	for _, rule := range ing.Spec.Rules {
-		server := nginx.Server{Name: rule.Host}
-
-		if pemFile, ok := pems[rule.Host]; ok {
-			server.SSL = true
-			server.SSLCertificate = pemFile
-			server.SSLCertificateKey = pemFile
-		}
-
-		var locations []nginx.Location
-
-		for _, path := range rule.HTTP.Paths {
-			loc := nginx.Location{Path: path.Path}
-			upsName := ing.GetName() + "-" + path.Backend.ServiceName
-
-			for _, ups := range upstreams {
-				if upsName == ups.Name {
-					loc.Upstream = ups
-				}
-			}
+			loc := nginx.Location{Path: path.Path, Upstream: ups}
 			locations = append(locations, loc)
+			upstreams = append(upstreams, ups)
 		}
 
 		server.Locations = locations


### PR DESCRIPTION
With the previous naming convention, I am unable to create an Ingress such as this:

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: example-ingress
spec:
  rules:
  - host: foo.bar.com
    http:
      paths:
      - backend:
          serviceName: s1
          servicePort: 80
        path: /foo
  - host: bar.baz.com
    http:
      paths:
      - backend:
          serviceName: s1
          servicePort: 80
        path: /foo
```

(where two rules point to the same service)

I'm unsure what the best naming convention would be, but this provides a good level of uniqueness. Should the servicePort be included in the name too?