### PR TITLE
allow non-standard listen ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ osx-nginx-ingress
 nginx-ingress
 osx-nginx-plus-ingress
 nginx-plus-ingress
+nginx-controller/nginx-controller
 
 # NGINX Plus license files
 *.crt

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -41,6 +41,9 @@ type Config struct {
 	JWTKey      string
 	JWTToken    string
 	JWTLoginURL string
+
+	Ports    []int
+	SSLPorts []int
 }
 
 // NewDefaultConfig creates a Config with default values
@@ -53,5 +56,7 @@ func NewDefaultConfig() *Config {
 		MainServerNamesHashMaxSize: "512",
 		ProxyBuffering:             true,
 		HSTSMaxAge:                 2592000,
+		Ports:                      []int{80},
+		SSLPorts:                   []int{443},
 	}
 }

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -76,6 +76,9 @@ type Server struct {
 	JWTRealm    string
 	JWTToken    string
 	JWTLoginURL string
+
+	Ports    []int
+	SSLPorts []int
 }
 
 // Location describes an NGINX location

--- a/nginx-controller/nginx/templates/nginx.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx.ingress.tmpl
@@ -7,9 +7,13 @@ upstream {{$upstream.Name}} {
 
 {{range $server := .Servers}}
 server {
-	listen 80{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	{{range $port := $server.Ports}}
+	listen {{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	{{- end}}
 	{{if $server.SSL}}
-	listen 443 ssl{{if $server.HTTP2}} http2{{end}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	{{- range $port := $server.SSLPorts}}
+	listen {{$port}} ssl{{if $server.HTTP2}} http2{{end}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	{{- end}}
 	ssl_certificate {{$server.SSLCertificate}};
 	ssl_certificate_key {{$server.SSLCertificateKey}};
 	{{end}}
@@ -28,7 +32,7 @@ server {
 	proxy_pass_header {{$proxyPassHeader}};{{end}}
 	{{if $server.SSL}}
 	if ($scheme = http) {
-		return 301 https://$host$request_uri;
+		return 301 https://$host:{{index $server.SSLPorts 0}}$request_uri;
 	}
 	{{- if $server.HSTS}}
 	proxy_hide_header Strict-Transport-Security;


### PR DESCRIPTION
PR introduces two new annotations:

* `nginx.org/listen-ports`
* `nginx.org/listen-ports-ssl`

When using ingress controller with `hostNetwork: true` it is possible to allow
to have non-standard ports (not 80 and 443) served by nginx. It's useful
for dynamic ports in ingress/port-based routing.

Fixes #98.