### PR TITLE
access_log to stdout and error_log to stderr

### DIFF
--- a/nginx-controller/Dockerfile
+++ b/nginx-controller/Dockerfile
@@ -18,10 +18,4 @@ COPY nginx/nginx.conf /etc/nginx/nginx.conf
 
 RUN rm /etc/nginx/conf.d/*
 
-# This works only if the nginx master process is started from the process which is the Docker entrypoint, and has its
-# stdout and stderr set to the stdout and stderr of its parent (entrypoint). nginx must also run with `daemon off`,
-# otherwise it will detach its stdout.
-RUN ln -sf /dev/stdout /var/log/nginx/access.log
-RUN ln -sf /dev/stderr /var/log/nginx/error.log
-
 CMD ["/nginx-ingress"]

--- a/nginx-controller/Dockerfile
+++ b/nginx-controller/Dockerfile
@@ -14,6 +14,7 @@ EXPOSE 80 443
 
 COPY nginx-ingress /
 COPY nginx/ingress.tmpl /
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
 
 RUN rm /etc/nginx/conf.d/*
 

--- a/nginx-controller/Dockerfile
+++ b/nginx-controller/Dockerfile
@@ -18,4 +18,10 @@ COPY nginx/nginx.conf /etc/nginx/nginx.conf
 
 RUN rm /etc/nginx/conf.d/*
 
+# This works only if the nginx master process is started from the process which is the Docker entrypoint, and has its
+# stdout and stderr set to the stdout and stderr of its parent (entrypoint). nginx must also run with `daemon off`,
+# otherwise it will detach its stdout.
+RUN ln -sf /dev/stdout /var/log/nginx/access.log
+RUN ln -sf /dev/stderr /var/log/nginx/error.log
+
 CMD ["/nginx-ingress"]

--- a/nginx-controller/main.go
+++ b/nginx-controller/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	resolver := getKubeDNSIP(kubeClient)
 	ngxc, _ := nginx.NewNGINXController(resolver, "/etc/nginx/", local)
-	ngxc.Start()
+	go ngxc.Start()
 	lbc, _ := controller.NewLoadBalancerController(kubeClient, 30*time.Second, *watchNamespace, ngxc)
 	lbc.Run()
 }

--- a/nginx-controller/nginx/nginx.conf
+++ b/nginx-controller/nginx/nginx.conf
@@ -1,0 +1,32 @@
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/nginx-controller/nginx/nginx.conf
+++ b/nginx-controller/nginx/nginx.conf
@@ -3,7 +3,7 @@ daemon off;
 user  nginx;
 worker_processes  1;
 
-error_log  /var/log/nginx/error.log warn;
+error_log  stderr warn;
 pid        /var/run/nginx.pid;
 
 
@@ -20,7 +20,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /dev/stdout main;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/nginx-controller/nginx/nginx.conf
+++ b/nginx-controller/nginx/nginx.conf
@@ -16,8 +16,8 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
+    log_format  main  '$remote_addr - $remote_user [$time_local] $host "$request" '
+                      '$status $body_bytes_sent $request_time "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     access_log  /dev/stdout main;

--- a/nginx-controller/nginx/nginx.conf
+++ b/nginx-controller/nginx/nginx.conf
@@ -1,4 +1,5 @@
 
+daemon off;
 user  nginx;
 worker_processes  1;
 

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -170,7 +170,17 @@ func (nginx *NGINXController) Reload() {
 // Start starts NGINX
 func (nginx *NGINXController) Start() {
 	if !nginx.local {
-		shellOut("nginx")
+		command := exec.Command("nginx")
+		command.Stdout = os.Stdout
+		command.Stderr = os.Stderr
+		err := command.Start()
+		if err != nil {
+			glog.Fatalf("Error while starting nginx: %v", err)
+		}
+		err = command.Wait()
+		if err != nil {
+			glog.Fatalf("Error while waiting for nginx: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
To easily get query logs into the [kubernetes fluentd-elasticsearch setup](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/fluentd-elasticsearch), log access_log to stdout and error_log to stderr.

* Move nginx.conf from the base image into the source tree so that we can modify it.
* When we start nginx, attach the controller's stdout and stderr to the nginx process. For this to work we have to run nginx in the foreground (`daemon off`). Since we're running nginx in the foreground, use a goroutine to avoid blocking the controller process.
* Set access_log to /dev/stdout and error_log to stderr.

I don't know if you want to merge this as it is a significant change to how logging happens, but we're  using this and I think it's useful, so I thought I'd share.

Since we can now edit nginx.conf, I've also added `$host`, so we can more easily tell which backend we're hitting when using host based Ingress, and `$request_time`, since that is generally useful, to the main access_log format.