### PR TITLE
Removed DNS dependency from NGINX controller

### DIFF
--- a/nginx-controller/main.go
+++ b/nginx-controller/main.go
@@ -43,18 +43,8 @@ func main() {
 		}
 	}
 
-	resolver := getKubeDNSIP(kubeClient)
-	ngxc, _ := nginx.NewNGINXController(resolver, "/etc/nginx/", local)
+	ngxc, _ := nginx.NewNGINXController("/etc/nginx/", local)
 	ngxc.Start()
 	lbc, _ := controller.NewLoadBalancerController(kubeClient, 30*time.Second, *watchNamespace, ngxc)
 	lbc.Run()
-}
-
-func getKubeDNSIP(kubeClient *client.Client) string {
-	svcClient := kubeClient.Services("kube-system")
-	svc, err := svcClient.Get("kube-dns")
-	if err != nil {
-		glog.Fatalf("Failed to get kube-dns service, err: %v", err)
-	}
-	return svc.Spec.ClusterIP
 }

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -12,7 +12,6 @@ import (
 
 // NGINXController Updates NGINX configuration, starts and reloads NGINX
 type NGINXController struct {
-	resolver       string
 	nginxConfdPath string
 	nginxCertsPath string
 	local          bool
@@ -62,9 +61,8 @@ func NewUpstreamWithDefaultServer(name string) Upstream {
 }
 
 // NewNGINXController creates a NGINX controller
-func NewNGINXController(resolver string, nginxConfPath string, local bool) (*NGINXController, error) {
+func NewNGINXController(nginxConfPath string, local bool) (*NGINXController, error) {
 	ngxc := NGINXController{
-		resolver:       resolver,
 		nginxConfdPath: path.Join(nginxConfPath, "conf.d"),
 		nginxCertsPath: path.Join(nginxConfPath, "ssl"),
 		local:          local,


### PR DESCRIPTION
The ingress controller for NGINX doesn't use DNS to resolve endpoints of services, but still depends on it--if it finds that DNS addon isn't enabled, the controller fails.
https://github.com/nginxinc/kubernetes-ingress/issues/8