### PR TITLE
Add HTTP2 as option in configmap and annotations

### DIFF
--- a/examples/customization/nginx-config.yaml
+++ b/examples/customization/nginx-config.yaml
@@ -8,3 +8,4 @@ data:
   client-max-body-size: "2m" # default is "1m". See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
   server-names-hash-bucket-size: "64" # default value depends on the size of the processor’s cache line. See http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size
   server-names-hash-max-size: "1024" # default is "512". See http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size
+  http2: 'True' # default is "False". Enables http2 in servers with SSL enabled. See https://nginx.org/en/docs/http/ngx_http_v2_module.html

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -320,6 +321,13 @@ func (lbc *LoadBalancerController) syncCfgm(key string) {
 		}
 		if serverNamesHashMaxSize, exists := cfgm.Data["server-names-hash-max-size"]; exists {
 			cfg.MainServerNamesHashMaxSize = serverNamesHashMaxSize
+		}
+		if HTTP2Str, exists := cfgm.Data["http2"]; exists {
+			if HTTP2, err := strconv.ParseBool(HTTP2Str); err == nil {
+				cfg.HTTP2 = HTTP2
+			} else {
+				glog.Errorf("In configmap %v/%v 'http2' contains invalid declaration: %v, ignoring", cfgm.Namespace, cfgm.Name, err)
+			}
 		}
 	}
 	lbc.cnf.UpdateConfig(cfg)

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -5,6 +5,7 @@ type Config struct {
 	ProxyConnectTimeout           string
 	ProxyReadTimeout              string
 	ClientMaxBodySize             string
+	HTTP2                         bool
 	MainServerNamesHashBucketSize string
 	MainServerNamesHashMaxSize    string
 }

--- a/nginx-controller/nginx/ingress.tmpl
+++ b/nginx-controller/nginx/ingress.tmpl
@@ -8,7 +8,7 @@ upstream {{$upstream.Name}} {
 server {
 	listen 80;
 	{{if $server.SSL}}
-	listen 443 ssl;
+	listen 443 ssl{{if $server.HTTP2}} http2{{end}};
 	ssl_certificate {{$server.SSLCertificate}};
 	ssl_certificate_key {{$server.SSLCertificateKey}};
 	{{end}}

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -43,6 +43,7 @@ type Server struct {
 	SSL               bool
 	SSLCertificate    string
 	SSLCertificateKey string
+	HTTP2             bool
 }
 
 // Location describes an NGINX location


### PR DESCRIPTION
Hi Nginx Team,

I have added default http2 support to the ingress template.
Is there a reason, that the nginx ingress controller does not enable http2 for ssl connections by default?
The only obstacle I had, was that the environment in the debian container (openssl 1.0.1f) does not support http2. That is why I changed the base container to alpine. (wich should also solve #11)

The changed image is uploaded to: (Tag: 0.5.0)
https://quay.io/repository/nico_schieder/nginxinc-kubernetes-ingress

Please keep in mind that I could not test the nginx plus config.