### PR TITLE
Secret retry

### DIFF
--- a/nginx-controller/controller/utils.go
+++ b/nginx-controller/controller/utils.go
@@ -59,6 +59,14 @@ func (t *taskQueue) requeue(key string, err error) {
 	t.queue.Add(key)
 }
 
+func (t *taskQueue) requeueAfter(key string, err error, after time.Duration) {
+	glog.Errorf("Requeuing %v after %s, err %v", key, after.String(), err)
+	go func(key string, after time.Duration) {
+		time.Sleep(after)
+		t.queue.Add(key)
+	}(key, after)
+}
+
 // worker processes work in the queue through sync.
 func (t *taskQueue) worker() {
 	for {


### PR DESCRIPTION
If a certificate secret referenced in an ingress object is not found,
the ingress controller will reject the ingress object. but retries every 5s.
This fixes #78.

I have tested this with success on my private cluster merged together with #77 and #81 and kube-lego.

This is a quite simple approach to the issue, next steps to improve this feature are:
- add a error event to the rejected ingress object
- only reject ingress rules referencing a host, that should be secured by the secret, when it can't be found

I think we can cover point 1 when we implement the event logging system also improving #77,
point 2 is more difficult, but I think most users will use only one host per ingress object, so this is not an issue in most cases.