### PR TITLE
add securityContext incontainer spec

### DIFF
--- a/examples/complete-example/nginx-ingress-rc.yaml
+++ b/examples/complete-example/nginx-ingress-rc.yaml
@@ -22,6 +22,8 @@ spec:
           hostPort: 80
         - containerPort: 443
           hostPort: 443
+        securityContext:
+          privileged: true
         # Uncomment the lines below to enable extensive logging and/or customization of
         # NGINX configuration with configmaps
         #args:

--- a/examples/complete-example/nginx-plus-ingress-rc.yaml
+++ b/examples/complete-example/nginx-plus-ingress-rc.yaml
@@ -24,6 +24,8 @@ spec:
           hostPort: 443
         - containerPort: 8080
           hostPort: 8080
+        securityContext:
+          privileged: true
         # Uncomment the lines below to enable extensive logging and/or customization of
         # NGINX configuration with configmaps
         #args:

--- a/examples/daemon-set/nginx-ingress.yaml
+++ b/examples/daemon-set/nginx-ingress.yaml
@@ -19,6 +19,8 @@ spec:
           hostPort: 80
         - containerPort: 443
           hostPort: 443
+        securityContext:
+          privileged: true
         # Uncomment the lines below to enable extensive logging and/or customization of
         # NGINX configuration with configmaps
         #args:

--- a/examples/daemon-set/nginx-plus-ingress.yaml
+++ b/examples/daemon-set/nginx-plus-ingress.yaml
@@ -19,6 +19,8 @@ spec:
           hostPort: 80
         - containerPort: 443
           hostPort: 443
+        securityContext:
+          privileged: true
         # Uncomment the lines below to enable extensive logging and/or customization of
         # NGINX configuration with configmaps
         #args:


### PR DESCRIPTION
when create nginx ingress controller, the nginx failed to start. after kubernetes 1.1,we need add securityContext in container spec.
`securityContext:
          privileged: true`
