### PR TITLE
Handle annotations and conflicting paths for MergeableTypes

### DIFF
--- a/examples/mergable-ingress-types/README.md
+++ b/examples/mergable-ingress-types/README.md
@@ -10,9 +10,32 @@ host level, which includes the TLS configuration, and any annotations which will
 can only be one ingress resource on a unique host that contains the master value. Paths cannot be part of the
 ingress resource.
 
+Masters cannot contain the following annotations:
+* nginx.org/rewrites
+* nginx.org/ssl-services
+* nginx.org/websocket-services
+* nginx.com/sticky-cookie-services
+
 A Minion is declared using `nginx.org/mergible-ingress-type: minion`. A Minion will be used to append different
-locations to an ingress resource with the Master value. The annotations of minions are replaced with the annotations of
-their master. TLS configurations are not allowed. There can be multiple minions which must have the same host as the master.
+locations to an ingress resource with the Master value. TLS configurations are not allowed. Multiple minions can be
+applied per master as long as they do not have conflicting paths. If a conflicting path is present then the path defined
+on the oldest minion will be used.
+
+Minions cannot contain the following annotations:
+* nginx.org/proxy-hide-headers
+* nginx.org/proxy-pass-headers
+* nginx.org/redirect-to-https
+* ingress.kubernetes.io/ssl-redirect
+* nginx.org/hsts
+* nginx.org/hsts-max-age
+* nginx.org/hsts-include-subdomains
+* nginx.org/server-tokens
+* nginx.org/listen-ports
+* nginx.org/listen-ports-ssl
+* nginx.com/jwt-key
+* nginx.com/jwt-realm
+* nginx.com/jwt-token
+* nginx.com/jwt-login-url
 
 Note: Ingress Resources with more than one host cannot be used.
 

--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -37,6 +37,7 @@ import (
 	api_v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sort"
 )
 
 const (
@@ -1203,7 +1204,14 @@ func (lbc *LoadBalancerController) getMinionsForMaster(master *nginx.IngressEx) 
 		return []*nginx.IngressEx{}, err
 	}
 
+	// ingresses are sorted by creation time
+	sort.Slice(ings.Items[:], func(i, j int) bool {
+		return ings.Items[i].CreationTimestamp.Time.UnixNano() < ings.Items[j].CreationTimestamp.Time.UnixNano()
+	})
+
 	var minions []*nginx.IngressEx
+	var minionPaths = make(map[string]*extensions.Ingress)
+
 	for i, _ := range ings.Items {
 		if !lbc.isNginxIngress(&ings.Items[i]) {
 			continue
@@ -1222,6 +1230,20 @@ func (lbc *LoadBalancerController) getMinionsForMaster(master *nginx.IngressEx) 
 			glog.Errorf("Ingress Resource %v/%v with the 'nginx.org/mergible-ingress-type' annotation set to 'minion' must contain a Path", ings.Items[i].Namespace, ings.Items[i].Name)
 			continue
 		}
+
+		uniquePaths := []extensions.HTTPIngressPath{}
+		for _, path := range ings.Items[i].Spec.Rules[0].HTTP.Paths {
+			if val, ok := minionPaths[path.Path]; ok {
+				glog.Errorf("Ingress Resource %v/%v with the 'nginx.org/mergible-ingress-type' annotation set to 'minion' cannot contain the same path as another ingress resource, %v/%v.",
+					ings.Items[i].Namespace, ings.Items[i].Name, val.Namespace, val.Name)
+				glog.Errorf("Path %s for Ingress Resource %v/%v will be ignored", path.Path, val.Namespace, val.Name)
+			} else {
+				minionPaths[path.Path] = &ings.Items[i]
+				uniquePaths = append(uniquePaths, path)
+			}
+		}
+		ings.Items[i].Spec.Rules[0].HTTP.Paths = uniquePaths
+
 		ingEx, err := lbc.createIngress(&ings.Items[i])
 		if err != nil {
 			glog.Errorf("Error creating ingress resource %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
@@ -1233,6 +1255,7 @@ func (lbc *LoadBalancerController) getMinionsForMaster(master *nginx.IngressEx) 
 		}
 		minions = append(minions, ingEx)
 	}
+
 	return minions, nil
 }
 

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -83,6 +83,13 @@ func (cnf *Configurator) addOrUpdateMergableIngress(mergeableIngs *MergeableIngr
 	var locations []Location
 	var upstreams []Upstream
 	var keepalive string
+	var removedAnnotations []string
+
+	removedAnnotations = filterMasterAnnotations(mergeableIngs.Master.Ingress.Annotations)
+	if len(removedAnnotations) != 0 {
+		glog.Errorf("Ingress Resource %v/%v with the annotation 'nginx.com/mergeable-ingress-type' set to 'master' cannot contain the '%v' annotation(s). They will be ignored",
+			mergeableIngs.Master.Ingress.Namespace, mergeableIngs.Master.Ingress.Name, strings.Join(removedAnnotations, ","))
+	}
 
 	pems, jwtKeyFileName := cnf.updateSecrets(mergeableIngs.Master)
 	masterNginxCfg := cnf.generateNginxCfg(mergeableIngs.Master, pems, jwtKeyFileName)
@@ -101,20 +108,28 @@ func (cnf *Configurator) addOrUpdateMergableIngress(mergeableIngs *MergeableIngr
 
 	minions := mergeableIngs.Minions
 	for _, minion := range minions {
+		// Remove the default backend so that "/" will not be generated
+		minion.Ingress.Spec.Backend = nil
+
+		// Add acceptable master annotations to minion
+		mergeMasterAnnotationsIntoMinion(minion.Ingress.Annotations, mergeableIngs.Master.Ingress.Annotations)
+
+		removedAnnotations = filterMinionAnnotations(minion.Ingress.Annotations)
+		if len(removedAnnotations) != 0 {
+			glog.Errorf("Ingress Resource %v/%v with the annotation 'nginx.com/mergeable-ingress-type' set to 'minion' cannot contain the %v annotation(s). They will be ignored",
+				minion.Ingress.Namespace, minion.Ingress.Name, strings.Join(removedAnnotations, ","))
+		}
+
 		pems, jwtKeyFileName := cnf.updateSecrets(minion)
 		nginxCfg := cnf.generateNginxCfg(minion, pems, jwtKeyFileName)
 
-		// Replace all minion annotations with master annotations
-		minion.Ingress.Annotations = mergeableIngs.Master.Ingress.Annotations
-
 		for _, server := range nginxCfg.Servers {
 			for _, loc := range server.Locations {
-				if loc.Path != "/" {
-					loc.IngressResource = objectMetaToFileName(&minion.Ingress.ObjectMeta)
-					locations = append(locations, loc)
-				}
+				loc.IngressResource = objectMetaToFileName(&minion.Ingress.ObjectMeta)
+				locations = append(locations, loc)
 			}
 		}
+
 		for _, val := range nginxCfg.Upstreams {
 			upstreams = append(upstreams, val)
 		}
@@ -764,6 +779,48 @@ func (cnf *Configurator) updatePlusEndpoints(ingEx *IngressEx) error {
 	}
 
 	return nil
+}
+
+func filterMasterAnnotations(annotations map[string]string) []string {
+	var removedAnnotations []string
+
+	for _, blacklistAnn := range masterBlacklist {
+		if _, ok := annotations[blacklistAnn]; ok {
+			removedAnnotations = append(removedAnnotations, blacklistAnn)
+			delete(annotations, blacklistAnn)
+		}
+	}
+
+	return removedAnnotations
+}
+
+func filterMinionAnnotations(annotations map[string]string) []string {
+	var removedAnnotations []string
+
+	for _, blacklistAnn := range minionBlacklist {
+		if _, ok := annotations[blacklistAnn]; ok {
+			removedAnnotations = append(removedAnnotations, blacklistAnn)
+			delete(annotations, blacklistAnn)
+		}
+	}
+
+	return removedAnnotations
+}
+
+func mergeMasterAnnotationsIntoMinion(minionAnnotations map[string]string, masterAnnotations map[string]string) {
+	for key, val := range masterAnnotations {
+		isBlacklisted := false
+		if _, ok := minionAnnotations[key]; !ok {
+			for _, blacklistAnn := range minionBlacklist {
+				if blacklistAnn == key {
+					isBlacklisted = true
+				}
+			}
+			if !isBlacklisted {
+				minionAnnotations[key] = val
+			}
+		}
+	}
 }
 
 // UpdateConfig updates NGINX Configuration parameters

--- a/nginx-controller/nginx/ingress.go
+++ b/nginx-controller/nginx/ingress.go
@@ -15,6 +15,30 @@ type IngressEx struct {
 }
 
 type MergeableIngresses struct {
-	Master *IngressEx
+	Master  *IngressEx
 	Minions []*IngressEx
+}
+
+var masterBlacklist = []string{
+	"nginx.org/rewrites",
+	"nginx.org/ssl-services",
+	"nginx.org/websocket-services",
+	"nginx.com/sticky-cookie-services",
+}
+
+var minionBlacklist = []string{
+	"nginx.org/proxy-hide-headers",
+	"nginx.org/proxy-pass-headers",
+	"nginx.org/redirect-to-https",
+	"ingress.kubernetes.io/ssl-redirect",
+	"nginx.org/hsts",
+	"nginx.org/hsts-max-age",
+	"nginx.org/hsts-include-subdomains",
+	"nginx.org/server-tokens",
+	"nginx.org/listen-ports",
+	"nginx.org/listen-ports-ssl",
+	"nginx.com/jwt-key",
+	"nginx.com/jwt-realm",
+	"nginx.com/jwt-token",
+	"nginx.com/jwt-login-url",
 }


### PR DESCRIPTION
Adds new rules for the MergeableTypes. Minions will not be able to have conflicting locations, and can only have service level annotations. Masters will only be able to have host level annotations.

Fixes #264 