### PR TITLE
Handle missing Path in HTTPIngressPath

### DIFF
--- a/nginx-controller/Makefile
+++ b/nginx-controller/Makefile
@@ -6,7 +6,10 @@ PREFIX = nginxdemos/nginx-ingress
 nginx-ingress:
 	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o nginx-ingress *.go
 
-container: nginx-ingress
+test:
+	godep go test ./...
+
+container: nginx-ingress test
 	docker build -t $(PREFIX):$(TAG) .
 
 push: container

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -317,7 +317,7 @@ func (lbc *LoadBalancerController) updateNGINX(name string, ing *extensions.Ingr
 		var locations []nginx.Location
 
 		for _, path := range rule.HTTP.Paths {
-			loc := nginx.Location{Path: path.Path}
+			loc := nginx.Location{Path: pathOrDefault(path.Path)}
 			upsName := getNameForUpstream(ing, rule.Host, path.Backend.ServiceName)
 
 			if ups, ok := upstreams[upsName]; ok {
@@ -331,6 +331,14 @@ func (lbc *LoadBalancerController) updateNGINX(name string, ing *extensions.Ingr
 	}
 
 	lbc.nginx.AddOrUpdateIngress(name, nginx.IngressNGINXConfig{Upstreams: upstreamMapToSlice(upstreams), Servers: servers})
+}
+
+func pathOrDefault(path string) string {
+	if path == "" {
+		return "/"
+	} else {
+		return path
+	}
 }
 
 func endpointsToUpstreamServers(endps api.Endpoints, servicePort int) []nginx.UpstreamServer {

--- a/nginx-controller/controller/controller_test.go
+++ b/nginx-controller/controller/controller_test.go
@@ -1,0 +1,20 @@
+package controller
+
+import (
+	"testing"
+)
+
+func TestPathOrDefaultReturnDefault(t *testing.T) {
+	path := ""
+	expected = "/"
+	if pathOrDefault(path) != expected {
+		t.Errorf("pathOrDefault(%q) should return %q", path, expected)
+	}
+}
+
+func TestPathOrDefaultReturnActual(t *testing.T) {
+	path := "/path/to/resource"
+	if pathOrDefault(path) != path {
+		t.Errorf("pathOrDefault(%q) should return %q", path, path)
+	}
+}

--- a/nginx-controller/controller/controller_test.go
+++ b/nginx-controller/controller/controller_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestPathOrDefaultReturnDefault(t *testing.T) {
 	path := ""
-	expected = "/"
+	expected := "/"
 	if pathOrDefault(path) != expected {
 		t.Errorf("pathOrDefault(%q) should return %q", path, expected)
 	}

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -187,10 +187,9 @@ func shellOut(cmd string) {
 	glog.Infof("executing %s", cmd)
 
 	command := exec.Command("sh", "-c", cmd)
-	if glog.V(2) {
-		command.Stdout = &stdout
-		command.Stderr = &stderr
-	}
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
 	err := command.Start()
 	if err != nil {
 		glog.Fatalf("Failed to execute %v, err: %v", cmd, err)
@@ -198,10 +197,8 @@ func shellOut(cmd string) {
 
 	err = command.Wait()
 	if err != nil {
-		if glog.V(2) {
-			glog.Errorf("Command %v stdout: %q", cmd, stdout.String())
-			glog.Errorf("Command %v stderr: %q", cmd, stderr.String())
-		}
+		glog.Errorf("Command %v stdout: %q", cmd, stdout.String())
+		glog.Errorf("Command %v stderr: %q", cmd, stderr.String())
 		glog.Fatalf("Command %v finished with error: %v", cmd, err)
 	}
 }

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -1,6 +1,7 @@
 package nginx
 
 import (
+	"bytes"
 	"html/template"
 	"os"
 	"os/exec"
@@ -180,9 +181,17 @@ func (nginx *NGINXController) createCertsDir() {
 }
 
 func shellOut(cmd string) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
 	glog.Infof("executing %s", cmd)
 
 	command := exec.Command("sh", "-c", cmd)
+	if glog.V(2) {
+
+		command.Stdout = &stdout
+		command.Stderr = &stderr
+	}
 	err := command.Start()
 	if err != nil {
 		glog.Fatalf("Failed to execute %v, err: %v", cmd, err)
@@ -191,5 +200,9 @@ func shellOut(cmd string) {
 	err = command.Wait()
 	if err != nil {
 		glog.Fatalf("Command %v finished with error: %v", cmd, err)
+		if glog.V(2) {
+			glog.Errorf("Command %v stdout: %q", stdout.String())
+			glog.Errorf("Command %v stderr: %q", stderr.String())
+		}
 	}
 }

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -199,8 +199,8 @@ func shellOut(cmd string) {
 	err = command.Wait()
 	if err != nil {
 		if glog.V(2) {
-			glog.Errorf("Command %v stdout: %q", stdout.String())
-			glog.Errorf("Command %v stderr: %q", stderr.String())
+			glog.Errorf("Command %v stdout: %q", cmd, stdout.String())
+			glog.Errorf("Command %v stderr: %q", cmd, stderr.String())
 		}
 		glog.Fatalf("Command %v finished with error: %v", cmd, err)
 	}

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -188,7 +188,6 @@ func shellOut(cmd string) {
 
 	command := exec.Command("sh", "-c", cmd)
 	if glog.V(2) {
-
 		command.Stdout = &stdout
 		command.Stderr = &stderr
 	}
@@ -199,10 +198,10 @@ func shellOut(cmd string) {
 
 	err = command.Wait()
 	if err != nil {
-		glog.Fatalf("Command %v finished with error: %v", cmd, err)
 		if glog.V(2) {
 			glog.Errorf("Command %v stdout: %q", stdout.String())
 			glog.Errorf("Command %v stderr: %q", stderr.String())
 		}
+		glog.Fatalf("Command %v finished with error: %v", cmd, err)
 	}
 }


### PR DESCRIPTION
I had an Ingress with no Path set, which caused the ingress controller to go into a crash/restart loop because the relevant nginx config file ended up invalid (`location` without a parameter). The documentation says that we should send all traffic to the backend when Path is empty, so use "/" as the default.

I also added some logging to more easily debug issues like this, which can be enabled with `-V=2`.