### PR TITLE
Added handling empty path in Ingress resource for NGINX Plus Controller

### DIFF
--- a/nginx-plus-controller/Makefile
+++ b/nginx-plus-controller/Makefile
@@ -6,7 +6,10 @@ PREFIX = gcr.io/nginx-ingress/nginx-plus-ingress
 nginx-plus-ingress:
 	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o nginx-plus-ingress *.go
 
-container: nginx-plus-ingress
+test:
+	godep go test ./...
+
+container: nginx-plus-ingress test
 	docker build -t $(PREFIX):$(TAG) .
 
 push: container

--- a/nginx-plus-controller/controller/controller.go
+++ b/nginx-plus-controller/controller/controller.go
@@ -191,7 +191,7 @@ func (lbc *LoadBalancerController) updateNGINX(name string, ing *extensions.Ingr
 		var locations []nginx.Location
 
 		for _, path := range rule.HTTP.Paths {
-			loc := nginx.Location{Path: path.Path}
+			loc := nginx.Location{Path: pathOrDefault(path.Path)}
 			upsName := getNameForUpstream(ing, rule.Host, path.Backend.ServiceName)
 
 			if ups, ok := upstreams[upsName]; ok {
@@ -205,6 +205,13 @@ func (lbc *LoadBalancerController) updateNGINX(name string, ing *extensions.Ingr
 	}
 
 	lbc.nginx.AddOrUpdateIngress(name, nginx.IngressNGINXConfig{Upstreams: upstreamMapToSlice(upstreams), Servers: servers})
+}
+
+func pathOrDefault(path string) string {
+	if path == "" {
+		return "/"
+	}
+	return path
 }
 
 func getNameForUpstream(ing *extensions.Ingress, host string, service string) string {

--- a/nginx-plus-controller/controller/controller_test.go
+++ b/nginx-plus-controller/controller/controller_test.go
@@ -1,0 +1,20 @@
+package controller
+
+import (
+	"testing"
+)
+
+func TestPathOrDefaultReturnDefault(t *testing.T) {
+	path := ""
+	expected := "/"
+	if pathOrDefault(path) != expected {
+		t.Errorf("pathOrDefault(%q) should return %q", path, expected)
+	}
+}
+
+func TestPathOrDefaultReturnActual(t *testing.T) {
+	path := "/path/to/resource"
+	if pathOrDefault(path) != path {
+		t.Errorf("pathOrDefault(%q) should return %q", path, path)
+	}
+}

--- a/nginx-plus-controller/nginx/nginx.go
+++ b/nginx-plus-controller/nginx/nginx.go
@@ -1,6 +1,7 @@
 package nginx
 
 import (
+	"bytes"
 	"html/template"
 	"os"
 	"os/exec"
@@ -219,9 +220,15 @@ func (nginx *NGINXController) createCertsDir() {
 }
 
 func shellOut(cmd string) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
 	glog.Infof("executing %s", cmd)
 
 	command := exec.Command("sh", "-c", cmd)
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
 	err := command.Start()
 	if err != nil {
 		glog.Fatalf("Failed to execute %v, err: %v", cmd, err)
@@ -229,6 +236,8 @@ func shellOut(cmd string) {
 
 	err = command.Wait()
 	if err != nil {
+		glog.Errorf("Command %v stdout: %q", cmd, stdout.String())
+		glog.Errorf("Command %v stderr: %q", cmd, stderr.String())
 		glog.Fatalf("Command %v finished with error: %v", cmd, err)
 	}
 }


### PR DESCRIPTION
Also added logging output of failed shellout commands

Changes were upstreamed from the NGINX Controller, for which the problem was fixed by https://github.com/nginxinc/kubernetes-ingress/pull/14