### PR TITLE
Support slow-start for Plus

### DIFF
--- a/examples/customization/README.md
+++ b/examples/customization/README.md
@@ -63,6 +63,7 @@ The table below summarizes all of the options. For some of them, there are examp
 | `nginx.com/health-checks` | N/A | Enables active health checks. | `False` | [Support for Active Health Checks](../health-checks). |
 | `nginx.com/health-checks-mandatory` | N/A | Configures active health checks as mandatory. | `False` | [Support for Active Health Checks](../health-checks). |
 | `nginx.com/health-checks-mandatory-queue` | N/A | When active health checks are mandatory, configures a queue for temporary storing incoming requests during the time when NGINX Plus is checking the health of the endpoints after a configuration reload. | `0` | [Support for Active Health Checks](../health-checks). |
+| `nginx.com/slow-start` | N/A | Sets the upstream server [slow-start period](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#server-slow-start). By default, slow-start is activated after a server becomes [available](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-health-check/#passive-health-checks) or [healthy](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-health-check/#active-health-checks). To enable slow-start for newly added servers, configure [mandatory active health checks](../health-checks). | `"0s"` | |
 
 ## Using ConfigMaps
 

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	HealthCheckEnabled            bool
 	HealthCheckMandatory          bool
 	HealthCheckMandatoryQueue     int64
+	SlowStart                     string
 
 	// http://nginx.org/en/docs/http/ngx_http_realip_module.html
 	RealIPHeader    string

--- a/nginx-controller/nginx/extensions.go
+++ b/nginx-controller/nginx/extensions.go
@@ -1,7 +1,9 @@
 package nginx
 
 import (
+	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -58,4 +60,29 @@ func validateHashLBMethod(method string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("Invalid load balancing method: %q", method)
+}
+
+// http://nginx.org/en/docs/syntax.html
+var validTimeSuffixes = []string{
+	"ms",
+	"s",
+	"m",
+	"h",
+	"d",
+	"w",
+	"M",
+	"y",
+}
+
+var durationEscaped = strings.Join(validTimeSuffixes, "|")
+var validNginxTime = regexp.MustCompile(`^([0-9]+([` + durationEscaped + `]?){0,1} *)+$`)
+
+// ParseSlowStart ensures that the slow_start value in the annotation is valid.
+func ParseSlowStart(s string) (string, error) {
+	s = strings.TrimSpace(s)
+
+	if validNginxTime.MatchString(s) {
+		return s, nil
+	}
+	return "", errors.New("Invalid time string")
 }

--- a/nginx-controller/nginx/extensions_test.go
+++ b/nginx-controller/nginx/extensions_test.go
@@ -81,3 +81,24 @@ func TestParseLBMethodForPlus(t *testing.T) {
 		}
 	}
 }
+
+
+func TestParseSlowStart(t *testing.T) {
+	var testsWithValidInput = []string{"1", "1m10s", "11 11", "5m 30s", "1s", "100m", "5w", "15m", "11M", "3h", "100y", "600"}
+	var invalidInput = []string{"ss", "rM", "m0m", "s1s", "-5s", "", "1L"}
+	for _, test := range testsWithValidInput {
+		result, err := ParseSlowStart(test)
+		if err != nil {
+			t.Errorf("TestParseSlowStart(%q) returned an error for valid input", test)
+		}
+		if test != result {
+			t.Errorf("TestParseSlowStart(%q) returned %q expected %q", test, result, test)
+		}
+	}
+	for _, test := range invalidInput {
+		result, err := ParseSlowStart(test)
+		if err == nil {
+			t.Errorf("TestParseSlowStart(%q) didn't return error. Returned: %q", test, result)
+		}
+	}
+}

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -51,6 +51,7 @@ type UpstreamServer struct {
 	Port        string
 	MaxFails    int64
 	FailTimeout string
+	SlowStart   string
 }
 
 // HealthCheck describes an active HTTP health check

--- a/nginx-controller/nginx/plus/nginx_api.go
+++ b/nginx-controller/nginx/plus/nginx_api.go
@@ -14,6 +14,7 @@ type NginxAPIController struct {
 type ServerConfig struct {
 	MaxFails    int64
 	FailTimeout string
+	SlowStart   string
 }
 
 func NewNginxAPIController(httpClient *http.Client, endpoint string, local bool) (*NginxAPIController, error) {
@@ -37,6 +38,7 @@ func (nginx *NginxAPIController) UpdateServers(upstream string, servers []string
 			Server:      s,
 			MaxFails:    config.MaxFails,
 			FailTimeout: config.FailTimeout,
+			SlowStart:   config.SlowStart,
 		})
 	}
 

--- a/nginx-controller/nginx/plus/nginx_client.go
+++ b/nginx-controller/nginx/plus/nginx_client.go
@@ -25,6 +25,7 @@ type UpstreamServer struct {
 	Server      string `json:"server"`
 	MaxFails    int64  `json:"max_fails"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
+	SlowStart   string `json:"slow_start,omitempty"`
 }
 
 type apiErrorResponse struct {

--- a/nginx-controller/nginx/templates/nginx-plus.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.ingress.tmpl
@@ -3,7 +3,8 @@ upstream {{$upstream.Name}} {
 	zone {{$upstream.Name}} 256k;
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
-	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}};{{end}}
+	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}}
+	    {{- if $server.SlowStart}} slow_start={{$server.SlowStart}}{{end}};{{end}}
 	{{if $upstream.StickyCookie}}
 	sticky cookie {{$upstream.StickyCookie}};
 	{{end}}

--- a/nginx-controller/nginx/templates/templates_test.go
+++ b/nginx-controller/nginx/templates/templates_test.go
@@ -21,6 +21,7 @@ var testUps = nginx.Upstream{
 			Port:        "8181",
 			MaxFails:    0,
 			FailTimeout: "1s",
+			SlowStart:   "5s",
 		},
 	},
 }


### PR DESCRIPTION
Sets the upstream server slow-start period. By default, slow-start is activated after a server becomes available or healthy. To enable slow-start for newly added servers, configure mandatory active health checks.

Enabled by annotation: `nginx.com/slow-start: "true"`