### PR TITLE
Add health check location

### DIFF
--- a/nginx-controller/main.go
+++ b/nginx-controller/main.go
@@ -16,6 +16,10 @@ var (
 	// Set during build
 	version string
 
+	healthStatus = flag.Bool("health-status", false,
+		`If present, the default server listening on port 80 with the health check
+		location "/nginx-health" gets added to the main nginx configuration.`)
+
 	proxyURL = flag.String("proxy", "",
 		`If specified, the controller assumes a kubctl proxy server is running on the
 		given url and creates a proxy client. Regenerated NGINX configuration files
@@ -52,7 +56,7 @@ func main() {
 		}
 	}
 
-	ngxc, _ := nginx.NewNginxController("/etc/nginx/", local)
+	ngxc, _ := nginx.NewNginxController("/etc/nginx/", local, *healthStatus)
 	ngxc.Start()
 	config := nginx.NewDefaultConfig()
 	cnf := nginx.NewConfigurator(ngxc, config)

--- a/nginx-controller/nginx/nginx.conf.tmpl
+++ b/nginx-controller/nginx/nginx.conf.tmpl
@@ -43,5 +43,18 @@ http {
     {{if .SSLPreferServerCiphers}}ssl_prefer_server_ciphers on;{{end}}
     {{if .SSLDHParam}}ssl_dhparam {{.SSLDHParam}};{{end}}
 
+    {{if .HealthStatus}}
+    server {
+        listen 80 default_server;
+        server_name _;
+
+        location /nginx-health {
+            access_log off;
+            default_type text/plain;
+            return 200 "healthy\n";
+        }
+    }
+    {{end}}
+
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -80,6 +80,7 @@ type NginxMainConfig struct {
 	ServerNamesHashBucketSize string
 	ServerNamesHashMaxSize    string
 	LogFormat                 string
+	HealthStatus              bool
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html
 	SSLProtocols           string
 	SSLPreferServerCiphers bool
@@ -98,7 +99,7 @@ func NewUpstreamWithDefaultServer(name string) Upstream {
 }
 
 // NewNginxController creates a NGINX controller
-func NewNginxController(nginxConfPath string, local bool) (*NginxController, error) {
+func NewNginxController(nginxConfPath string, local bool, healthStatus bool) (*NginxController, error) {
 	ngxc := NginxController{
 		nginxConfdPath: path.Join(nginxConfPath, "conf.d"),
 		nginxCertsPath: path.Join(nginxConfPath, "ssl"),
@@ -109,7 +110,7 @@ func NewNginxController(nginxConfPath string, local bool) (*NginxController, err
 		createDir(ngxc.nginxCertsPath)
 	}
 
-	cfg := &NginxMainConfig{ServerNamesHashMaxSize: NewDefaultConfig().MainServerNamesHashMaxSize}
+	cfg := &NginxMainConfig{ServerNamesHashMaxSize: NewDefaultConfig().MainServerNamesHashMaxSize, HealthStatus: healthStatus}
 	ngxc.UpdateMainConfigFile(cfg)
 
 	return &ngxc, nil

--- a/nginx-plus-controller/main.go
+++ b/nginx-plus-controller/main.go
@@ -16,6 +16,10 @@ var (
 	// Set during build
 	version string
 
+	healthStatus = flag.Bool("health-status", false,
+		`If present, the default server listening on port 80 with the health check
+		location "/nginx-health" gets added to the main nginx configuration.`)
+
 	proxyURL = flag.String("proxy", "",
 		`If specified, the controller assumes a kubctl proxy server is running on the
 		given url and creates a proxy client. Regenerated NGINX configuration files
@@ -52,7 +56,7 @@ func main() {
 		}
 	}
 
-	ngxc, _ := nginx.NewNginxController("/etc/nginx/", local)
+	ngxc, _ := nginx.NewNginxController("/etc/nginx/", local, *healthStatus)
 	ngxc.Start()
 	config := nginx.NewDefaultConfig()
 	nginxAPI, err := nginx.NewNginxAPIController("http://127.0.0.1:8080/upstream_conf", "http://127.0.0.1:8080/status", local)

--- a/nginx-plus-controller/nginx/nginx.conf.tmpl
+++ b/nginx-plus-controller/nginx/nginx.conf.tmpl
@@ -39,5 +39,18 @@ http {
         ''      close;
     }
 
+    {{if .HealthStatus}}
+    server {
+        listen 80 default_server;
+        server_name _;
+
+        location /nginx-health {
+            access_log off;
+            default_type text/plain;
+            return 200 "healthy\n";
+        }
+    }
+    {{end}}
+
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx-plus-controller/nginx/nginx.go
+++ b/nginx-plus-controller/nginx/nginx.go
@@ -93,10 +93,11 @@ type NginxMainConfig struct {
 	ServerNamesHashBucketSize string
 	ServerNamesHashMaxSize    string
 	LogFormat                 string
+	HealthStatus              bool
 }
 
 // NewNginxController creates a NGINX controller
-func NewNginxController(nginxConfPath string, local bool) (*NginxController, error) {
+func NewNginxController(nginxConfPath string, local bool, healthStatus bool) (*NginxController, error) {
 	ngxc := NginxController{
 		nginxConfdPath: path.Join(nginxConfPath, "conf.d"),
 		nginxCertsPath: path.Join(nginxConfPath, "ssl"),
@@ -108,7 +109,7 @@ func NewNginxController(nginxConfPath string, local bool) (*NginxController, err
 		ngxc.writeStatusAndUpstreamConfAPIsConf()
 	}
 
-	cfg := &NginxMainConfig{ServerNamesHashMaxSize: NewDefaultConfig().MainServerNamesHashMaxSize}
+	cfg := &NginxMainConfig{ServerNamesHashMaxSize: NewDefaultConfig().MainServerNamesHashMaxSize, HealthStatus: healthStatus}
 	ngxc.UpdateMainConfigFile(cfg)
 
 	return &ngxc, nil


### PR DESCRIPTION
Ideally, this feature should be a part of a bigger feature (the default
server) that solves #52.

For now, we add the "-health-status" parameter to the controller. If
it is present, the default server listening on port 80 with the health
check location "/nginx-health" gets added to the main nginx
configuration.

Closes #90