### PR TITLE
Refactor queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ nginx-plus-ingress
 *.crt
 *.key
 
+# Visual Studio Code settings
+.vscode
+


### PR DESCRIPTION
Using a single queue instead of multiple queues prevents potential race conditions which could result into generating inconsistent configuration.