### PR TITLE
RFC: additional variables to log pod attributes

### DIFF
--- a/nginx-controller/Dockerfile
+++ b/nginx-controller/Dockerfile
@@ -5,7 +5,11 @@ FROM nginx:1.13.3
 RUN ln -sf /proc/1/fd/1 /var/log/nginx/access.log \
 	&& ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
-COPY nginx-ingress nginx/templates/nginx.ingress.tmpl nginx/templates/nginx.tmpl /
+COPY nginx-ingress \
+    nginx/templates/nginx.ingress.tmpl \
+    nginx/templates/nginx.tmpl \
+    nginx/templates/nginx.maps.tmpl \
+    /
 
 RUN rm /etc/nginx/conf.d/*
 

--- a/nginx-controller/Dockerfile
+++ b/nginx-controller/Dockerfile
@@ -15,6 +15,9 @@ RUN rm /etc/nginx/conf.d/*
 
 RUN mkdir -p /etc/nginx/secrets
 
+ADD https://github.com/seletskiy/killinit/releases/download/1.0/killinit /
+RUN chmod +x /killinit
+
 # Uncomment the line below if you would like to add the default.pem to the image
 # and use it as a certificate and key for the default server
 # ADD default.pem /etc/nginx/secrets/default

--- a/nginx-controller/Makefile
+++ b/nginx-controller/Makefile
@@ -8,7 +8,7 @@ DOCKER_RUN = docker run --rm -v $(shell pwd)/../:/go/src/github.com/nginxinc/kub
 GOLANG_CONTAINER = golang:1.8
 DOCKERFILE = Dockerfile
 
-BUILD_IN_CONTAINER = 1
+BUILD_IN_CONTAINER = 0
 PUSH_TO_GCR =
 GENERATE_DEFAULT_CERT_AND_KEY = 
 

--- a/nginx-controller/Makefile
+++ b/nginx-controller/Makefile
@@ -8,7 +8,7 @@ DOCKER_RUN = docker run --rm -v $(shell pwd)/../:/go/src/github.com/nginxinc/kub
 GOLANG_CONTAINER = golang:1.8
 DOCKERFILE = Dockerfile
 
-BUILD_IN_CONTAINER = 0
+BUILD_IN_CONTAINER = 1
 PUSH_TO_GCR =
 GENERATE_DEFAULT_CERT_AND_KEY = 
 

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -907,9 +907,9 @@ func (lbc *LoadBalancerController) createIngress(ing *extensions.Ingress) (*ngin
 		validRules++
 	}
 
-	if validRules == 0 {
-		return nil, fmt.Errorf("Ingress contains no valid rules")
-	}
+	//if validRules == 0 {
+	//    return nil, fmt.Errorf("Ingress contains no valid rules")
+	//}
 
 	return ingEx, nil
 }

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -397,6 +397,9 @@ func (lbc *LoadBalancerController) syncCfgm(task Task) {
 			cfg.LBMethod = lbMethod
 		}
 
+		if proxyTimeout, exists := cfgm.Data["proxy-timeout"]; exists {
+			cfg.ProxyTimeout = proxyTimeout
+		}
 		if proxyConnectTimeout, exists := cfgm.Data["proxy-connect-timeout"]; exists {
 			cfg.ProxyConnectTimeout = proxyConnectTimeout
 		}

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -1009,9 +1009,7 @@ func (lbc *LoadBalancerController) getTargetPort(svcPort *api_v1.ServicePort, sv
 	return portNum, nil
 }
 
-func (lbc *LoadBalancerController) getEndpointsInfo(
-	svc *api_v1.Service,
-) ([]nginx.EndpointInfo, error) {
+func (lbc *LoadBalancerController) getEndpointsInfo(svc *api_v1.Service) ([]nginx.EndpointInfo, error) {
 	pods, err := lbc.client.Core().Pods(svc.Namespace).List(
 		meta_v1.ListOptions{
 			LabelSelector: labels.Set(svc.Spec.Selector).String(),

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -579,6 +579,13 @@ func (lbc *LoadBalancerController) syncCfgm(task Task) {
 				cfg.MainWorkerProcesses = cfgm.Data["worker-processes"]
 			}
 		}
+		if workerConnections, exists, err := nginx.GetMapKeyAsInt(cfgm.Data, "worker-connections", cfgm); exists {
+			if err != nil {
+				glog.Errorf("Configmap %s/%s: Invalid value for worker-connections key: must be an integer, got %q", cfgm.GetNamespace(), cfgm.GetName(), cfgm.Data["worker-connections"])
+			} else {
+				cfg.MainWorkerConnections = workerConnections
+			}
+		}
 		if workerCPUAffinity, exists := cfgm.Data["worker-cpu-affinity"]; exists {
 			cfg.MainWorkerCPUAffinity = workerCPUAffinity
 		}

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -1033,13 +1033,17 @@ func (lbc *LoadBalancerController) getEndpointsInfo(
 		for _, container := range pod.Spec.Containers {
 			for _, port := range container.Ports {
 				info = append(info, nginx.EndpointInfo{
-					Address: fmt.Sprintf("%s:%d", ip, port.ContainerPort),
-					Info: map[string]interface{}{
-						"namespace":  pod.Namespace,
-						"pod":        pod.Name,
-						"container":  container.Name,
-						"pod_labels": nginx.Labels(pod.Labels),
-					},
+					Address:   fmt.Sprintf("%s:%d", ip, port.ContainerPort),
+					Namespace: pod.Namespace,
+					Pod:       pod.Name,
+					Container: container.Name,
+					PodLabels: nginx.Labels(pod.Labels),
+					//Info: map[string]interface{}{
+					//    "namespace":  pod.Namespace,
+					//    "pod":        pod.Name,
+					//    "container":  container.Name,
+					//    "pod_labels": nginx.Labels(pod.Labels),
+					//},
 				})
 			}
 		}

--- a/nginx-controller/main.go
+++ b/nginx-controller/main.go
@@ -89,13 +89,25 @@ func main() {
 
 	local := *proxyURL != ""
 
-	nginxConfTemplatePath := "nginx.tmpl"
-	nginxIngressTemplatePath := "nginx.ingress.tmpl"
+	var (
+		nginxConfTemplatePath     = "nginx.tmpl"
+		nginxMapsConfTemplatePath = "nginx.maps.tmpl"
+		nginxIngressTemplatePath  = "nginx.ingress.tmpl"
+	)
+
 	if *nginxPlus {
 		nginxConfTemplatePath = "nginx-plus.tmpl"
 		nginxIngressTemplatePath = "nginx-plus.ingress.tmpl"
 	}
-	ngxc, _ := nginx.NewNginxController("/etc/nginx/", local, *healthStatus, nginxConfTemplatePath, nginxIngressTemplatePath)
+
+	ngxc, _ := nginx.NewNginxController(
+		"/etc/nginx/",
+		local,
+		*healthStatus,
+		nginxConfTemplatePath,
+		nginxMapsConfTemplatePath,
+		nginxIngressTemplatePath,
+	)
 
 	if *defaultServerSecret != "" {
 		ns, name, err := controller.ParseNamespaceName(*defaultServerSecret)

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	SSLPorts []int
 
 	Stream bool
+
+	Address string
+	Enabled bool
 }
 
 // NewDefaultConfig creates a Config with default values

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	ServerTokens                  string
 	ProxyConnectTimeout           string
 	ProxyReadTimeout              string
+	ProxyTimeout                  string
 	ClientMaxBodySize             string
 	HTTP2                         bool
 	RedirectToHTTPS               bool
@@ -62,6 +63,7 @@ func NewDefaultConfig() *Config {
 		ServerTokens:               "on",
 		ProxyConnectTimeout:        "60s",
 		ProxyReadTimeout:           "60s",
+		ProxyTimeout:               "10m",
 		ClientMaxBodySize:          "1m",
 		SSLRedirect:                true,
 		MainServerNamesHashMaxSize: "512",

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	HSTSIncludeSubdomains         bool
 	LBMethod                      string
 	MainWorkerProcesses           string
+	MainWorkerConnections         int64
 	MainWorkerCPUAffinity         string
 	Keepalive                     int64
 
@@ -66,6 +67,7 @@ func NewDefaultConfig() *Config {
 		MainServerNamesHashMaxSize: "512",
 		ProxyBuffering:             true,
 		MainWorkerProcesses:        "auto",
+		MainWorkerConnections:      2048,
 		HSTSMaxAge:                 2592000,
 		Ports:                      []int{80},
 		SSLPorts:                   []int{443},

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -48,6 +48,8 @@ type Config struct {
 
 	Ports    []int
 	SSLPorts []int
+
+	Stream bool
 }
 
 // NewDefaultConfig creates a Config with default values

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -206,6 +206,7 @@ func (cnf *Configurator) generateNginxCfgHTTP(ingEx *IngressEx, ingCfg Config, p
 			ServerSnippets:        ingCfg.ServerSnippets,
 			Ports:                 ingCfg.Ports,
 			SSLPorts:              ingCfg.SSLPorts,
+			Address:               ingCfg.Address,
 		}
 
 		if pemFile, ok := pems[serverName]; ok {
@@ -293,6 +294,7 @@ func (cnf *Configurator) generateNginxCfgStream(ingEx *IngressEx, ingCfg Config)
 			ServerSnippets:      ingCfg.ServerSnippets,
 			ProxyBufferSize:     ingCfg.ProxyBufferSize,
 			ProxyConnectTimeout: ingCfg.ProxyConnectTimeout,
+			Address:             ingCfg.Address,
 		}
 	}
 
@@ -395,15 +397,13 @@ func (cnf *Configurator) createConfig(ingEx *IngressEx) Config {
 		if err != nil {
 			glog.Errorf("unable to list interface addresses: %s", err)
 		} else {
-			ip, _, err := net.ParseCIDR(listenAddress)
-			if err != nil {
-				glog.Errorf("unable to parse listen address: %s", err)
-			} else {
-				for _, addr := range addrs {
-					if addr.String() == ip.String() {
-						ingCfg.Address = ip.String()
-						ingCfg.Enabled = true
-					}
+			listenIP := net.ParseIP(listenAddress)
+			for _, addr := range addrs {
+				hostIP, _, _ := net.ParseCIDR(addr.String())
+
+				if hostIP.String() == listenIP.String() {
+					ingCfg.Address = listenIP.String()
+					ingCfg.Enabled = true
 				}
 			}
 		}

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -294,6 +294,7 @@ func (cnf *Configurator) generateNginxCfgStream(ingEx *IngressEx, ingCfg Config)
 			ServerSnippets:      ingCfg.ServerSnippets,
 			ProxyBufferSize:     ingCfg.ProxyBufferSize,
 			ProxyConnectTimeout: ingCfg.ProxyConnectTimeout,
+			ProxyTimeout:        ingCfg.ProxyTimeout,
 			Address:             ingCfg.Address,
 		}
 	}
@@ -686,6 +687,7 @@ func createLocation(path string, upstream UpstreamHTTP, cfg *Config, websocket b
 	loc := Location{
 		Path:                 path,
 		Upstream:             upstream,
+		ProxyTimeout:         cfg.ProxyTimeout,
 		ProxyConnectTimeout:  cfg.ProxyConnectTimeout,
 		ProxyReadTimeout:     cfg.ProxyReadTimeout,
 		ClientMaxBodySize:    cfg.ClientMaxBodySize,

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -234,6 +234,15 @@ func getVariableMaps(ingEx *IngressEx) []Map {
 
 	for key, _ := range ingEx.Endpoints {
 		bucket := ingEx.EndpointsInfo[key]
+
+		// If there's no matching endpoints for ingress, we should
+		// provide dummy maps to satisfy maps.conf mappings.
+		if len(bucket) == 0 {
+			bucket = []EndpointInfo{
+				NewDefaultEndpointInfo(),
+			}
+		}
+
 		for _, info := range bucket {
 			for variable, value := range info.GetMapValues() {
 				if _, ok := maps[variable]; !ok {

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -78,11 +78,25 @@ func (cnf *Configurator) updateMaps() {
 		values := map[string]string{}
 
 		for _, ingress := range cnf.ingresses {
-			values[getFullIngressName(ingress.Ingress)] = getMappedVariableName(
-				ingress.Ingress.Namespace,
-				ingress.Ingress.Name,
-				"k8s_upstream_"+variable,
+			stream, exists, err := GetMapKeyAsBool(
+				ingress.Ingress.Annotations,
+				"nginx.org/stream",
+				ingress.Ingress,
 			)
+			if exists {
+				if err != nil {
+					glog.Error(err)
+					continue
+				}
+			}
+
+			if !stream {
+				values[getFullIngressName(ingress.Ingress)] = getMappedVariableName(
+					ingress.Ingress.Namespace,
+					ingress.Ingress.Name,
+					"k8s_upstream_"+variable,
+				)
+			}
 		}
 
 		maps = append(

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -554,7 +554,7 @@ func getServicesPorts(ingEx *IngressEx) ([]int, []int) {
 }
 
 func parsePort(value string) (int, error) {
-	port, err := strconv.ParseInt(value, 10, 16)
+	port, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"Unable to parse port as integer: %s\n",

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -377,6 +377,10 @@ func (cnf *Configurator) createConfig(ingEx *IngressEx) Config {
 		}
 	}
 
+	if proxyTimeout, exists := ingEx.Ingress.Annotations["nginx.org/proxy-timeout"]; exists {
+		ingCfg.ProxyTimeout = proxyTimeout
+	}
+
 	if proxyConnectTimeout, exists := ingEx.Ingress.Annotations["nginx.org/proxy-connect-timeout"]; exists {
 		ingCfg.ProxyConnectTimeout = proxyConnectTimeout
 	}

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -265,34 +265,6 @@ func getVariableMaps(ingEx *IngressEx) []Map {
 				)
 			}
 		}
-
-		//for _, variable := range []string{
-		//    "namespace",
-		//    "pod",
-		//    "container",
-		//    "pod_labels",
-		//} {
-		//    if _, ok := maps[variable]; !ok {
-		//        maps[variable] = Map{
-		//            Source: "$upstream_addr",
-		//            Variable: getMappedVariableName(
-		//                ingEx.Ingress.Namespace,
-		//                ingEx.Ingress.Name,
-		//                "k8s_upstream_"+variable,
-		//            ),
-		//            Values: map[string]string{},
-		//        }
-		//    }
-
-		//    for _, info := range bucket {
-		//        address := `~` + regexp.QuoteMeta(info.Address) + `$`
-
-		//        maps[variable].Values[address] = fmt.Sprintf(
-		//            "%q",
-		//            info.Info[variable],
-		//        )
-		//    }
-		//}
 	}
 
 	result := []Map{}

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -944,6 +944,7 @@ func (cnf *Configurator) UpdateConfig(config *Config, ingExes []*IngressEx) erro
 		ServerTokens:      config.ServerTokens,
 		ProxyProtocol:     config.ProxyProtocol,
 		WorkerProcesses:   config.MainWorkerProcesses,
+		WorkerConnections: config.MainWorkerConnections,
 		WorkerCPUAffinity: config.MainWorkerCPUAffinity,
 	}
 

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -3,6 +3,7 @@ package nginx
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"os"
 	"regexp"
 	"strconv"
@@ -65,10 +66,12 @@ func (cnf *Configurator) AddOrUpdateIngress(ingEx *IngressEx) error {
 func (cnf *Configurator) addOrUpdateIngress(ingEx *IngressEx) {
 	pems, jwtKeyFileName := cnf.updateSecrets(ingEx)
 	nginxCfg := cnf.generateNginxCfg(ingEx, pems, jwtKeyFileName)
-	name := objectMetaToFileName(&ingEx.Ingress.ObjectMeta)
-	cnf.nginx.AddOrUpdateIngress(name, nginxCfg)
+	if nginxCfg != nil {
+		name := objectMetaToFileName(&ingEx.Ingress.ObjectMeta)
+		cnf.nginx.AddOrUpdateIngress(name, nginxCfg)
 
-	cnf.ingresses[getFullIngressName(ingEx.Ingress)] = ingEx
+		cnf.ingresses[getFullIngressName(ingEx.Ingress)] = ingEx
+	}
 }
 
 func (cnf *Configurator) updateMaps() {
@@ -140,11 +143,15 @@ func (cnf *Configurator) updateSecrets(ingEx *IngressEx) (map[string]string, str
 func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]string, jwtKeyFileName string) IngressNginxConfig {
 	ingCfg := cnf.createConfig(ingEx)
 
-	if ingCfg.Stream {
-		return cnf.generateNginxCfgStream(ingEx, ingCfg)
-	} else {
-		return cnf.generateNginxCfgHTTP(ingEx, ingCfg, pems, jwtKeyFileName)
+	if ingCfg.Enabled {
+		if ingCfg.Stream {
+			return cnf.generateNginxCfgStream(ingEx, ingCfg)
+		} else {
+			return cnf.generateNginxCfgHTTP(ingEx, ingCfg, pems, jwtKeyFileName)
+		}
 	}
+
+	return nil
 }
 
 func (cnf *Configurator) generateNginxCfgHTTP(ingEx *IngressEx, ingCfg Config, pems map[string]string, jwtKeyFileName string) IngressNginxConfigHTTP {
@@ -378,6 +385,28 @@ func (cnf *Configurator) createConfig(ingEx *IngressEx) Config {
 	ports, sslPorts := getServicesPorts(ingEx)
 	if len(ports) > 0 {
 		ingCfg.Ports = ports
+	}
+
+	ingCfg.Enabled = true
+	if listenAddress, exists := ingEx.Ingress.Annotations["nginx.org/listen-address"]; exists {
+		ingCfg.Enabled = false
+
+		addrs, err := net.InterfaceAddrs()
+		if err != nil {
+			glog.Errorf("unable to list interface addresses: %s", err)
+		} else {
+			ip, _, err := net.ParseCIDR(listenAddress)
+			if err != nil {
+				glog.Errorf("unable to parse listen address: %s", err)
+			} else {
+				for _, addr := range addrs {
+					if addr.String() == ip.String() {
+						ingCfg.Address = ip.String()
+						ingCfg.Enabled = true
+					}
+				}
+			}
+		}
 	}
 
 	if !stream {

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -716,9 +716,9 @@ func (cnf *Configurator) DeleteSecret(key string, ings []extensions.Ingress) err
 
 	cnf.nginx.DeleteSecretFile(keyToFileName(key))
 
-	cnf.updateMaps()
-
 	if len(ings) > 0 {
+		cnf.updateMaps()
+
 		if err := cnf.nginx.Reload(); err != nil {
 			return fmt.Errorf("Error when reloading NGINX when deleting Secret %v: %v", key, err)
 		}

--- a/nginx-controller/nginx/endpoints_info.go
+++ b/nginx-controller/nginx/endpoints_info.go
@@ -5,14 +5,24 @@ import (
 	"strings"
 )
 
-// TODO
+// EndpointInfo describes pod-level information about given endpoint.
 type EndpointInfo struct {
-	Address string
-	//Info    map[string]interface{}
+	Address   string
 	Namespace string
 	Pod       string
 	Container string
 	PodLabels Labels
+}
+
+func NewDefaultEndpointInfo() EndpointInfo {
+	upstream := NewUpstreamWithDefaultServer("default")
+	return EndpointInfo{
+		Address: fmt.Sprintf(
+			"%s:%s",
+			upstream.UpstreamServers[0].Address,
+			upstream.UpstreamServers[0].Port,
+		),
+	}
 }
 
 func (info EndpointInfo) GetMapValues() map[string]string {

--- a/nginx-controller/nginx/endpoints_info.go
+++ b/nginx-controller/nginx/endpoints_info.go
@@ -1,0 +1,45 @@
+package nginx
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TODO
+type EndpointInfo struct {
+	Address string
+	//Info    map[string]interface{}
+	Namespace string
+	Pod       string
+	Container string
+	PodLabels Labels
+}
+
+func (info EndpointInfo) GetMapValues() map[string]string {
+	return map[string]string{
+		"namespace":  info.Namespace,
+		"pod":        info.Pod,
+		"container":  info.Container,
+		"pod_labels": info.PodLabels.String(),
+	}
+	//for _, variable := range []string{
+	//    "namespace",
+	//    "pod",
+	//    "container",
+	//    "pod_labels",
+	//} {
+
+	//}
+}
+
+type Labels map[string]string
+
+func (labels Labels) String() string {
+	result := []string{}
+
+	for key, value := range labels {
+		result = append(result, fmt.Sprintf("%s:%s", key, value))
+	}
+
+	return strings.Join(result, ",")
+}

--- a/nginx-controller/nginx/endpoints_info.go
+++ b/nginx-controller/nginx/endpoints_info.go
@@ -15,7 +15,7 @@ type EndpointInfo struct {
 }
 
 func NewDefaultEndpointInfo() EndpointInfo {
-	upstream := NewUpstreamWithDefaultServer("default")
+	upstream := NewUpstreamHTTPWithDefaultServer("default")
 	return EndpointInfo{
 		Address: fmt.Sprintf(
 			"%s:%s",

--- a/nginx-controller/nginx/ingress.go
+++ b/nginx-controller/nginx/ingress.go
@@ -1,6 +1,9 @@
 package nginx
 
 import (
+	"fmt"
+	"strings"
+
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
@@ -8,8 +11,27 @@ import (
 // IngressEx holds an Ingress along with Secrets and Endpoints of the services
 // that are referenced in this Ingress
 type IngressEx struct {
-	Ingress    *extensions.Ingress
-	TLSSecrets map[string]*api_v1.Secret
-	JWTKey     *api_v1.Secret
-	Endpoints  map[string][]string
+	Ingress       *extensions.Ingress
+	TLSSecrets    map[string]*api_v1.Secret
+	JWTKey        *api_v1.Secret
+	Endpoints     map[string][]string
+	EndpointsInfo map[string][]EndpointInfo
+}
+
+// TODO
+type EndpointInfo struct {
+	Address string
+	Info    map[string]interface{}
+}
+
+type Labels map[string]string
+
+func (labels Labels) String() string {
+	result := []string{}
+
+	for key, value := range labels {
+		result = append(result, fmt.Sprintf("%s:%s", key, value))
+	}
+
+	return strings.Join(result, ",")
 }

--- a/nginx-controller/nginx/ingress.go
+++ b/nginx-controller/nginx/ingress.go
@@ -1,9 +1,6 @@
 package nginx
 
 import (
-	"fmt"
-	"strings"
-
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
@@ -16,22 +13,4 @@ type IngressEx struct {
 	JWTKey        *api_v1.Secret
 	Endpoints     map[string][]string
 	EndpointsInfo map[string][]EndpointInfo
-}
-
-// TODO
-type EndpointInfo struct {
-	Address string
-	Info    map[string]interface{}
-}
-
-type Labels map[string]string
-
-func (labels Labels) String() string {
-	result := []string{}
-
-	for key, value := range labels {
-		result = append(result, fmt.Sprintf("%s:%s", key, value))
-	}
-
-	return strings.Join(result, ",")
 }

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -143,6 +143,7 @@ type ServerStream struct {
 	Ports               []int
 	ServerSnippets      []string
 	ProxyConnectTimeout string
+	ProxyTimeout        string
 	ProxyBufferSize     string
 }
 
@@ -155,6 +156,7 @@ type Location struct {
 	LocationSnippets     []string
 	Path                 string
 	Upstream             UpstreamHTTP
+	ProxyTimeout         string
 	ProxyConnectTimeout  string
 	ProxyReadTimeout     string
 	ClientMaxBodySize    string

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -343,7 +343,7 @@ func (nginx *NginxController) getSecretFileName(name string) string {
 }
 
 func (nginx *NginxController) templateIt(config IngressNginxConfig, filename string) {
-	tmpl := nginx.getTemplate(nginx.nginxConfTemplatePath)
+	tmpl := nginx.getTemplate(nginx.nginxIngressTempatePath)
 	glog.V(3).Infof("Writing NGINX conf to %v", filename)
 
 	if glog.V(3) {
@@ -458,10 +458,7 @@ func shellOut(cmd string) (err error) {
 func (nginx *NginxController) UpdateMainConfigFile(cfg *NginxMainConfig) {
 	cfg.HealthStatus = nginx.healthStatus
 
-	tmpl, err := template.New(nginx.nginxConfTemplatePath).ParseFiles(nginx.nginxConfTemplatePath)
-	if err != nil {
-		glog.Fatalf("Failed to parse the main config template file: %v", err)
-	}
+	tmpl := nginx.getTemplate(nginx.nginxConfTemplatePath)
 
 	filename := "/etc/nginx/nginx.conf"
 	glog.V(3).Infof("Writing NGINX conf to %v", filename)
@@ -486,14 +483,7 @@ func (nginx *NginxController) UpdateMainConfigFile(cfg *NginxMainConfig) {
 }
 
 func (nginx *NginxController) UpdateMapsConfigFile(maps []Map) {
-	tmpl, err := template.New(
-		nginx.nginxMapsConfTemplatePath,
-	).ParseFiles(
-		nginx.nginxMapsConfTemplatePath,
-	)
-	if err != nil {
-		glog.Fatalf("Failed to parse the maps config template file: %v", err)
-	}
+	tmpl := nginx.getTemplate(nginx.nginxMapsConfTemplatePath)
 
 	filename := "/etc/nginx/maps.conf"
 	glog.V(3).Infof("Writing NGINX conf to %v", filename)

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -397,6 +397,18 @@ func (nginx *NginxController) Reload() error {
 	return nil
 }
 
+// Reload reloads NGINX
+func (nginx *NginxController) Reopen() error {
+	if !nginx.local {
+		if err := shellOut("nginx -s reopen"); err != nil {
+			return fmt.Errorf("Reopening NGINX log files failed: %s", err)
+		}
+	} else {
+		glog.V(3).Info("Reopening nginx log files")
+	}
+	return nil
+}
+
 // Start starts NGINX
 func (nginx *NginxController) Start(done chan error) {
 	if !nginx.local {

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -183,6 +183,7 @@ type NginxMainConfig struct {
 	ServerTokens           string
 	ProxyProtocol          bool
 	WorkerProcesses        string
+	WorkerConnections      int64
 	WorkerCPUAffinity      string
 }
 
@@ -230,6 +231,7 @@ func NewNginxController(
 		ServerNamesHashMaxSize: NewDefaultConfig().MainServerNamesHashMaxSize,
 		ServerTokens:           NewDefaultConfig().ServerTokens,
 		WorkerProcesses:        NewDefaultConfig().MainWorkerProcesses,
+		WorkerConnections:      NewDefaultConfig().MainWorkerConnections,
 	}
 	ngxc.UpdateMainConfigFile(cfg)
 	ngxc.UpdateMapsConfigFile([]Map{})

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -167,6 +167,7 @@ func NewNginxController(
 		WorkerProcesses:        NewDefaultConfig().MainWorkerProcesses,
 	}
 	ngxc.UpdateMainConfigFile(cfg)
+	ngxc.UpdateMapsConfigFile([]Map{})
 
 	return &ngxc, nil
 }

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -129,6 +129,8 @@ type ServerHTTP struct {
 
 	Ports    []int
 	SSLPorts []int
+
+	Address string
 }
 
 func (http ServerHTTP) Type() string {
@@ -137,6 +139,7 @@ func (http ServerHTTP) Type() string {
 
 // Server describes an Stream NGINX server
 type ServerStream struct {
+	Address             string
 	Ports               []int
 	ServerSnippets      []string
 	ProxyConnectTimeout string

--- a/nginx-controller/nginx/templates/nginx-plus.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.ingress.tmpl
@@ -1,3 +1,4 @@
+{{- if eq .Type "http" }}
 {{range $upstream := .Upstreams}}
 upstream {{$upstream.Name}} {
 	zone {{$upstream.Name}} 256k;
@@ -56,9 +57,9 @@ server {
 	{{ if $server.JWTKey}}
 	auth_jwt_key_file {{$server.JWTKey}};
 	auth_jwt "{{$server.JWTRealm}}"{{if $server.JWTToken}} token={{$server.JWTToken}}{{end}};
-	
+
 	{{- if $server.JWTLoginURL}}
-	error_page 401 @login_url;	
+	error_page 401 @login_url;
 	location @login_url {
 		internal;
 		return 302 {{$server.JWTLoginURL}};
@@ -112,3 +113,29 @@ server {
 		{{end}}
 	}{{end}}
 }{{end}}
+{{- else }}
+upstream {{.Upstream.Name}} {
+	{{if .Upstream.LBMethod }}{{.Upstream.LBMethod}};{{end}}
+	{{range $server := .Upstream.UpstreamServers}}
+	server {{$server.Address}}:{{$server.Port}};{{end}}
+}
+
+server {
+	{{range $port := .Server.Ports}}
+	listen {{$port}};
+	{{- end}}
+	{{- if .Server.ServerSnippets}}
+	{{range $value := .Server.ServerSnippets}}
+	{{$value}}{{end}}
+	{{- end}}
+
+    {{- if .Server.ProxyBufferSize}}
+    proxy_connect_timeout {{.Server.ProxyConnectTimeout}};
+    {{- end }}
+    {{- if .Server.ProxyBufferSize}}
+    proxy_buffer_size {{.Server.ProxyBufferSize}};
+    {{- end}}
+
+    proxy_pass {{.Upstream.Name}};
+}
+{{ end }}

--- a/nginx-controller/nginx/templates/nginx.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx.ingress.tmpl
@@ -115,9 +115,11 @@ upstream {{.Upstream.Name}} {
 	server {{$server.Address}}:{{$server.Port}};{{end}}
 }
 
+{{ $server := .Server }}
+
 server {
 	{{range $port := .Server.Ports}}
-	listen {{$port}};
+	listen {{if $server.Address}}{{$server.Address}}:{{end}}{{$port}};
 	{{- end}}
 	{{- if .Server.ServerSnippets}}
 	{{range $value := .Server.ServerSnippets}}

--- a/nginx-controller/nginx/templates/nginx.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx.ingress.tmpl
@@ -1,3 +1,4 @@
+{{- if eq .Type "http" }}
 {{range $upstream := .Upstreams}}
 upstream {{$upstream.Name}} {
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
@@ -39,7 +40,7 @@ server {
 	server_tokens {{$server.ServerTokens}};
 
 	server_name {{$server.Name}};
-	
+
 	{{range $proxyHideHeader := $server.ProxyHideHeaders}}
 	proxy_hide_header {{$proxyHideHeader}};{{end}}
 	{{range $proxyPassHeader := $server.ProxyPassHeaders}}
@@ -107,3 +108,29 @@ server {
 		{{end}}
 	}{{end}}
 }{{end}}
+{{- else }}
+upstream {{.Upstream.Name}} {
+	{{if .Upstream.LBMethod }}{{.Upstream.LBMethod}};{{end}}
+	{{range $server := .Upstream.UpstreamServers}}
+	server {{$server.Address}}:{{$server.Port}};{{end}}
+}
+
+server {
+	{{range $port := .Server.Ports}}
+	listen {{$port}};
+	{{- end}}
+	{{- if .Server.ServerSnippets}}
+	{{range $value := .Server.ServerSnippets}}
+	{{$value}}{{end}}
+	{{- end}}
+
+    {{- if .Server.ProxyBufferSize}}
+    proxy_connect_timeout {{.Server.ProxyConnectTimeout}};
+    {{- end }}
+    {{- if .Server.ProxyBufferSize}}
+    proxy_buffer_size {{.Server.ProxyBufferSize}};
+    {{- end}}
+
+    proxy_pass {{.Upstream.Name}};
+}
+{{ end }}

--- a/nginx-controller/nginx/templates/nginx.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx.ingress.tmpl
@@ -23,11 +23,11 @@ server {
 	set "$k8s_ingress" "{{$cfg.IngressName}}";
 
 	{{range $port := $server.Ports}}
-	listen {{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	listen {{if $server.Address}}{{$server.Address}}:{{end}}{{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
 	{{- end}}
 	{{if $server.SSL}}
 	{{- range $port := $server.SSLPorts}}
-	listen {{$port}} ssl{{if $server.HTTP2}} http2{{end}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	listen {{if $server.Address}}{{$server.Address}}:{{end}}{{$port}} ssl{{if $server.HTTP2}} http2{{end}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
 	{{- end}}
 	ssl_certificate {{$server.SSLCertificate}};
 	ssl_certificate_key {{$server.SSLCertificateKey}};

--- a/nginx-controller/nginx/templates/nginx.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx.ingress.tmpl
@@ -6,8 +6,21 @@ upstream {{$upstream.Name}} {
 	{{if $.Keepalive}}keepalive {{$.Keepalive}};{{end}}
 }{{end}}
 
-{{range $server := .Servers}}
+{{range $map := .Maps}}
+map {{$map.Source}} {{$map.Variable}} {
+{{- range $endpoint, $value := $map.Values}}
+	{{$endpoint}} {{$value}};
+{{- end}}
+}
+{{end}}
+
+{{- $cfg := .}}
+
+{{- range $server := .Servers}}
 server {
+	set "$k8s_namespace" "{{$cfg.Namespace}}";
+	set "$k8s_ingress" "{{$cfg.IngressName}}";
+
 	{{range $port := $server.Ports}}
 	listen {{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
 	{{- end}}

--- a/nginx-controller/nginx/templates/nginx.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx.ingress.tmpl
@@ -126,12 +126,15 @@ server {
 	{{$value}}{{end}}
 	{{- end}}
 
-    {{- if .Server.ProxyBufferSize}}
+    {{- if .Server.ProxyConnectTimeout}}
     proxy_connect_timeout {{.Server.ProxyConnectTimeout}};
     {{- end }}
     {{- if .Server.ProxyBufferSize}}
     proxy_buffer_size {{.Server.ProxyBufferSize}};
     {{- end}}
+    {{- if .Server.ProxyTimeout}}
+    proxy_timeout {{.Server.ProxyTimeout}};
+    {{- end }}
 
     proxy_pass {{.Upstream.Name}};
 }

--- a/nginx-controller/nginx/templates/nginx.maps.tmpl
+++ b/nginx-controller/nginx/templates/nginx.maps.tmpl
@@ -1,0 +1,9 @@
+{{- range $map := .}}
+{{- with $map.Values}}
+map {{$map.Source}} {{$map.Variable}} {
+{{- range $endpoint, $value := $map.Values}}
+	{{$endpoint}} {{$value}};
+{{- end}}
+}
+{{- end}}
+{{end}}

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -9,7 +9,7 @@ error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
 events {
-    worker_connections  1024;
+    worker_connections  {{.WorkerConnections}};
 }
 
 http {

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -1,4 +1,3 @@
-
 user  nginx;
 worker_processes  {{.WorkerProcesses}};
 {{- if .WorkerCPUAffinity}}
@@ -9,11 +8,9 @@ daemon off;
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
-
 events {
     worker_connections  1024;
 }
-
 
 http {
     include       /etc/nginx/mime.types;
@@ -76,5 +73,10 @@ http {
     }
 
     include /etc/nginx/maps.conf;
-    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/conf.d/http-*.conf;
+}
+
+stream {
+    include /etc/nginx/maps.conf;
+    include /etc/nginx/conf.d/stream-*.conf;
 }

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -75,6 +75,6 @@ http {
         }
     }
 
-    include /etc/nginx/maps*.conf;
+    include /etc/nginx/maps.conf;
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -77,6 +77,5 @@ http {
 }
 
 stream {
-    include /etc/nginx/maps.conf;
     include /etc/nginx/conf.d/stream-*.conf;
 }

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -75,5 +75,6 @@ http {
         }
     }
 
+    include /etc/nginx/maps*.conf;
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx-controller/nginx/templates/templates_test.go
+++ b/nginx-controller/nginx/templates/templates_test.go
@@ -136,6 +136,21 @@ func TestIngressStreamForNGINX(t *testing.T) {
 	}
 }
 
+func TestIngressStreamAsIngressNginxConfigForNGINX(t *testing.T) {
+	tmpl, err := template.New(nginxIngressTmpl).ParseFiles(nginxIngressTmpl)
+	if err != nil {
+		t.Fatalf("Failed to parse template file: %v", err)
+	}
+
+	var buf bytes.Buffer
+
+	err = tmpl.Execute(&buf, (nginx.IngressNginxConfig)(ingCfgStream))
+	t.Log(string(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Failed to write template %v", err)
+	}
+}
+
 func TestMainForNGINXPlus(t *testing.T) {
 	tmpl, err := template.New(nginxPlusMainTmpl).ParseFiles(nginxPlusMainTmpl)
 	if err != nil {


### PR DESCRIPTION
As we know, we can log upstream(s) which served request by using
`$upstream_addr` variable in `log_format` definition. However, pod IPs in k8s
are intrinsically volatile and can be changed at pod restart, so if we will use
`$upstream_addr` in logs it will be difficult to understand which pods really
processed request.

I propose a PR which adds a way to use `$pod_name`, `$namespace_name` (sic!),
`$container_name` and `$pod_labels` to be available for use in `log_format`.

Their values are inferred from latest address in the `$upstream_addr` variable
by using `map` directive. Since mapped variables are evaluated at expansion
time, it works and will not introduce additional overhead for users who will
not use mentioned variables in their log format.

Current implementation is quite rough and I open for comments to improve it.