### PR TITLE
Added forwarding NGINX access and error logs to docker log collector

### DIFF
--- a/nginx-controller/Dockerfile
+++ b/nginx-controller/Dockerfile
@@ -20,6 +20,11 @@ RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC64107
 
 EXPOSE 80 443
 
+# forward nginx access and error logs to stdout and stderr of the ingress
+# controller process
+RUN ln -sf /proc/1/fd/1 /var/log/nginx/access.log \
+	&& ln -sf /proc/1/fd/2 /var/log/nginx/error.log
+
 COPY nginx-ingress /
 COPY nginx/ingress.tmpl /
 

--- a/nginx-plus-controller/Dockerfile
+++ b/nginx-plus-controller/Dockerfile
@@ -24,6 +24,11 @@ RUN apt-get update && apt-get install -y nginx-plus
 
 EXPOSE 80 443 8080
 
+# forward nginx access and error logs to stdout and stderr of the ingress
+# controller process
+RUN ln -sf /proc/1/fd/1 /var/log/nginx/access.log \
+	&& ln -sf /proc/1/fd/2 /var/log/nginx/error.log
+
 COPY nginx-plus-ingress /
 COPY nginx/ingress.tmpl /
 

--- a/nginx-plus-controller/nginx/nginx.go
+++ b/nginx-plus-controller/nginx/nginx.go
@@ -20,6 +20,7 @@ const statusAPIConf = `server {
     }
 
     location /status {
+        access_log off;
         status;
     }
 }`


### PR DESCRIPTION
NGINX access and error logs are now redirected to stdout and stderr of the ingress controller process, which are collected by docker. You can see the logs by running `kubectl logs <nginx-ingress-podname>`