### PR TITLE
Add overwriting of the hsts header

### DIFF
--- a/nginx-controller/nginx/ingress.tmpl
+++ b/nginx-controller/nginx/ingress.tmpl
@@ -29,6 +29,7 @@ server {
 		return 301 https://$host$request_uri;
 	}
 	{{- if $server.HSTS}}
+	proxy_hide_header Strict-Transport-Security;
 	add_header Strict-Transport-Security "max-age={{$server.HSTSMaxAge}}; {{if $server.HSTSIncludeSubdomains}}includeSubDomains; {{end}}preload" always;{{end}}
 	{{- end}}
 


### PR DESCRIPTION
Add overwriting of the hsts header if the backend sends one and the hsts is enabled in the controller. Fixes https://github.com/nginxinc/kubernetes-ingress/issues/86