### PR TITLE
Add graceful termination

### DIFF
--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -260,6 +260,17 @@ func (lbc *LoadBalancerController) Run() {
 	<-lbc.stopCh
 }
 
+// Stop shutdowns the load balancer controller
+func (lbc *LoadBalancerController) Stop() {
+	close(lbc.stopCh)
+
+	lbc.ingQueue.shutdown()
+	if lbc.watchNginxConfigMaps {
+		lbc.cfgmQueue.shutdown()
+	}
+	lbc.endpQueue.shutdown()
+}
+
 func (lbc *LoadBalancerController) syncEndp(key string) {
 	glog.V(3).Infof("Syncing endpoints %v", key)
 

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -2,6 +2,8 @@
 user  nginx;
 worker_processes  auto;
 
+daemon off;
+
 error_log  /var/log/nginx/error.log notice;
 pid        /var/run/nginx.pid;
 

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -2,6 +2,8 @@
 user  nginx;
 worker_processes  auto;
 
+daemon off;
+
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 


### PR DESCRIPTION
* When the controller receives `SIGTERM`, it shutdowns itself as well as NGINX, using `nginx -s quit`.
* If NGINX master process exists for some reason (for example, the master crashes), the controller exits as well.
* NGINX is no longer running as a daemon