### PR TITLE
Add support for active health checks for Plus

### DIFF
--- a/examples/customization/README.md
+++ b/examples/customization/README.md
@@ -60,6 +60,9 @@ The table below summarizes all of the options. For some of them, there are examp
 | `nginx.com/jwt-realm` | N/A | Specifies a realm. | N/A | [Support for JSON Web Tokens (JWTs)](../jwt). |
 | `nginx.com/jwt-token` | N/A | Specifies a variable that contains JSON Web Token. | By default, a JWT is expected in the `Authorization` header as a Bearer Token. | [Support for JSON Web Tokens (JWTs)](../jwt). |
 | `nginx.com/jwt-login-url` | N/A | Specifies a URL to which a client is redirected in case of an invalid or missing JWT. | N/A | [Support for JSON Web Tokens (JWTs)](../jwt). |
+| `nginx.com/health-checks` | N/A | Enables active health checks. | `False` | [Support for Active Health Checks](../health-checks). |
+| `nginx.com/health-checks-mandatory` | N/A | Configures active health checks as mandatory. | `False` | [Support for Active Health Checks](../health-checks). |
+| `nginx.com/health-checks-mandatory-queue` | N/A | When active health checks are mandatory, configures a queue for temporary storing incoming requests during the time when NGINX Plus is checking the health of the endpoints after a configuration reload. | `0` | [Support for Active Health Checks](../health-checks). |
 
 ## Using ConfigMaps
 

--- a/examples/health-checks/README.md
+++ b/examples/health-checks/README.md
@@ -1,0 +1,79 @@
+# Support for Active Health Checks
+
+NGINX Plus supports [active health checks](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-health-check/#active-health-checks). To use active health checks in the Ingress controller:
+
+1. Define health checks ([HTTP Readiness Probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-readiness-probes)) in the templates of your application pods.
+2. Enable heath checks in the Ingress controller using the annotations.
+
+The Ingress controller provides the following annotations for configuring active health checks:
+
+* Required: `nginx.com/health-checks: "true"` -- enables active health checks. The default is `false`.
+* Optional: `nginx.com/health-checks-mandatory: "true"` -- configures active health checks as mandatory. With the default active health checks, when an endpoint is added to NGINX Plus via the API or after a configuration reload, NGINX Plus considers the endpoint to be healthy. With mandatory health checks, when an endpoint is added to NGINX Plus or after a configuration reload, NGINX Plus considers the endpoint to be unhealthy until its health check passes. The default is `false`.
+* Optional: `nginx.com/health-checks-mandatory-queue: "500"` -- configures a [queue](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#queue) for temporary storing incoming requests during the time when NGINX Plus is checking the health of the endpoints after a configuration reload. If the queue is not configured or the queue is full, NGINX Plus will drop an incoming request returning the `502` code to the client. The queue is configured only when health checks are mandatory. The timeout parameter of the queue is configured with the value of the timeoutSeconds field of the corresponding Readiness Probe. Choose the size of the queue according with your requirements such as the expected number of requests per second and the timeout. The default is `0`.
+
+# Example
+
+In the following example we enable active health checks in the cafe-ingress Ingress:
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: cafe-ingress
+  annotations:
+     kubernetes.io/ingress.class: "nginx"
+     nginx.com/health-checks: "true"
+spec:
+  rules:
+  - host: "cafe.example.com"
+    http:
+      paths:
+      - path: /tea
+        backend:
+          serviceName: tea-svc
+          servicePort: 80
+      - path: /coffee
+        backend:
+          serviceName: coffee-svc
+          servicePort: 80
+      - path: /beer
+        backend:
+          serviceName: beer-svc
+          servicePort: 80
+```
+
+Note that a Readiness Probe must be configured in the pod template:
+```yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: tea
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: tea
+  template: 
+    metadata:
+      labels:
+        app: tea
+    spec:
+      containers:
+      - name: tea
+        image: nginxdemos/hello:plain-text
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            port: 80
+            path: /healthz/tea
+            httpHeaders:
+            - name: header1
+              value: "some value"
+            - name: header2
+              value: "123"
+          initialDelaySeconds: 1
+          periodSeconds: 5
+          timeoutSeconds: 4
+          successThreshold: 2
+          failureThreshold: 3
+```

--- a/examples/mergeable-ingress-types/README.md
+++ b/examples/mergeable-ingress-types/README.md
@@ -15,6 +15,9 @@ Masters cannot contain the following annotations:
 * nginx.org/ssl-services
 * nginx.org/websocket-services
 * nginx.com/sticky-cookie-services
+* nginx.com/health-checks
+* nginx.com/health-checks-mandatory
+* nginx.com/health-checks-mandatory-queue
 
 A Minion is declared using `nginx.org/mergeable-ingress-type: minion`. A Minion will be used to append different
 locations to an ingress resource with the Master value. TLS configurations are not allowed. Multiple minions can be

--- a/nginx-controller/controller/controller_test.go
+++ b/nginx-controller/controller/controller_test.go
@@ -2,6 +2,11 @@ package controller
 
 import (
 	"fmt"
+	"reflect"
+	"testing"
+	"time"
+	"unsafe"
+
 	"github.com/nginxinc/kubernetes-ingress/nginx-controller/nginx"
 	"github.com/nginxinc/kubernetes-ingress/nginx-controller/nginx/plus"
 	"k8s.io/api/core/v1"
@@ -11,10 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
-	"reflect"
-	"testing"
-	"time"
-	"unsafe"
 )
 
 func TestIsNginxIngress(t *testing.T) {
@@ -592,4 +593,237 @@ func getMergableDefaults() (cafeMaster, coffeeMinion, teaMinion extensions.Ingre
 	lbc.svcLister.Add(teaService)
 
 	return
+}
+
+func TestComparePorts(t *testing.T) {
+	scenarios := []struct {
+		sp       v1.ServicePort
+		cp       v1.ContainerPort
+		expected bool
+	}{
+		{
+			// match TargetPort.strval and Protocol
+			v1.ServicePort{
+				TargetPort: intstr.FromString("name"),
+				Protocol:   v1.ProtocolTCP,
+			},
+			v1.ContainerPort{
+				Name:          "name",
+				Protocol:      v1.ProtocolTCP,
+				ContainerPort: 80,
+			},
+			true,
+		},
+		{
+			// don't match Name and Protocol
+			v1.ServicePort{
+				Name:     "name",
+				Protocol: v1.ProtocolTCP,
+			},
+			v1.ContainerPort{
+				Name:          "name",
+				Protocol:      v1.ProtocolTCP,
+				ContainerPort: 80,
+			},
+			false,
+		},
+		{
+			// TargetPort intval mismatch, don't match by TargetPort.Name
+			v1.ServicePort{
+				Name:       "name",
+				TargetPort: intstr.FromInt(80),
+			},
+			v1.ContainerPort{
+				Name:          "name",
+				ContainerPort: 81,
+			},
+			false,
+		},
+		{
+			// match by TargetPort intval
+			v1.ServicePort{
+				TargetPort: intstr.IntOrString{
+					IntVal: 80,
+				},
+			},
+			v1.ContainerPort{
+				ContainerPort: 80,
+			},
+			true,
+		},
+		{
+			// Fall back on ServicePort.Port if TargetPort is empty
+			v1.ServicePort{
+				Name: "name",
+				Port: 80,
+			},
+			v1.ContainerPort{
+				Name:          "name",
+				ContainerPort: 80,
+			},
+			true,
+		},
+		{
+			// TargetPort intval mismatch
+			v1.ServicePort{
+				TargetPort: intstr.FromInt(80),
+			},
+			v1.ContainerPort{
+				ContainerPort: 81,
+			},
+			false,
+		},
+		{
+			// don't match empty ports
+			v1.ServicePort{},
+			v1.ContainerPort{},
+			false,
+		},
+	}
+
+	for _, scen := range scenarios {
+		if scen.expected != compareContainerPortAndServicePort(scen.cp, scen.sp) {
+			t.Errorf("Expected: %v, ContainerPort: %v, ServicePort: %v", scen.expected, scen.cp, scen.sp)
+		}
+	}
+}
+
+func TestFindProbeForPods(t *testing.T) {
+	pods := []v1.Pod{
+		v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					v1.Container{
+						ReadinessProbe: &v1.Probe{
+							Handler: v1.Handler{
+								HTTPGet: &v1.HTTPGetAction{
+									Path: "/",
+									Host: "asdf.com",
+									Port: intstr.IntOrString{
+										IntVal: 80,
+									},
+								},
+							},
+							PeriodSeconds: 42,
+						},
+						Ports: []v1.ContainerPort{
+							v1.ContainerPort{
+								Name:          "name",
+								ContainerPort: 80,
+								Protocol:      v1.ProtocolTCP,
+								HostIP:        "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	svcPort := v1.ServicePort{
+		TargetPort: intstr.FromInt(80),
+	}
+	probe := findProbeForPods(pods, &svcPort)
+	if probe == nil || probe.PeriodSeconds != 42 {
+		t.Errorf("ServicePort.TargetPort as int match failed: %+v", probe)
+	}
+
+	svcPort = v1.ServicePort{
+		TargetPort: intstr.FromString("name"),
+		Protocol:   v1.ProtocolTCP,
+	}
+	probe = findProbeForPods(pods, &svcPort)
+	if probe == nil || probe.PeriodSeconds != 42 {
+		t.Errorf("ServicePort.TargetPort as string failed: %+v", probe)
+	}
+
+	svcPort = v1.ServicePort{
+		TargetPort: intstr.FromInt(80),
+		Protocol:   v1.ProtocolTCP,
+	}
+	probe = findProbeForPods(pods, &svcPort)
+	if probe == nil || probe.PeriodSeconds != 42 {
+		t.Errorf("ServicePort.TargetPort as int failed: %+v", probe)
+	}
+
+	svcPort = v1.ServicePort{
+		Port: 80,
+	}
+	probe = findProbeForPods(pods, &svcPort)
+	if probe == nil || probe.PeriodSeconds != 42 {
+		t.Errorf("ServicePort.Port should match if TargetPort is not set: %+v", probe)
+	}
+
+	svcPort = v1.ServicePort{
+		TargetPort: intstr.FromString("wrong_name"),
+	}
+	probe = findProbeForPods(pods, &svcPort)
+	if probe != nil {
+		t.Errorf("ServicePort.TargetPort should not have matched string: %+v", probe)
+	}
+
+	svcPort = v1.ServicePort{
+		TargetPort: intstr.FromInt(22),
+	}
+	probe = findProbeForPods(pods, &svcPort)
+	if probe != nil {
+		t.Errorf("ServicePort.TargetPort should not have matched int: %+v", probe)
+	}
+
+	svcPort = v1.ServicePort{
+		Port: 22,
+	}
+	probe = findProbeForPods(pods, &svcPort)
+	if probe != nil {
+		t.Errorf("ServicePort.Port mismatch: %+v", probe)
+	}
+
+}
+
+func TestGetServicePortForIngressPort(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	cnf := nginx.NewConfigurator(&nginx.NginxController{}, &nginx.Config{}, &plus.NginxAPIController{})
+	lbc := LoadBalancerController{
+		client:       fakeClient,
+		ingressClass: "nginx",
+		cnf:          cnf,
+	}
+	svc := v1.Service{
+		TypeMeta: meta_v1.TypeMeta{},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "coffee-svc",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				v1.ServicePort{
+					Name:       "foo",
+					Port:       80,
+					TargetPort: intstr.FromInt(22),
+				},
+			},
+		},
+		Status: v1.ServiceStatus{},
+	}
+	ingSvcPort := intstr.FromString("foo")
+	svcPort := lbc.getServicePortForIngressPort(ingSvcPort, &svc)
+	if svcPort == nil || svcPort.Port != 80 {
+		t.Errorf("TargetPort string match failed: %+v", svcPort)
+	}
+
+	ingSvcPort = intstr.FromInt(80)
+	svcPort = lbc.getServicePortForIngressPort(ingSvcPort, &svc)
+	if svcPort == nil || svcPort.Port != 80 {
+		t.Errorf("TargetPort int match failed: %+v", svcPort)
+	}
+
+	ingSvcPort = intstr.FromInt(22)
+	svcPort = lbc.getServicePortForIngressPort(ingSvcPort, &svc)
+	if svcPort != nil {
+		t.Errorf("Mismatched ints should not return port: %+v", svcPort)
+	}
+	ingSvcPort = intstr.FromString("bar")
+	svcPort = lbc.getServicePortForIngressPort(ingSvcPort, &svc)
+	if svcPort != nil {
+		t.Errorf("Mismatched strings should not return port: %+v", svcPort)
+	}
 }

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -35,6 +35,9 @@ type Config struct {
 	Keepalive                     int64
 	MaxFails                      int64
 	FailTimeout                   string
+	HealthCheckEnabled            bool
+	HealthCheckMandatory          bool
+	HealthCheckMandatoryQueue     int64
 
 	// http://nginx.org/en/docs/http/ngx_http_realip_module.html
 	RealIPHeader    string

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -82,6 +82,7 @@ func (cnf *Configurator) addOrUpdateMergableIngress(mergeableIngs *MergeableIngr
 	var masterServer Server
 	var locations []Location
 	var upstreams []Upstream
+	healthChecks := make(map[string]HealthCheck)
 	var keepalive string
 	var removedAnnotations []string
 
@@ -128,6 +129,9 @@ func (cnf *Configurator) addOrUpdateMergableIngress(mergeableIngs *MergeableIngr
 				loc.IngressResource = objectMetaToFileName(&minion.Ingress.ObjectMeta)
 				locations = append(locations, loc)
 			}
+			for hcName, healthCheck := range server.HealthChecks {
+				healthChecks[hcName] = healthCheck
+			}
 		}
 
 		for _, val := range nginxCfg.Upstreams {
@@ -135,6 +139,7 @@ func (cnf *Configurator) addOrUpdateMergableIngress(mergeableIngs *MergeableIngr
 		}
 	}
 
+	masterServer.HealthChecks = healthChecks
 	masterServer.Locations = locations
 
 	nginxCfg := IngressNginxConfig{
@@ -176,6 +181,7 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 	ingCfg := cnf.createConfig(ingEx)
 
 	upstreams := make(map[string]Upstream)
+	healthChecks := make(map[string]HealthCheck)
 
 	wsServices := getWebsocketServices(ingEx)
 	spServices := getSessionPersistenceServices(ingEx)
@@ -190,9 +196,15 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 	}
 
 	if ingEx.Ingress.Spec.Backend != nil {
-		name := getNameForUpstream(ingEx.Ingress, emptyHost, ingEx.Ingress.Spec.Backend)
+		name := getNameForUpstream(ingEx.Ingress, emptyHost, ingEx.Ingress.Spec.Backend.ServiceName)
 		upstream := cnf.createUpstream(ingEx, name, ingEx.Ingress.Spec.Backend, ingEx.Ingress.Namespace, spServices[ingEx.Ingress.Spec.Backend.ServiceName], &ingCfg)
 		upstreams[name] = upstream
+
+		if ingCfg.HealthCheckEnabled {
+			if hc, exists := ingEx.HealthChecks[ingEx.Ingress.Spec.Backend.ServiceName+ingEx.Ingress.Spec.Backend.ServicePort.String()]; exists {
+				healthChecks[name] = cnf.createHealthCheck(hc, name, &ingCfg)
+			}
+		}
 	}
 
 	var servers []Server
@@ -241,6 +253,8 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 		}
 
 		var locations []Location
+		healthChecks := make(map[string]HealthCheck)
+
 		rootLocation := false
 
 		grpcOnly := true
@@ -256,7 +270,13 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 		}
 
 		for _, path := range rule.HTTP.Paths {
-			upsName := getNameForUpstream(ingEx.Ingress, rule.Host, &path.Backend)
+			upsName := getNameForUpstream(ingEx.Ingress, rule.Host, path.Backend.ServiceName)
+
+			if ingCfg.HealthCheckEnabled {
+				if hc, exists := ingEx.HealthChecks[path.Backend.ServiceName+path.Backend.ServicePort.String()]; exists {
+					healthChecks[upsName] = cnf.createHealthCheck(hc, upsName, &ingCfg)
+				}
+			}
 
 			if _, exists := upstreams[upsName]; !exists {
 				upstream := cnf.createUpstream(ingEx, upsName, &path.Backend, ingEx.Ingress.Namespace, spServices[path.Backend.ServiceName], &ingCfg)
@@ -273,11 +293,16 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 		}
 
 		if rootLocation == false && ingEx.Ingress.Spec.Backend != nil {
-			upsName := getNameForUpstream(ingEx.Ingress, emptyHost, ingEx.Ingress.Spec.Backend)
-
+			upsName := getNameForUpstream(ingEx.Ingress, emptyHost, ingEx.Ingress.Spec.Backend.ServiceName)
 			loc := createLocation(pathOrDefault("/"), upstreams[upsName], &ingCfg, wsServices[ingEx.Ingress.Spec.Backend.ServiceName], rewrites[ingEx.Ingress.Spec.Backend.ServiceName],
 				sslServices[ingEx.Ingress.Spec.Backend.ServiceName], grpcServices[ingEx.Ingress.Spec.Backend.ServiceName])
 			locations = append(locations, loc)
+
+			if ingCfg.HealthCheckEnabled {
+				if hc, exists := ingEx.HealthChecks[ingEx.Ingress.Spec.Backend.ServiceName+ingEx.Ingress.Spec.Backend.ServicePort.String()]; exists {
+					healthChecks[upsName] = cnf.createHealthCheck(hc, upsName, &ingCfg)
+				}
+			}
 
 			if _, exists := grpcServices[ingEx.Ingress.Spec.Backend.ServiceName]; !exists {
 				grpcOnly = false
@@ -285,6 +310,7 @@ func (cnf *Configurator) generateNginxCfg(ingEx *IngressEx, pems map[string]stri
 		}
 
 		server.Locations = locations
+		server.HealthChecks = healthChecks
 		server.GRPCOnly = grpcOnly
 
 		servers = append(servers, server)
@@ -319,6 +345,29 @@ func (cnf *Configurator) createConfig(ingEx *IngressEx) Config {
 			} else {
 				ingCfg.LBMethod = parsedMethod
 			}
+		}
+	}
+
+	if healthCheckEnabled, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, "nginx.com/health-checks", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		}
+		if cnf.isPlus() {
+			ingCfg.HealthCheckEnabled = healthCheckEnabled
+			if healthCheckMandatory, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, "nginx.com/health-checks-mandatory", ingEx.Ingress); exists {
+				if err != nil {
+					glog.Error(err)
+				}
+				ingCfg.HealthCheckMandatory = healthCheckMandatory
+				if healthCheckQueue, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.com/health-checks-mandatory-queue", ingEx.Ingress); exists {
+					if err != nil {
+						glog.Error(err)
+					}
+					ingCfg.HealthCheckMandatoryQueue = healthCheckQueue
+				}
+			}
+		} else {
+			glog.Warning("Annotation 'nginx.com/health-checks' requires NGINX Plus")
 		}
 	}
 
@@ -655,11 +704,25 @@ func createLocation(path string, upstream Upstream, cfg *Config, websocket bool,
 	return loc
 }
 
+// upstreamRequiresQueue checks if the upstream requires a queue.
+// Mandatory Health Checks can cause nginx to return errors on reload, since all Upstreams start
+// Unhealthy. By adding a queue to the Upstream we can avoid returning errors, at the cost of a short delay.
+func (cnf *Configurator) upstreamRequiresQueue(name string, ingEx *IngressEx, cfg *Config) (n int64, timeout int64) {
+	if cnf.isPlus() && cfg.HealthCheckEnabled && cfg.HealthCheckMandatory && cfg.HealthCheckMandatoryQueue > 0 {
+		if hc, exists := ingEx.HealthChecks[name]; exists {
+			return cfg.HealthCheckMandatoryQueue, int64(hc.TimeoutSeconds)
+		}
+	}
+	return 0, 0
+}
+
 func (cnf *Configurator) createUpstream(ingEx *IngressEx, name string, backend *extensions.IngressBackend, namespace string, stickyCookie string, cfg *Config) Upstream {
 	var ups Upstream
 
+	queue, timeout := cnf.upstreamRequiresQueue(backend.ServiceName+backend.ServicePort.String(), ingEx, cfg)
+
 	if cnf.isPlus() {
-		ups = Upstream{Name: name, StickyCookie: stickyCookie}
+		ups = Upstream{Name: name, StickyCookie: stickyCookie, Queue: queue, QueueTimeout: timeout}
 	} else {
 		ups = NewUpstreamWithDefaultServer(name)
 	}
@@ -684,6 +747,28 @@ func (cnf *Configurator) createUpstream(ingEx *IngressEx, name string, backend *
 	return ups
 }
 
+func (cnf *Configurator) createHealthCheck(hc *api_v1.Probe, upstreamName string, cfg *Config) HealthCheck {
+	return HealthCheck{
+		UpstreamName:   upstreamName,
+		Fails:          hc.FailureThreshold,
+		Interval:       hc.PeriodSeconds,
+		Passes:         hc.SuccessThreshold,
+		URI:            hc.HTTPGet.Path,
+		Scheme:         strings.ToLower(string(hc.HTTPGet.Scheme)),
+		Mandatory:      cfg.HealthCheckMandatory,
+		Headers:        headersToString(hc.HTTPGet.HTTPHeaders),
+		TimeoutSeconds: int64(hc.TimeoutSeconds),
+	}
+}
+
+func headersToString(headers []api_v1.HTTPHeader) map[string]string {
+	m := make(map[string]string)
+	for _, header := range headers {
+		m[header.Name] = header.Value
+	}
+	return m
+}
+
 func pathOrDefault(path string) string {
 	if path == "" {
 		return "/"
@@ -691,8 +776,8 @@ func pathOrDefault(path string) string {
 	return path
 }
 
-func getNameForUpstream(ing *extensions.Ingress, host string, backend *extensions.IngressBackend) string {
-	return fmt.Sprintf("%v-%v-%v-%v-%v", ing.Namespace, ing.Name, host, backend.ServiceName, backend.ServicePort.String())
+func getNameForUpstream(ing *extensions.Ingress, host string, service string) string {
+	return fmt.Sprintf("%v-%v-%v-%v", ing.Namespace, ing.Name, host, service)
 }
 
 func upstreamMapToSlice(upstreams map[string]Upstream) []Upstream {
@@ -828,7 +913,7 @@ func (cnf *Configurator) updatePlusEndpoints(ingEx *IngressEx) error {
 	}
 
 	if ingEx.Ingress.Spec.Backend != nil {
-		name := getNameForUpstream(ingEx.Ingress, emptyHost, ingEx.Ingress.Spec.Backend)
+		name := getNameForUpstream(ingEx.Ingress, emptyHost, ingEx.Ingress.Spec.Backend.ServiceName)
 		endps, exists := ingEx.Endpoints[ingEx.Ingress.Spec.Backend.ServiceName+ingEx.Ingress.Spec.Backend.ServicePort.String()]
 		if exists {
 			err := cnf.nginxAPI.UpdateServers(name, endps, cfg)
@@ -842,7 +927,7 @@ func (cnf *Configurator) updatePlusEndpoints(ingEx *IngressEx) error {
 			continue
 		}
 		for _, path := range rule.HTTP.Paths {
-			name := getNameForUpstream(ingEx.Ingress, rule.Host, &path.Backend)
+			name := getNameForUpstream(ingEx.Ingress, rule.Host, path.Backend.ServiceName)
 			endps, exists := ingEx.Endpoints[path.Backend.ServiceName+path.Backend.ServicePort.String()]
 			if exists {
 				err := cnf.nginxAPI.UpdateServers(name, endps, cfg)

--- a/nginx-controller/nginx/ingress.go
+++ b/nginx-controller/nginx/ingress.go
@@ -8,10 +8,11 @@ import (
 // IngressEx holds an Ingress along with Secrets and Endpoints of the services
 // that are referenced in this Ingress
 type IngressEx struct {
-	Ingress    *extensions.Ingress
-	TLSSecrets map[string]*api_v1.Secret
-	JWTKey     *api_v1.Secret
-	Endpoints  map[string][]string
+	Ingress      *extensions.Ingress
+	TLSSecrets   map[string]*api_v1.Secret
+	JWTKey       *api_v1.Secret
+	Endpoints    map[string][]string
+	HealthChecks map[string]*api_v1.Probe
 }
 
 type MergeableIngresses struct {
@@ -20,10 +21,13 @@ type MergeableIngresses struct {
 }
 
 var masterBlacklist = map[string]bool{
-	"nginx.org/rewrites":               true,
-	"nginx.org/ssl-services":           true,
-	"nginx.org/websocket-services":     true,
-	"nginx.com/sticky-cookie-services": true,
+	"nginx.org/rewrites":                      true,
+	"nginx.org/ssl-services":                  true,
+	"nginx.org/websocket-services":            true,
+	"nginx.com/sticky-cookie-services":        true,
+	"nginx.com/health-checks":                 true,
+	"nginx.com/health-checks-mandatory":       true,
+	"nginx.com/health-checks-mandatory-queue": true,
 }
 
 var minionBlacklist = map[string]bool{

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -41,6 +41,8 @@ type Upstream struct {
 	UpstreamServers []UpstreamServer
 	StickyCookie    string
 	LBMethod        string
+	Queue           int64
+	QueueTimeout    int64
 }
 
 // UpstreamServer describes a server in an NGINX upstream
@@ -49,6 +51,19 @@ type UpstreamServer struct {
 	Port        string
 	MaxFails    int64
 	FailTimeout string
+}
+
+// HealthCheck describes an active HTTP health check
+type HealthCheck struct {
+	UpstreamName   string
+	URI            string
+	Interval       int32
+	Fails          int32
+	Passes         int32
+	Scheme         string
+	Mandatory      bool
+	Headers        map[string]string
+	TimeoutSeconds int64
 }
 
 // Server describes an NGINX server
@@ -71,6 +86,8 @@ type Server struct {
 	HSTSIncludeSubdomains bool
 	ProxyHideHeaders      []string
 	ProxyPassHeaders      []string
+
+	HealthChecks map[string]HealthCheck
 
 	// http://nginx.org/en/docs/http/ngx_http_realip_module.html
 	RealIPHeader    string

--- a/nginx-controller/nginx/templates/nginx-plus.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.ingress.tmpl
@@ -8,7 +8,13 @@ upstream {{$upstream.Name}} {
 	sticky cookie {{$upstream.StickyCookie}};
 	{{end}}
 	{{if $.Keepalive}}keepalive {{$.Keepalive}};{{end}}
-}{{end}}
+	{{- if $upstream.UpstreamServers -}}
+	{{- if $upstream.Queue }}
+	queue {{$upstream.Queue}} timeout={{$upstream.QueueTimeout}}s;
+	{{- end -}}
+	{{- end }}
+}
+{{- end}}
 
 {{range $server := .Servers}}
 server {
@@ -76,6 +82,20 @@ server {
 	{{range $value := $server.ServerSnippets}}
 	{{$value}}{{end}}
 	{{- end}}
+
+	{{- range $healthCheck := $server.HealthChecks}}
+	location @hc-{{$healthCheck.UpstreamName}} {
+		{{- range $name, $header := $healthCheck.Headers }}
+		proxy_set_header {{$name}} "{{$header}}";
+		{{- end }}
+		proxy_connect_timeout {{$healthCheck.TimeoutSeconds}}s;
+		proxy_read_timeout {{$healthCheck.TimeoutSeconds}}s;
+		proxy_send_timeout {{$healthCheck.TimeoutSeconds}}s;
+		proxy_pass {{$healthCheck.Scheme}}://{{$healthCheck.UpstreamName}};
+		health_check {{if $healthCheck.Mandatory}}mandatory {{end}}uri={{$healthCheck.URI}} interval=
+			{{- $healthCheck.Interval}}s fails={{$healthCheck.Fails}} passes={{$healthCheck.Passes}};
+	}
+	{{end -}}
 
 	{{range $location := $server.Locations}}
 	location {{$location.Path}} {

--- a/nginx-controller/nginx/templates/templates_test.go
+++ b/nginx-controller/nginx/templates/templates_test.go
@@ -25,6 +25,15 @@ var testUps = nginx.Upstream{
 	},
 }
 
+var headers = map[string]string{"Test-Header": "test-header-value"}
+var healthCheck = nginx.HealthCheck{
+	UpstreamName: "test",
+	Fails:        1,
+	Interval:     1,
+	Passes:       1,
+	Headers:      headers,
+}
+
 var ingCfg = nginx.IngressNginxConfig{
 
 	Servers: []nginx.Server{
@@ -50,6 +59,7 @@ var ingCfg = nginx.IngressNginxConfig{
 					ClientMaxBodySize:   "2m",
 				},
 			},
+			HealthChecks: map[string]nginx.HealthCheck{"test": healthCheck},
 		},
 	},
 	Upstreams: []nginx.Upstream{testUps},


### PR DESCRIPTION
NGINX Plus supports active health checks.

To use, set the annotation `nginx.com/health-checks: "true"`. The Ingress Controller will pull health check (Readiness Probe) information from the Kubernetes API and configure matching active health checks in NGINX Plus