### PR TITLE
add support for proxy_ignore_headers via config

### DIFF
--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -367,6 +367,13 @@ func (lbc *LoadBalancerController) syncCfgm(key string) {
 		if proxyReadTimeout, exists := cfgm.Data["proxy-read-timeout"]; exists {
 			cfg.ProxyReadTimeout = proxyReadTimeout
 		}
+		if proxyIgnoreHeaders, exists, err := nginx.GetMapKeyAsStringSlice(cfgm.Data, "proxy-ignore-headers", cfgm); exists {
+			if err != nil {
+				glog.Error(err)
+			} else {
+				cfg.ProxyIgnoreHeaders = proxyIgnoreHeaders
+			}
+		}
 		if proxyHideHeaders, exists, err := nginx.GetMapKeyAsStringSlice(cfgm.Data, "proxy-hide-headers", cfgm); exists {
 			if err != nil {
 				glog.Error(err)

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	ProxyBufferSize               string
 	ProxyMaxTempFileSize          string
 	ProxyProtocol                 bool
+	ProxyIgnoreHeaders            []string
 	ProxyHideHeaders              []string
 	ProxyPassHeaders              []string
 	HSTS                          bool

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -117,6 +117,7 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 			RealIPHeader:          ingCfg.RealIPHeader,
 			SetRealIPFrom:         ingCfg.SetRealIPFrom,
 			RealIPRecursive:       ingCfg.RealIPRecursive,
+			ProxyIgnoreHeaders:    ingCfg.ProxyIgnoreHeaders,
 			ProxyHideHeaders:      ingCfg.ProxyHideHeaders,
 			ProxyPassHeaders:      ingCfg.ProxyPassHeaders,
 		}
@@ -198,6 +199,13 @@ func (cnf *Configurator) createConfig(ingEx *IngressEx) Config {
 	}
 	if proxyReadTimeout, exists := ingEx.Ingress.Annotations["nginx.org/proxy-read-timeout"]; exists {
 		ingCfg.ProxyReadTimeout = proxyReadTimeout
+	}
+	if proxyIgnoreHeaders, exists, err := GetMapKeyAsStringSlice(ingEx.Ingress.Annotations, "nginx.org/proxy-ignore-headers", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			ingCfg.ProxyIgnoreHeaders = proxyIgnoreHeaders
+		}
 	}
 	if proxyHideHeaders, exists, err := GetMapKeyAsStringSlice(ingEx.Ingress.Annotations, "nginx.org/proxy-hide-headers", ingEx.Ingress); exists {
 		if err != nil {

--- a/nginx-controller/nginx/ingress.tmpl
+++ b/nginx-controller/nginx/ingress.tmpl
@@ -20,6 +20,8 @@ server {
 	{{if $server.Name}}
 	server_name {{$server.Name}};
 	{{end}}
+	{{range $proxyIgnoreHeader := $server.ProxyIgnoreHeaders}}
+	proxy_ignore_header {{$proxyIgnoreHeader}};{{end}}
 	{{range $proxyHideHeader := $server.ProxyHideHeaders}}
 	proxy_hide_header {{$proxyHideHeader}};{{end}}
 	{{range $proxyPassHeader := $server.ProxyPassHeaders}}

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -50,6 +50,7 @@ type Server struct {
 	HSTS                  bool
 	HSTSMaxAge            int64
 	HSTSIncludeSubdomains bool
+	ProxyIgnoreHeaders    []string
 	ProxyHideHeaders      []string
 	ProxyPassHeaders      []string
 


### PR DESCRIPTION
Allow setting `proxy_ignore_header` values via config, similar to `proxy_hide_header` and `proxy_pass_header`.