### PR TITLE
Implement lb-method fixes #94

### DIFF
--- a/examples/customization/README.md
+++ b/examples/customization/README.md
@@ -34,6 +34,7 @@ The table below summarizes some of the options. More options (extensions) are av
 | N/A | `http-snippets` | Sets a custom snippet in http context. | N/A |
 | `nginx.org/location-snippets` | `location-snippets` | Sets a custom snippet in location context. | N/A |
 | `nginx.org/server-snippets` | `server-snippets` | Sets a custom snippet in server context. | N/A |
+| `nginx.org/lb-method` | `lb-method` | Sets the [load balancing method](https://www.nginx.com/resources/admin-guide/load-balancer/#method). The default `""` specifies the round-robin method. | `""` |
 
 ## Using ConfigMaps
 

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -377,6 +377,10 @@ func (lbc *LoadBalancerController) syncCfgm(task Task) {
 			}
 		}
 
+		if lbMethod, exists := cfgm.Data["lb-method"]; exists {
+			cfg.LBMethod = lbMethod
+		}
+
 		if proxyConnectTimeout, exists := cfgm.Data["proxy-connect-timeout"]; exists {
 			cfg.ProxyConnectTimeout = proxyConnectTimeout
 		}

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	HSTS                          bool
 	HSTSMaxAge                    int64
 	HSTSIncludeSubdomains         bool
+	LBMethod                      string
 
 	// http://nginx.org/en/docs/http/ngx_http_realip_module.html
 	RealIPHeader    string

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -35,6 +35,7 @@ type Upstream struct {
 	Name            string
 	UpstreamServers []UpstreamServer
 	StickyCookie    string
+	LBMethod        string
 }
 
 // UpstreamServer describes a server in an NGINX upstream

--- a/nginx-controller/nginx/templates/nginx.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx.ingress.tmpl
@@ -1,5 +1,6 @@
 {{range $upstream := .Upstreams}}
 upstream {{$upstream.Name}} {
+	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}}:{{$server.Port}};{{end}}
 }{{end}}


### PR DESCRIPTION
Image built from my fork : `turbobytes/nginx-ingress:0.9.0`

This adds a configmap key `lb-method` and annotation `nginx.org/lb-method` as suggested by @pleshakov  in #94 .

If this setting is not blank, then the value is pasted into the upstream block in the nginx config. This is configurable per Ingress, and not per service.