### PR TITLE
Correct Logs for Mergeable Types with Duplicate Location

### DIFF
--- a/nginx-controller/controller/controller.go
+++ b/nginx-controller/controller/controller.go
@@ -1259,7 +1259,7 @@ func (lbc *LoadBalancerController) getMinionsForMaster(master *nginx.IngressEx) 
 			if val, ok := minionPaths[path.Path]; ok {
 				glog.Errorf("Ingress Resource %v/%v with the 'nginx.org/mergeable-ingress-type' annotation set to 'minion' cannot contain the same path as another ingress resource, %v/%v.",
 					ings.Items[i].Namespace, ings.Items[i].Name, val.Namespace, val.Name)
-				glog.Errorf("Path %s for Ingress Resource %v/%v will be ignored", path.Path, val.Namespace, val.Name)
+				glog.Errorf("Path %s for Ingress Resource %v/%v will be ignored", path.Path, ings.Items[i].Namespace, ings.Items[i].Name)
 			} else {
 				minionPaths[path.Path] = &ings.Items[i]
 				uniquePaths = append(uniquePaths, path)


### PR DESCRIPTION
The logs displayed, showed the wrong ingress resource as the ignored ingress resource when a duplicate location was setup