### PR TITLE
Redirect proxy pass subpaths

### DIFF
--- a/nginx-controller/nginx/ingress.tmpl
+++ b/nginx-controller/nginx/ingress.tmpl
@@ -24,7 +24,7 @@ server {
 	{{end}}
 
 	{{range $location := $server.Locations}}
-	location {{$location.Path}} {
+	location ~ ^{{$location.Path}}(.*)$ {
 		proxy_http_version 1.1;
 		{{if $location.Websocket}}
 		proxy_set_header Upgrade $http_upgrade;
@@ -39,6 +39,7 @@ server {
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Port $server_port;
 		proxy_set_header X-Forwarded-Proto $scheme;
+		rewrite ^{{$location.Path}}/(.*) /$1 break;
 		{{if $location.SSL}}
 		proxy_pass https://{{$location.Upstream.Name}};
 		{{else}}

--- a/nginx-plus-controller/nginx/ingress.tmpl
+++ b/nginx-plus-controller/nginx/ingress.tmpl
@@ -29,7 +29,7 @@ server {
 	{{end}}
 
 	{{range $location := $server.Locations}}
-	location {{$location.Path}} {
+	location ~ ^{{$location.Path}}(.*)$ {
 		proxy_http_version 1.1;
 		{{if $location.Websocket}}
 		proxy_set_header Upgrade $http_upgrade;
@@ -44,6 +44,7 @@ server {
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Port $server_port;
 		proxy_set_header X-Forwarded-Proto $scheme;
+		rewrite ^{{$location.Path}}/(.*) /$1 break;
 		{{if $location.SSL}}
 		proxy_pass https://{{$location.Upstream.Name}};
 		{{else}}


### PR DESCRIPTION
Otherwise more complex examples like e.g. RabbitMQ will not work,
because they try to load e.g. 'src=js/foo.js'.
