### PR TITLE
Add SSL services annotation

### DIFF
--- a/examples/ssl-services/README.md
+++ b/examples/ssl-services/README.md
@@ -1,0 +1,34 @@
+# SSL Services Support
+
+To load balance an application that requires HTTPS with NGINX Ingress controllers, you need to add the **nginx.org/ssl-services** annotation to your Ingress resource definition. The annotation specifies which services are SSL services. The annotation syntax is as follows:
+```
+nginx.org/ssl-services: "service1[,service2,...]"
+```
+
+In the following example we load balance three applications, one of which requires HTTPS:
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: cafe-ingress
+  annotations:
+    nginx.org/ssl-services: "ssl-svc"
+spec:
+  rules:
+  - host: cafe.example.com
+    http:
+      paths:
+      - path: /tea
+        backend:
+          serviceName: tea-svc
+          servicePort: 80
+      - path: /coffee
+        backend:
+          serviceName: coffee-svc
+          servicePort: 80
+      - path: /ssl
+        backend:
+          serviceName: ssl-svc
+          servicePort: 443
+```
+*ssl-svc* is a service for an HTTPS application. The service becomes available at the `/ssl` path. Note how we used the **nginx.org/ssl-services** annotation.

--- a/nginx-controller/nginx/ingress.tmpl
+++ b/nginx-controller/nginx/ingress.tmpl
@@ -39,6 +39,10 @@ server {
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Port $server_port;
 		proxy_set_header X-Forwarded-Proto $scheme;
+		{{if $location.SSL}}
+		proxy_pass https://{{$location.Upstream.Name}};
+		{{else}}
 		proxy_pass http://{{$location.Upstream.Name}};
+		{{end}}
 	}{{end}}
 }{{end}}

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -53,6 +53,7 @@ type Location struct {
 	ProxyReadTimeout    string
 	ClientMaxBodySize   string
 	Websocket           bool
+	SSL                 bool
 }
 
 // NginxMainConfig describe the main NGINX configuration file

--- a/nginx-plus-controller/nginx/ingress.tmpl
+++ b/nginx-plus-controller/nginx/ingress.tmpl
@@ -44,6 +44,10 @@ server {
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Port $server_port;
 		proxy_set_header X-Forwarded-Proto $scheme;
+		{{if $location.SSL}}
+		proxy_pass https://{{$location.Upstream.Name}};
+		{{else}}
 		proxy_pass http://{{$location.Upstream.Name}};
+		{{end}}
 	}{{end}}
 }{{end}}

--- a/nginx-plus-controller/nginx/nginx.go
+++ b/nginx-plus-controller/nginx/nginx.go
@@ -76,6 +76,7 @@ type Location struct {
 	ProxyReadTimeout    string
 	ClientMaxBodySize   string
 	Websocket           bool
+	SSL                 bool
 }
 
 // NginxMainConfig describe the main NGINX configuration file


### PR DESCRIPTION
If an application in a container requires HTTPS, one needs to set the
'proxy_path https://...' instead of 'proxy_pass http://...'. With this
patch one can use the annotation:

  'nginx.org/ssl-services: "service1[,service2,...]"'

to specify, which services require HTTPS.

Fixes #61