### PR TITLE
Support for custom log-format

### DIFF
--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -329,6 +329,9 @@ func (lbc *LoadBalancerController) syncCfgm(key string) {
 				glog.Errorf("In configmap %v/%v 'http2' contains invalid declaration: %v, ignoring", cfgm.Namespace, cfgm.Name, err)
 			}
 		}
+		if logFormat, exists := cfgm.Data["log-format"]; exists {
+			cfg.MainLogFormat = logFormat
+		}
 	}
 	lbc.cnf.UpdateConfig(cfg)
 

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	HTTP2                         bool
 	MainServerNamesHashBucketSize string
 	MainServerNamesHashMaxSize    string
+	MainLogFormat                 string
 }
 
 // NewDefaultConfig creates a Config with default values

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -329,6 +329,7 @@ func (cnf *Configurator) UpdateConfig(config *Config) {
 	mainCfg := &NginxMainConfig{
 		ServerNamesHashBucketSize: config.MainServerNamesHashBucketSize,
 		ServerNamesHashMaxSize:    config.MainServerNamesHashMaxSize,
+		LogFormat:                 config.MainLogFormat,
 	}
 
 	cnf.nginx.UpdateMainConfigFile(mainCfg)

--- a/nginx-controller/nginx/nginx.conf.tmpl
+++ b/nginx-controller/nginx/nginx.conf.tmpl
@@ -15,10 +15,13 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    {{if .LogFormat -}}
+    log_format  main  '{{.LogFormat}}';
+    {{- else -}}
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
-
+    {{- end }}
     access_log  /var/log/nginx/access.log  main;
 
     sendfile        on;

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -3,7 +3,7 @@ package nginx
 import (
 	"bytes"
 	"fmt"
-	"html/template"
+	"text/template"
 	"os"
 	"os/exec"
 	"path"
@@ -62,6 +62,7 @@ type Location struct {
 type NginxMainConfig struct {
 	ServerNamesHashBucketSize string
 	ServerNamesHashMaxSize    string
+	LogFormat                 string
 }
 
 // NewUpstreamWithDefaultServer creates an upstream with the default server.


### PR DESCRIPTION
I noticed that the log-format could not be customized and created a small patch that makes exactly this possible so everyone can add fields to his or her liking or switch to a totally different format. Use like this to switch to JSON-logging for example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: nginx-ingress-conf
  namespace: kube-system
data:
  log-format: '{ "@timestamp": "$time_iso8601", "@version": "1", "clientip": "$remote_addr", "tag": "ingress", "remote_user": "$remote_user", "bytes": $bytes_sent, "duration": $request_time, "status": $status, "request": "$request_uri", "urlpath": "$uri", "urlquery": "$args", "method": "$request_method", "referer": "$http_referer", "useragent": "$http_user_agent", "software": "nginx", "version": "$nginx_version", "host": "$host", "upstream": "$upstream_addr", "upstream-status": "$upstream_status" }'
```
I also noticed that the tempalte engine was `html/template`,  which caused all text inside single quotes to be escaped like it was an HTML attribute. I therefore switched to `text/template`, I think this was meant to be used anyway.