### PR TITLE
Add watching for secret resource updates

### DIFF
--- a/nginx-controller/controller/secret.go
+++ b/nginx-controller/controller/secret.go
@@ -1,0 +1,20 @@
+package controller
+
+import (
+	"fmt"
+
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+// ValidateTLSSecret validates the secret. If it is valid, the function returns nil.
+func ValidateTLSSecret(secret *api_v1.Secret) error {
+	if _, exists := secret.Data[api_v1.TLSCertKey]; !exists {
+		return fmt.Errorf("Secret doesn't have %v", api_v1.TLSCertKey)
+	}
+
+	if _, exists := secret.Data[api_v1.TLSPrivateKeyKey]; !exists {
+		return fmt.Errorf("Secret doesn't have %v", api_v1.TLSPrivateKeyKey)
+	}
+
+	return nil
+}

--- a/nginx-controller/controller/utils.go
+++ b/nginx-controller/controller/utils.go
@@ -118,6 +118,8 @@ const (
 	Endpoints
 	// ConfigMap resource
 	ConfigMap
+	// Secret resource
+	Secret
 )
 
 // Task is an element of a taskQueue
@@ -136,6 +138,8 @@ func NewTask(key string, obj interface{}) (Task, error) {
 		k = Endpoints
 	case *api_v1.ConfigMap:
 		k = ConfigMap
+	case *api_v1.Secret:
+		k = Secret
 	default:
 		return Task{}, fmt.Errorf("Unknow type: %v", t)
 	}


### PR DESCRIPTION
- Feature: The Ingress controller now watches for updates of Secrets with a TLS certificate and a key. If a Secret is updated and it is referenced by any deployed Ingress resource, the Ingress controller will update NGINX configuration.
- Change: If a Secret referenced by one or more Ingress resources becomes invalid or gets removed, the configuration for those Ingress resources will be disabled until there is a valid Secret.