### PR TITLE
Add proxy_hide_header directive

### DIFF
--- a/nginx-controller/Makefile
+++ b/nginx-controller/Makefile
@@ -1,14 +1,14 @@
 all: push
 
-VERSION = 0.6.0
+VERSION = 0.6.3-merged
 TAG = $(VERSION)
-PREFIX = nginxdemos/nginx-ingress
+PREFIX = quay.io/nico_schieder/nginxinc-kubernetes-ingress
 
-DOCKER_RUN = docker run --rm -v $(shell pwd)/../:/go/src/github.com/nginxinc/kubernetes-ingress -w /go/src/github.com/nginxinc/kubernetes-ingress/nginx-controller/
+DOCKER_RUN = docker run --rm -v $(shell pwd)/../:/go/src/github.com/nginxinc/kubernetes-ingress:Z -w /go/src/github.com/nginxinc/kubernetes-ingress/nginx-controller/
 GOLANG_CONTAINER = golang:1.6
 DOCKERFILE = Dockerfile
 
-BUILD_IN_CONTAINER = 1
+BUILD_IN_CONTAINER = 0
 PUSH_TO_GCR =
 
 ifeq ($(PUSH_TO_GCR),1)

--- a/nginx-controller/Makefile
+++ b/nginx-controller/Makefile
@@ -1,14 +1,14 @@
 all: push
 
-VERSION = 0.6.3-merged
+VERSION = 0.6.0
 TAG = $(VERSION)
-PREFIX = quay.io/nico_schieder/nginxinc-kubernetes-ingress
+PREFIX = nginxdemos/nginx-ingress
 
-DOCKER_RUN = docker run --rm -v $(shell pwd)/../:/go/src/github.com/nginxinc/kubernetes-ingress:Z -w /go/src/github.com/nginxinc/kubernetes-ingress/nginx-controller/
+DOCKER_RUN = docker run --rm -v $(shell pwd)/../:/go/src/github.com/nginxinc/kubernetes-ingress -w /go/src/github.com/nginxinc/kubernetes-ingress/nginx-controller/
 GOLANG_CONTAINER = golang:1.6
 DOCKERFILE = Dockerfile
 
-BUILD_IN_CONTAINER = 0
+BUILD_IN_CONTAINER = 1
 PUSH_TO_GCR =
 
 ifeq ($(PUSH_TO_GCR),1)

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -322,6 +322,13 @@ func (lbc *LoadBalancerController) syncCfgm(key string) {
 				cfg.ProxyHideHeaders = proxyHideHeaders
 			}
 		}
+		if proxyPassHeaders, exists, err := nginx.GetMapKeyAsStringSlice(cfgm.Data, "proxy-pass-headers", cfgm); exists {
+			if err != nil {
+				glog.Error(err)
+			} else {
+				cfg.ProxyPassHeaders = proxyPassHeaders
+			}
+		}
 		if clientMaxBodySize, exists := cfgm.Data["client-max-body-size"]; exists {
 			cfg.ClientMaxBodySize = clientMaxBodySize
 		}

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -315,6 +315,13 @@ func (lbc *LoadBalancerController) syncCfgm(key string) {
 		if proxyReadTimeout, exists := cfgm.Data["proxy-read-timeout"]; exists {
 			cfg.ProxyReadTimeout = proxyReadTimeout
 		}
+		if proxyHideHeaders, exists, err := nginx.GetMapKeyAsStringSlice(cfgm.Data, "proxy-hide-headers", cfgm); exists {
+			if err != nil {
+				glog.Error(err)
+			} else {
+				cfg.ProxyHideHeaders = proxyHideHeaders
+			}
+		}
 		if clientMaxBodySize, exists := cfgm.Data["client-max-body-size"]; exists {
 			cfg.ClientMaxBodySize = clientMaxBodySize
 		}

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	ProxyMaxTempFileSize          string
 	ProxyProtocol                 bool
 	ProxyHideHeaders              []string
+	ProxyPassHeaders              []string
 	HSTS                          bool
 	HSTSMaxAge                    int64
 	HSTSIncludeSubdomains         bool

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	ProxyBufferSize               string
 	ProxyMaxTempFileSize          string
 	ProxyProtocol                 bool
+	ProxyHideHeaders              []string
 	HSTS                          bool
 	HSTSMaxAge                    int64
 	HSTSIncludeSubdomains         bool

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -113,6 +113,7 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 			SetRealIPFrom:         ingCfg.SetRealIPFrom,
 			RealIPRecursive:       ingCfg.RealIPRecursive,
 			ProxyHideHeaders:      ingCfg.ProxyHideHeaders,
+			ProxyPassHeaders:      ingCfg.ProxyPassHeaders,
 		}
 
 		if pemFile, ok := pems[serverName]; ok {
@@ -162,6 +163,7 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 			SetRealIPFrom:         ingCfg.SetRealIPFrom,
 			RealIPRecursive:       ingCfg.RealIPRecursive,
 			ProxyHideHeaders:      ingCfg.ProxyHideHeaders,
+			ProxyPassHeaders:      ingCfg.ProxyPassHeaders,
 		}
 
 		if pemFile, ok := pems[emptyHost]; ok {
@@ -196,11 +198,14 @@ func (cnf *Configurator) createConfig(ingEx *IngressEx) Config {
 		if err != nil {
 			glog.Error(err)
 		} else {
-			if ingCfg.ProxyHideHeaders == nil || len(ingCfg.ProxyHideHeaders) == 0 {
-				ingCfg.ProxyHideHeaders = proxyHideHeaders
-			} else {
-				ingCfg.ProxyHideHeaders = append(ingCfg.ProxyHideHeaders, proxyHideHeaders...)
-			}
+			ingCfg.ProxyHideHeaders = proxyHideHeaders
+		}
+	}
+	if proxyPassHeaders, exists, err := GetMapKeyAsStringSlice(ingEx.Ingress.Annotations, "nginx.org/proxy-pass-headers", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			ingCfg.ProxyPassHeaders = proxyPassHeaders
 		}
 	}
 	if clientMaxBodySize, exists := ingEx.Ingress.Annotations["nginx.org/client-max-body-size"]; exists {

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -112,6 +112,7 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 			RealIPHeader:          ingCfg.RealIPHeader,
 			SetRealIPFrom:         ingCfg.SetRealIPFrom,
 			RealIPRecursive:       ingCfg.RealIPRecursive,
+			ProxyHideHeaders:      ingCfg.ProxyHideHeaders,
 		}
 
 		if pemFile, ok := pems[serverName]; ok {
@@ -160,6 +161,7 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 			RealIPHeader:          ingCfg.RealIPHeader,
 			SetRealIPFrom:         ingCfg.SetRealIPFrom,
 			RealIPRecursive:       ingCfg.RealIPRecursive,
+			ProxyHideHeaders:      ingCfg.ProxyHideHeaders,
 		}
 
 		if pemFile, ok := pems[emptyHost]; ok {
@@ -189,6 +191,17 @@ func (cnf *Configurator) createConfig(ingEx *IngressEx) Config {
 	}
 	if proxyReadTimeout, exists := ingEx.Ingress.Annotations["nginx.org/proxy-read-timeout"]; exists {
 		ingCfg.ProxyReadTimeout = proxyReadTimeout
+	}
+	if proxyHideHeaders, exists, err := GetMapKeyAsStringSlice(ingEx.Ingress.Annotations, "nginx.org/proxy-hide-headers", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			if ingCfg.ProxyHideHeaders == nil || len(ingCfg.ProxyHideHeaders) == 0 {
+				ingCfg.ProxyHideHeaders = proxyHideHeaders
+			} else {
+				ingCfg.ProxyHideHeaders = append(ingCfg.ProxyHideHeaders, proxyHideHeaders...)
+			}
+		}
 	}
 	if clientMaxBodySize, exists := ingEx.Ingress.Annotations["nginx.org/client-max-body-size"]; exists {
 		ingCfg.ClientMaxBodySize = clientMaxBodySize

--- a/nginx-controller/nginx/ingress.tmpl
+++ b/nginx-controller/nginx/ingress.tmpl
@@ -20,10 +20,10 @@ server {
 	{{if $server.Name}}
 	server_name {{$server.Name}};
 	{{end}}
-
 	{{range $proxyHideHeader := $server.ProxyHideHeaders}}
 	proxy_hide_header {{$proxyHideHeader}};{{end}}
-
+	{{range $proxyPassHeader := $server.ProxyPassHeaders}}
+	proxy_pass_header {{$proxyPassHeader}};{{end}}
 	{{if $server.SSL}}
 	if ($scheme = http) {
 		return 301 https://$host$request_uri;

--- a/nginx-controller/nginx/ingress.tmpl
+++ b/nginx-controller/nginx/ingress.tmpl
@@ -21,6 +21,9 @@ server {
 	server_name {{$server.Name}};
 	{{end}}
 
+	{{range $proxyHideHeader := $server.ProxyHideHeaders}}
+	proxy_hide_header {{$proxyHideHeader}};{{end}}
+
 	{{if $server.SSL}}
 	if ($scheme = http) {
 		return 301 https://$host$request_uri;

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -48,6 +48,7 @@ type Server struct {
 	HSTS                  bool
 	HSTSMaxAge            int64
 	HSTSIncludeSubdomains bool
+	ProxyHideHeaders      []string
 
 	// http://nginx.org/en/docs/http/ngx_http_realip_module.html
 	RealIPHeader    string

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -49,6 +49,7 @@ type Server struct {
 	HSTSMaxAge            int64
 	HSTSIncludeSubdomains bool
 	ProxyHideHeaders      []string
+	ProxyPassHeaders      []string
 
 	// http://nginx.org/en/docs/http/ngx_http_realip_module.html
 	RealIPHeader    string


### PR DESCRIPTION
Fixes #86 

```yaml
#configmap
data:
  proxy-hide-headers: X-My-Header,Strict-Transport-Security

#ingress
annotations:
  nginx.org/proxy-hide-headers: X-My-Header,Strict-Transport-Security
```

will render:
```
proxy_hide_header Strict-Transport-Security;
proxy_hide_header X-My-Header;
```