### PR TITLE
Added `nginx.org/proxy-terminate-auth-headers` Ingress annotation for…

### DIFF
--- a/examples/customization/README.md
+++ b/examples/customization/README.md
@@ -15,6 +15,7 @@ The table below summarizes some of the options. More options (extensions) are av
 | `nginx.org/proxy-max-temp-file-size` | `proxy-max-temp-file-size` | Sets the value of the  [proxy_max_temp_file_size](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size) directive. | `1024m` |
 | `nginx.org/proxy-hide-headers` | `proxy-hide-headers` | Sets the value of one or more  [proxy_hide_header](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_hide_header) directives. Example: `"nginx.org/proxy-hide-headers": "header-a,header-b"` | N/A |
 | `nginx.org/proxy-pass-headers` | `proxy-pass-headers` | Sets the value of one or more   [proxy_pass_header](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass_header) directives. Example: `"nginx.org/proxy-pass-headers": "header-a,header-b"` | N/A |
+| `nginx.org/proxy-terminate-auth-headers` | N/A | If true, sets the Authorization header to "" to terminate Auth at the proxy. Example: `"nginx.org/proxy-pass-headers": "true"` | N/A |
 | N/A | `server-names-hash-bucket-size` | Sets the value of the [server_names_hash_bucket_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size) directive. | Depends on the size of the processor’s cache line. |
 | N/A | `server-names-hash-max-size` | Sets the value of the [server_names_hash_max_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size) directive. | `512` |
 | N/A | `http2` | Enables HTTP/2 in servers with SSL enabled. | `False` |

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	ProxyProtocol                 bool
 	ProxyHideHeaders              []string
 	ProxyPassHeaders              []string
+	ProxyTerminateAuthHeaders     bool
 	HSTS                          bool
 	HSTSMaxAge                    int64
 	HSTSIncludeSubdomains         bool

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -133,6 +133,7 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 			RealIPRecursive:       ingCfg.RealIPRecursive,
 			ProxyHideHeaders:      ingCfg.ProxyHideHeaders,
 			ProxyPassHeaders:      ingCfg.ProxyPassHeaders,
+			ProxyTerminateAuthHeaders: ingCfg.ProxyTerminateAuthHeaders,
 			ServerSnippets:        ingCfg.ServerSnippets,
 			Ports:                 ingCfg.Ports,
 			SSLPorts:              ingCfg.SSLPorts,
@@ -248,6 +249,13 @@ func (cnf *Configurator) createConfig(ingEx *IngressEx) Config {
 			glog.Error(err)
 		} else {
 			ingCfg.ProxyPassHeaders = proxyPassHeaders
+		}
+	}
+	if proxyTerminateAuthHeaders, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, "nginx.org/proxy-terminate-auth-headers", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			ingCfg.ProxyTerminateAuthHeaders = proxyTerminateAuthHeaders
 		}
 	}
 	if clientMaxBodySize, exists := ingEx.Ingress.Annotations["nginx.org/client-max-body-size"]; exists {

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -68,6 +68,7 @@ type Server struct {
 	HSTSIncludeSubdomains bool
 	ProxyHideHeaders      []string
 	ProxyPassHeaders      []string
+	ProxyTerminateAuthHeaders bool
 
 	// http://nginx.org/en/docs/http/ngx_http_realip_module.html
 	RealIPHeader    string

--- a/nginx-controller/nginx/templates/nginx-plus.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.ingress.tmpl
@@ -95,6 +95,9 @@ server {
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Port $server_port;
 		proxy_set_header X-Forwarded-Proto {{if $server.RedirectToHTTPS}}https{{else}}$scheme{{end}};
+		{{- if $server.ProxyTerminateAuthHeaders}}
+		proxy_set_header Authorization "";
+		{{- end}}
 		proxy_buffering {{if $location.ProxyBuffering}}on{{else}}off{{end}};
 		{{- if $location.ProxyBuffers}}
 		proxy_buffers {{$location.ProxyBuffers}};

--- a/nginx-controller/nginx/templates/nginx.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx.ingress.tmpl
@@ -77,6 +77,10 @@ server {
 		proxy_set_header X-Forwarded-Port $server_port;
 		proxy_set_header X-Forwarded-Proto {{if $server.RedirectToHTTPS}}https{{else}}$scheme{{end}};
 
+		{{- if $server.ProxyTerminateAuthHeaders}}
+		proxy_set_header Authorization "";
+		{{- end}}
+
 		proxy_buffering {{if $location.ProxyBuffering}}on{{else}}off{{end}};
 		{{- if $location.ProxyBuffers}}
 		proxy_buffers {{$location.ProxyBuffers}};


### PR DESCRIPTION
Added `nginx.org/proxy-terminate-auth-headers` Ingress annotation for setting `proxy_set_header Authorization "";` to prevent Authorization headers from being passed along to the proxied endpoint as described in #200 