### PR TITLE
gcloud is now forcing -- be present for all docker commands

### DIFF
--- a/nginx-controller/Makefile
+++ b/nginx-controller/Makefile
@@ -33,7 +33,11 @@ container: test nginx-ingress
 	docker build -f $(DOCKERFILE) -t $(PREFIX):$(TAG) .
 
 push: container
-	$(GCLOUD) docker push $(PREFIX):$(TAG)
+ifeq ($(PUSH_TO_GCR),1)
+	$(GCLOUD) docker -- push $(PREFIX):$(TAG)
+else
+	docker push $(PREFIX):$(TAG)
+endif
 
 osx:
 ifeq ($(BUILD_IN_CONTAINER),1)

--- a/nginx-plus-controller/Makefile
+++ b/nginx-plus-controller/Makefile
@@ -32,7 +32,11 @@ container: test nginx-plus-ingress
 	docker build -t $(PREFIX):$(TAG) .
 
 push: container
-	$(GCLOUD) docker push $(PREFIX):$(TAG)
+ifeq ($(PUSH_TO_GCR),1)
+	$(GCLOUD) docker -- push $(PREFIX):$(TAG)
+else
+	docker push $(PREFIX):$(TAG)
+endif
 
 osx:
 ifeq ($(BUILD_IN_CONTAINER),1)
@@ -43,3 +47,4 @@ endif
 
 clean:
 	rm -f nginx-plus-ingress
+


### PR DESCRIPTION
The new commands should be

gcloud docker -- push image:tag 

vs

gcloud docker push image:tag