### PR TITLE
Fix default server

### DIFF
--- a/nginx-controller/nginx/ingress.tmpl
+++ b/nginx-controller/nginx/ingress.tmpl
@@ -6,9 +6,9 @@ upstream {{$upstream.Name}} {
 
 {{range $server := .Servers}}
 server {
-	listen 80;
+	listen 80{{if not $server.Name}} default_server{{end}};
 	{{if $server.SSL}}
-	listen 443 ssl{{if $server.HTTP2}} http2{{end}};
+	listen 443 ssl{{if $server.HTTP2}} http2{{end}}{{if not $server.Name}} default_server{{end}};
 	ssl_certificate {{$server.SSLCertificate}};
 	ssl_certificate_key {{$server.SSLCertificateKey}};
 	{{end}}


### PR DESCRIPTION
If I create a default server using a ingress config like this:
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: default-backend
  namespace: default
spec:
  backend:
    serviceName: default-backend
    servicePort: 80
```
the configuration is created, but because of a missing default_server option in the servers listen directive it is not actually been used as the default backend.