### PR TITLE
set a default server_names_hash_bucket_size so that controller logic …

### DIFF
--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -16,5 +16,6 @@ func NewDefaultConfig() *Config {
 		ProxyReadTimeout:           "60s",
 		ClientMaxBodySize:          "1m",
 		MainServerNamesHashMaxSize: "512",
+		MainServerNamesHashBucketSize: "32",
 	}
 }

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -81,7 +81,11 @@ func NewNginxController(nginxConfPath string, local bool) (*NginxController, err
 		ngxc.createCertsDir()
 	}
 
-	cfg := &NginxMainConfig{ServerNamesHashMaxSize: NewDefaultConfig().MainServerNamesHashMaxSize}
+	cfg := &NginxMainConfig{
+		ServerNamesHashMaxSize: NewDefaultConfig().MainServerNamesHashMaxSize,
+		ServerNamesHashBucketSize: NewDefaultConfig().MainServerNamesHashBucketSize,
+	}
+
 	ngxc.UpdateMainConfigFile(cfg)
 
 	return &ngxc, nil


### PR DESCRIPTION
…applies ConfigMap overrides fixes nginxinc/kubernetes-ingress#34