### PR TITLE
Reduce the number of reloads for endpoints changes

### DIFF
--- a/nginx-controller/nginx/ingress.go
+++ b/nginx-controller/nginx/ingress.go
@@ -1,6 +1,8 @@
 package nginx
 
 import (
+	"fmt"
+
 	api_v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 )
@@ -12,4 +14,12 @@ type IngressEx struct {
 	TLSSecrets map[string]*api_v1.Secret
 	JWTKey     *api_v1.Secret
 	Endpoints  map[string][]string
+}
+
+func (ingEx *IngressEx) String() string {
+	if ingEx.Ingress == nil {
+		return "IngressEx has no Ingress"
+	}
+
+	return fmt.Sprintf("%v/%v", ingEx.Ingress.Namespace, ingEx.Ingress.Name)
 }


### PR DESCRIPTION
Reduce the number of reloads for endpoints changes when one service is used across multiple Ingress rules.