### PR TITLE
fixed README doc for proxy_connect_timeout

### DIFF
--- a/examples/customization/README.md
+++ b/examples/customization/README.md
@@ -6,7 +6,7 @@ The table below summarizes some of the options. More options (extensions) are av
 
 | Annotation | ConfigMaps Key | Description | Default |
 | ---------- | -------------- | ----------- | ------- |
-| `nginx.org/proxy-read-timeout` | `proxy-read-timeout` | Sets the value of the [proxy_connect_timeout](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_connect_timeout) directive. | `60s` |
+| `nginx.org/proxy-connect-timeout` | `proxy-connect-timeout` | Sets the value of the [proxy_connect_timeout](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_connect_timeout) directive. | `60s` |
 | `nginx.org/proxy-read-timeout` | `proxy-read-timeout` | Sets the value of the [proxy_read_timeout](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout) directive. | `60s` |
 | `nginx.org/client-max-body-size` | `client-max-body-size` | Sets the value of the [client_max_body_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) directive. | `1m` |
 | `nginx.org/proxy-buffering` | `proxy-buffering` | Enables or disables [buffering of responses](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering) from the proxied server. | `True` |


### PR DESCRIPTION
It's correct in the example but the README was wrong. :book: 