### PR TITLE
Move nginx-ingress image to the official nginx DockerHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ NGINX Plus provides you with [advanced statistics](https://www.nginx.com/product
 * **Support** Support from NGINX Inc is available for NGINX Plus Ingress controller.
 
 **Note**: Deployment of the Ingress controller for NGINX Plus requires you to do one extra step: build your own [Docker image](nginx-controller) using the certificate and key for your subscription.
-The Docker image of the Ingress controller for NGINX is [available on Docker Hub](https://hub.docker.com/r/nginxdemos/nginx-ingress/).
+The Docker image of the Ingress controller for NGINX is [available on Docker Hub](https://hub.docker.com/r/nginx/nginx-ingress/).
 
 ## Using Multiple Ingress Controllers
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 Make sure you have access to the Ingress controller image:
 
-* For NGINX Ingress controller, use the image `nginxdemos/nginx-ingress` from [DockerHub](https://hub.docker.com/r/nginxdemos/nginx-ingress/).
+* For NGINX Ingress controller, use the image `nginx/nginx-ingress` from [DockerHub](https://hub.docker.com/r/nginx/nginx-ingress/).
 * For NGINX Plus Ingress controller, build your own image and push it to your private Docker registry by following the instructions from [here](../nginx-controller).
 
 The installation manifests are located in the [install](../install) folder. In the steps below we assume that you will be running the commands from that folder.

--- a/docs/nginx-ingress-controllers.md
+++ b/docs/nginx-ingress-controllers.md
@@ -4,7 +4,7 @@ There are two NGINX-based Ingress controller implementations out there: the one 
 
 ## Which One Am I Using?
 
-If you are unsure about which implementation you are using, check the container image of the Ingress controller that is running. For the nginxinc/kubernetes-ingress Ingress controller its Docker image is published on [DockerHub](https://hub.docker.com/r/nginxdemos/nginx-ingress/) and available as *nginxdemos/nginx-ingress*.
+If you are unsure about which implementation you are using, check the container image of the Ingress controller that is running. For the nginxinc/kubernetes-ingress Ingress controller its Docker image is published on [DockerHub](https://hub.docker.com/r/nginx/nginx-ingress/) and available as *nginx/nginx-ingress*.
 
 ## The Key Differences
 

--- a/examples/openshift/nginx-ingress-rc.yaml
+++ b/examples/openshift/nginx-ingress-rc.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: nginx-ingress
       containers:
-      - image: nginxdemos/nginx-ingress:1.0.0
+      - image: nginx/nginx-ingress:1.1.1
         imagePullPolicy: Always
         name: nginx-ingress
         ports:

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -49,7 +49,7 @@ Parameter | Description | Default
 `controller.kind` | The kind of the Ingress controller installation - deployment or daemonset. | deployment
 `controller.nginxplus` | Should NGINX Plus be deployed. | false
 `controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace. | false
-`controller.image.repository` | The image repository of the Ingress controller. | nginxdemos/nginx-ingress
+`controller.image.repository` | The image repository of the Ingress controller. | nginx/nginx-ingress
 `controller.image.tag` | The tag of the Ingress controller image. | 1.1.1
 `controller.image.pullPolicy` | The pull policy for the Ingress controller image. | IfNotPresent
 `controller.config.entries` | The entries of the ConfigMap for customizing NGINX configuration. | { }

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -4,7 +4,7 @@ controller:
   nginxplus: "false"
   hostNetwork: "false"
   image:
-    repository: nginxdemos/nginx-ingress
+    repository: nginx/nginx-ingress
     tag: "1.1.1"
     pullPolicy: IfNotPresent
   config:

--- a/install/daemon-set/nginx-ingress.yaml
+++ b/install/daemon-set/nginx-ingress.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       serviceAccountName: nginx-ingress
       containers:
-      - image: nginxdemos/nginx-ingress:1.1.1
+      - image: nginx/nginx-ingress:1.1.1
         name: nginx-ingress
         ports:
         - name: http

--- a/install/deployment/nginx-ingress.yaml
+++ b/install/deployment/nginx-ingress.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: nginx-ingress
       containers:
-      - image: nginxdemos/nginx-ingress:1.1.1
+      - image: nginx/nginx-ingress:1.1.1
         name: nginx-ingress
         ports:
         - name: http

--- a/nginx-controller/Makefile
+++ b/nginx-controller/Makefile
@@ -2,7 +2,7 @@ all: push
 
 VERSION = 1.1.1
 TAG = $(VERSION)
-PREFIX = nginxdemos/nginx-ingress
+PREFIX = nginx/nginx-ingress
 
 DOCKER_RUN = docker run --rm -v $(shell pwd)/../:/go/src/github.com/nginxinc/kubernetes-ingress -w /go/src/github.com/nginxinc/kubernetes-ingress/nginx-controller/
 GOLANG_CONTAINER = golang:1.9

--- a/nginx-controller/README.md
+++ b/nginx-controller/README.md
@@ -4,7 +4,7 @@ This is an implementation of a Kubernetes Ingress controller for NGINX and NGINX
 
 ## How to Use the Controller
 
-To find examples on how to deploy, configure and use the Ingress controller, please see [the examples folder](../examples). The examples require the Docker image of the controller to be available to your Kubernetes cluster. We provide such an image though [DockerHub](https://hub.docker.com/r/nginxdemos/nginx-ingress/) for NGINX. If you are using NGINX Plus, you need to build the image.
+To find examples on how to deploy, configure and use the Ingress controller, please see [the examples folder](../examples). The examples require the Docker image of the controller to be available to your Kubernetes cluster. We provide such an image though [DockerHub](https://hub.docker.com/r/nginx/nginx-ingress/) for NGINX. If you are using NGINX Plus, you need to build the image.
 
 There are other cases when you need to build your own image. For example if you want to customize the controller, either by changing the NGINX configuration templates and/or modifying the controller logic. Please read the next section for instructions on how to build an image.
 
@@ -71,7 +71,7 @@ The **Makefile** we provide has the following targets:
 ### Makefile Variables
 
 The **Makefile** contains the following main variables for you to customize (either by changing the Makefile or by overriding the variables in the make command):
-* **PREFIX** -- the name of the image. The default is `nginxdemos/nginx-ingress`.
+* **PREFIX** -- the name of the image. The default is `nginx/nginx-ingress`.
 * **VERSION** -- the current version of the controller.
 * **TAG** -- the tag added to the image. It's set to the value of the `VERSION` variable by default.
 * **PUSH_TO_GCR**. If you’re running your Kubernetes in GCE and using Google Container Registry, make sure that `PUSH_TO_GCR = 1`. This means using the `gcloud docker push` command to push the image, which is convenient when pushing images to GCR. By default, the variable is unset and the regular `docker push` command is used to push the image to the registry.


### PR DESCRIPTION
All nginx-ingress image references have been moved from nginxdemos to nginx, the official docker hub repository.