### PR TITLE
Add support for configuring pxoxy-buffer-settings

### DIFF
--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -332,6 +332,22 @@ func (lbc *LoadBalancerController) syncCfgm(key string) {
 		if logFormat, exists := cfgm.Data["log-format"]; exists {
 			cfg.MainLogFormat = logFormat
 		}
+		if proxyBufferingStr, exists := cfgm.Data["proxy-buffering"]; exists {
+			if ProxyBuffering, err := strconv.ParseBool(proxyBufferingStr); err == nil {
+				cfg.ProxyBuffering = ProxyBuffering
+			} else {
+				glog.Errorf("In configmap %v/%v 'proxy-buffering' contains invalid declaration: %v, ignoring", cfgm.Namespace, cfgm.Name, err)
+			}
+		}
+		if proxyBuffers, exists := cfgm.Data["proxy-buffers"]; exists {
+			cfg.ProxyBuffers = proxyBuffers
+		}
+		if proxyBufferSize, exists := cfgm.Data["proxy-buffer-size"]; exists {
+			cfg.ProxyBufferSize = proxyBufferSize
+		}
+		if proxyMaxTempFileSize, exists := cfgm.Data["proxy-max-temp-file-size"]; exists {
+			cfg.ProxyMaxTempFileSize = proxyMaxTempFileSize
+		}
 	}
 	lbc.cnf.UpdateConfig(cfg)
 

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -9,6 +9,10 @@ type Config struct {
 	MainServerNamesHashBucketSize string
 	MainServerNamesHashMaxSize    string
 	MainLogFormat                 string
+	ProxyBuffering                bool
+	ProxyBuffers                  string
+	ProxyBufferSize               string
+	ProxyMaxTempFileSize          string
 }
 
 // NewDefaultConfig creates a Config with default values
@@ -18,5 +22,6 @@ func NewDefaultConfig() *Config {
 		ProxyReadTimeout:           "60s",
 		ClientMaxBodySize:          "1m",
 		MainServerNamesHashMaxSize: "512",
+		ProxyBuffering:             true,
 	}
 }

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -187,6 +187,22 @@ func (cnf *Configurator) createConfig(ingEx *IngressEx) Config {
 			glog.Errorf("In %v/%v nginx.org/http2 contains invalid declaration: %v, ignoring", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
 		}
 	}
+	if proxyBufferingStr, exists := ingEx.Ingress.Annotations["nginx.org/proxy-buffering"]; exists {
+		if ProxyBuffering, err := strconv.ParseBool(proxyBufferingStr); err == nil {
+			ingCfg.ProxyBuffering = ProxyBuffering
+		} else {
+			glog.Errorf("In %v/%v nginx.org/proxy-buffering contains invalid declaration: %v, ignoring", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+		}
+	}
+	if proxyBuffers, exists := ingEx.Ingress.Annotations["nginx.org/proxy-buffers"]; exists {
+		ingCfg.ProxyBuffers = proxyBuffers
+	}
+	if proxyBufferSize, exists := ingEx.Ingress.Annotations["nginx.org/proxy-buffer-size"]; exists {
+		ingCfg.ProxyBufferSize = proxyBufferSize
+	}
+	if proxyMaxTempFileSize, exists := ingEx.Ingress.Annotations["nginx.org/proxy-max-temp-file-size"]; exists {
+		ingCfg.ProxyMaxTempFileSize = proxyMaxTempFileSize
+	}
 	return ingCfg
 }
 
@@ -252,14 +268,18 @@ func getSSLServices(ingEx *IngressEx) map[string]bool {
 
 func createLocation(path string, upstream Upstream, cfg *Config, websocket bool, rewrite string, ssl bool) Location {
 	loc := Location{
-		Path:                path,
-		Upstream:            upstream,
-		ProxyConnectTimeout: cfg.ProxyConnectTimeout,
-		ProxyReadTimeout:    cfg.ProxyReadTimeout,
-		ClientMaxBodySize:   cfg.ClientMaxBodySize,
-		Websocket:           websocket,
-		Rewrite:             rewrite,
-		SSL:                 ssl,
+		Path:                 path,
+		Upstream:             upstream,
+		ProxyConnectTimeout:  cfg.ProxyConnectTimeout,
+		ProxyReadTimeout:     cfg.ProxyReadTimeout,
+		ClientMaxBodySize:    cfg.ClientMaxBodySize,
+		Websocket:            websocket,
+		Rewrite:              rewrite,
+		SSL:                  ssl,
+		ProxyBuffering:       cfg.ProxyBuffering,
+		ProxyBuffers:         cfg.ProxyBuffers,
+		ProxyBufferSize:      cfg.ProxyBufferSize,
+		ProxyMaxTempFileSize: cfg.ProxyMaxTempFileSize,
 	}
 
 	return loc

--- a/nginx-controller/nginx/ingress.tmpl
+++ b/nginx-controller/nginx/ingress.tmpl
@@ -39,6 +39,17 @@ server {
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Port $server_port;
 		proxy_set_header X-Forwarded-Proto $scheme;
+
+		proxy_buffering {{if $location.ProxyBuffering}}on{{else}}off{{end}};
+		{{- if $location.ProxyBuffers}}
+		proxy_buffers {{$location.ProxyBuffers}};
+		{{- end}}
+		{{- if $location.ProxyBufferSize}}
+		proxy_buffer_size {{$location.ProxyBufferSize}};
+		{{- end}}
+		{{- if $location.ProxyMaxTempFileSize}}
+		proxy_max_temp_file_size {{$location.ProxyMaxTempFileSize}};
+		{{- end}}
 		{{if $location.SSL}}
 		proxy_pass https://{{$location.Upstream.Name}}{{$location.Rewrite}};
 		{{else}}

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -48,14 +48,18 @@ type Server struct {
 
 // Location describes an NGINX location
 type Location struct {
-	Path                string
-	Upstream            Upstream
-	ProxyConnectTimeout string
-	ProxyReadTimeout    string
-	ClientMaxBodySize   string
-	Websocket           bool
-	Rewrite             string
-	SSL                 bool
+	Path                 string
+	Upstream             Upstream
+	ProxyConnectTimeout  string
+	ProxyReadTimeout     string
+	ClientMaxBodySize    string
+	Websocket            bool
+	Rewrite              string
+	SSL                  bool
+	ProxyBuffering       bool
+	ProxyBuffers         string
+	ProxyBufferSize      string
+	ProxyMaxTempFileSize string
 }
 
 // NginxMainConfig describe the main NGINX configuration file


### PR DESCRIPTION
A small patch to enable configuring `proxy_buffers` and `proxy_buffer_size` which is necessary especially when your backends send a lot of headers and you want to increase the default value.