### PR TITLE
disable emitting nginx version

### DIFF
--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -361,6 +361,14 @@ func (lbc *LoadBalancerController) syncCfgm(key string) {
 	if cfgmExists {
 		cfgm := obj.(*api.ConfigMap)
 
+		if serverTokens, exists, err := nginx.GetMapKeyAsBool(cfgm.Data, "server-tokens", cfgm); exists {
+			if err != nil {
+				glog.Error(err)
+			} else {
+				cfg.ServerTokens = serverTokens
+			}
+		}
+
 		if proxyConnectTimeout, exists := cfgm.Data["proxy-connect-timeout"]; exists {
 			cfg.ProxyConnectTimeout = proxyConnectTimeout
 		}

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -2,6 +2,7 @@ package nginx
 
 // Config holds NGINX configuration parameters
 type Config struct {
+	ServerTokens                  bool
 	ProxyConnectTimeout           string
 	ProxyReadTimeout              string
 	ClientMaxBodySize             string
@@ -35,6 +36,7 @@ type Config struct {
 // NewDefaultConfig creates a Config with default values
 func NewDefaultConfig() *Config {
 	return &Config{
+		ServerTokens:               true,
 		ProxyConnectTimeout:        "60s",
 		ProxyReadTimeout:           "60s",
 		ClientMaxBodySize:          "1m",

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -109,6 +109,7 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 
 		server := Server{
 			Name:                  serverName,
+			ServerTokens:          ingCfg.ServerTokens,
 			HTTP2:                 ingCfg.HTTP2,
 			ProxyProtocol:         ingCfg.ProxyProtocol,
 			HSTS:                  ingCfg.HSTS,
@@ -159,6 +160,7 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 	if len(ingEx.Ingress.Spec.Rules) == 0 && ingEx.Ingress.Spec.Backend != nil {
 		server := Server{
 			Name:                  emptyHost,
+			ServerTokens:          ingCfg.ServerTokens,
 			HTTP2:                 ingCfg.HTTP2,
 			ProxyProtocol:         ingCfg.ProxyProtocol,
 			HSTS:                  ingCfg.HSTS,
@@ -193,6 +195,13 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 
 func (cnf *Configurator) createConfig(ingEx *IngressEx) Config {
 	ingCfg := *cnf.config
+	if serverTokens, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, "nginx.org/server-tokens", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			ingCfg.ServerTokens = serverTokens
+		}
+	}
 	if proxyConnectTimeout, exists := ingEx.Ingress.Annotations["nginx.org/proxy-connect-timeout"]; exists {
 		ingCfg.ProxyConnectTimeout = proxyConnectTimeout
 	}

--- a/nginx-controller/nginx/ingress.tmpl
+++ b/nginx-controller/nginx/ingress.tmpl
@@ -17,6 +17,8 @@ server {
 	{{if $server.RealIPHeader}}real_ip_header {{$server.RealIPHeader}};{{end}}
 	{{if $server.RealIPRecursive}}real_ip_recursive on;{{end}}
 
+	{{if not $server.ServerTokens}}server_tokens off;{{end}}
+
 	{{if $server.Name}}
 	server_name {{$server.Name}};
 	{{end}}

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -41,6 +41,7 @@ type UpstreamServer struct {
 // Server describes an NGINX server
 type Server struct {
 	Name                  string
+	ServerTokens          bool
 	Locations             []Location
 	SSL                   bool
 	SSLCertificate        string


### PR DESCRIPTION
It's generally a best practice to disable server_tokens to prevent the nginx version from being emitted.