### PR TITLE
Add support for alpine-based image

### DIFF
--- a/nginx-controller/DockerfileForAlpine
+++ b/nginx-controller/DockerfileForAlpine
@@ -1,0 +1,12 @@
+FROM nginx:1.11.5-alpine
+
+# forward nginx access and error logs to stdout and stderr of the ingress
+# controller process
+RUN ln -sf /proc/1/fd/1 /var/log/nginx/access.log \
+	&& ln -sf /proc/1/fd/2 /var/log/nginx/error.log
+
+COPY nginx-ingress nginx/ingress.tmpl nginx/nginx.conf.tmpl /
+
+RUN rm /etc/nginx/conf.d/*
+
+ENTRYPOINT ["/nginx-ingress"]

--- a/nginx-controller/Makefile
+++ b/nginx-controller/Makefile
@@ -6,6 +6,7 @@ PREFIX = nginxdemos/nginx-ingress
 
 DOCKER_RUN = docker run --rm -v $(shell pwd)/../:/go/src/github.com/nginxinc/kubernetes-ingress -w /go/src/github.com/nginxinc/kubernetes-ingress/nginx-controller/
 GOLANG_CONTAINER = golang:1.6
+DOCKERFILE = Dockerfile
 
 BUILD_IN_CONTAINER = 1
 PUSH_TO_GCR =
@@ -29,7 +30,7 @@ else
 endif
 
 container: test nginx-ingress
-	docker build -t $(PREFIX):$(TAG) .
+	docker build -f $(DOCKERFILE) -t $(PREFIX):$(TAG) .
 
 push: container
 	$(GCLOUD) docker push $(PREFIX):$(TAG)

--- a/nginx-controller/README.md
+++ b/nginx-controller/README.md
@@ -30,8 +30,11 @@ The **Makefile** contains the following main variables, which you should customi
 * **VERSION** -- the current version of the controller.
 * **TAG** -- the tag added to the image. It's set to the value of the `VERSION` variable by default.
 * **PUSH_TO_GCR**. If you’re running your Kubernetes in GCE and using Google Container Registry, make sure that `PUSH_TO_GCR = 1`. This means using the `gcloud docker push` command to push the image, which is convenient when pushing images to GCR. By default, the variable is unset and the regular `docker push` command is used to push the image to the registry.
+* **DOCKERFILE** -- the path to a Dockerfile. We provide two Dockerfiles:
+  1. `Dockerfile`, for building a debian-based image. It's used by default.
+  1. `DockerfileForAlpine`, for building an alpine-based image.
 
-Let’s create the controller binary, build an image and push the image to the private registry. Make sure to run the `docker login` command first to login to the registry. If you’re using Google Container Registry, as we are in our example here, you don’t need to use the docker command to login. However, make sure you’re logged into the gcloud tool (using the `gcloud auth login` command). 
+Let’s create the controller binary, build an image and push the image to the private registry. Make sure to run the `docker login` command first to login to the registry. If you’re using Google Container Registry, as we are in our example here, you don’t need to use the docker command to login. However, make sure you’re logged into the gcloud tool (using the `gcloud auth login` command).
 
 In this folder we run the following commands in the shell:
 ```


### PR DESCRIPTION
Closes https://github.com/nginxinc/kubernetes-ingress/issues/11
Helps https://github.com/nginxinc/kubernetes-ingress/pull/65

HTTP/2 support for Chrome users is available via the alpine-based image.