### PR TITLE
Fix a problem with endpoints updates for Plus

### DIFF
--- a/nginx-controller/nginx/plus/nginx_client.go
+++ b/nginx-controller/nginx/plus/nginx_client.go
@@ -236,7 +236,7 @@ func (client *NginxClient) GetHTTPServers(upstream string) ([]string, error) {
 func (client *NginxClient) getIDOfHTTPServer(upstream string, name string) (int, error) {
 	peers, err := client.getUpstreamPeers(upstream)
 	if err != nil {
-		return -1, fmt.Errorf("Error getting id of server %v of upstream %v:", name, upstream)
+		return -1, fmt.Errorf("Error getting id of server %v of upstream %v: %v", name, upstream, err)
 	}
 
 	for _, p := range peers.Peers {


### PR DESCRIPTION
* Make sure that if an update of endpoints via NGINX Plus API fails, NGINX configuration is reloaded, so that the update is applied.
* Minimize the number of configuration reloads when the Ingress controller starts (NGINX OSS/ Plus)

