### PR TITLE
Auto scale workers

### DIFF
--- a/nginx-controller/nginx/nginx.conf.tmpl
+++ b/nginx-controller/nginx/nginx.conf.tmpl
@@ -1,6 +1,6 @@
 
 user  nginx;
-worker_processes  1;
+worker_processes  auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;


### PR DESCRIPTION
I dont see any reason not to use auto for the worker processes  too, like the plus edition uses. Why ever limit  this to 1 in an ingress case?