### PR TITLE
Add fetch custom NGINX template from ConfigMap

### DIFF
--- a/examples/custom-templates/README.md
+++ b/examples/custom-templates/README.md
@@ -1,0 +1,54 @@
+# Custom Templates
+
+The Ingress controller allows you to customize your templates through a [ConfigMap](https://github.com/nginxinc/kubernetes-ingress/tree/master/examples/customization) via the following keys:
+* `main-template` - Sets the main NGINX configuration template.
+* `ingress-template` - Sets the Ingress NGINX configuration template for an Ingress resource.
+
+## Example
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-config
+  namespace: nginx-ingress
+data:
+  main-template: |
+    user  nginx;
+    worker_processes  {{.WorkerProcesses}};
+    ...
+        include /etc/nginx/conf.d/*.conf;
+    }
+  ingress-template: |
+    {{range $upstream := .Upstreams}}
+    upstream {{$upstream.Name}} {
+      {{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
+    ...
+    }{{end}}
+```
+**Note:** the templates are truncated for the clarity of the example.
+
+## Troubleshooting
+* If a custom template contained within the ConfigMap is invalid on startup, the Ingress controller will fail to start, the error will be reported in the Ingress controller logs.
+
+    An example of an error from the logs:
+    ```
+    Error updating NGINX main template: template: nginxTemplate:98: unexpected EOF
+    ```
+
+* If a custom template contained within the ConfigMap is invalid on update, the Ingress controller will not update the NGINX configuration, the error will be reported in the Ingress controller logs and an event with the error will be associated with the ConfigMap.
+
+    An example of an error from the logs:
+    ```
+    Error when updating config from ConfigMap: Invalid nginx configuration detected, not reloading
+    ```
+
+  An example of an event with an error (you can view events associated with the ConfigMap by running `kubectl describe -n nginx-ingress configmap nginx-config`):
+
+    ```
+    Events:
+      Type     Reason            Age                From                      Message
+      ----     ------            ----               ----                      -------
+      Normal   Updated           12s (x2 over 25s)  nginx-ingress-controller  Configuration from nginx-ingress/nginx-config was updated
+      Warning  UpdatedWithError  10s                nginx-ingress-controller  Configuration from nginx-ingress/nginx-config was updated, but not applied: Error when parsing the main template: template: nginxTemplate:98: unexpected EOF
+      Warning  UpdatedWithError  8s                 nginx-ingress-controller  Configuration from nginx-ingress/nginx-config was updated, but not applied: Error when writing main Config
+    ```

--- a/examples/customization/README.md
+++ b/examples/customization/README.md
@@ -37,6 +37,8 @@ The table below summarizes all of the options. For some of them, there are examp
 | `nginx.org/server-tokens` | `server-tokens` | Enables or disables the [server_tokens](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens) directive. Additionally, with the NGINX Plus, you can specify a custom string value, including the empty string value, which disables the emission of the “Server” field. | `True`| |
 | N/A | `main-snippets` | Sets a custom snippet in main context. | N/A | |
 | N/A | `http-snippets` | Sets a custom snippet in http context. | N/A | |
+| N/A | `main-template` | Sets the main NGINX configuration template. | By default the template is read from the file in the container. | [Custom Templates](../custom-templates). |
+| N/A | `ingress-template` | Sets the NGINX configuration template for an Ingress resource. | By default the template is read from the file on the container. | [Custom Templates](../custom-templates). |
 | `nginx.org/location-snippets` | `location-snippets` | Sets a custom snippet in location context. | N/A | |
 | `nginx.org/server-snippets` | `server-snippets` | Sets a custom snippet in server context. | N/A | |
 | `nginx.org/lb-method` | `lb-method` | Sets the [load balancing method](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#choosing-a-load-balancing-method). To use the round-robin method, specify `"round_robin"`. | `"least_conn"` | |

--- a/nginx-controller/controller/controller_test.go
+++ b/nginx-controller/controller/controller_test.go
@@ -548,7 +548,7 @@ func getMergableDefaults() (cafeMaster, coffeeMinion, teaMinion extensions.Ingre
 	cafeMasterIngEx, _ := lbc.createIngress(&cafeMaster)
 	ingExMap["default-cafe-master"] = cafeMasterIngEx
 
-	cnf := nginx.NewConfigurator(&nginx.NginxController{}, &nginx.Config{}, &plus.NginxAPIController{})
+	cnf := nginx.NewConfigurator(&nginx.NginxController{}, &nginx.Config{}, &plus.NginxAPIController{}, &nginx.TemplateExecutor{})
 
 	// edit private field ingresses to use in testing
 	pointerVal := reflect.ValueOf(cnf)
@@ -781,7 +781,7 @@ func TestFindProbeForPods(t *testing.T) {
 
 func TestGetServicePortForIngressPort(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset()
-	cnf := nginx.NewConfigurator(&nginx.NginxController{}, &nginx.Config{}, &plus.NginxAPIController{})
+	cnf := nginx.NewConfigurator(&nginx.NginxController{}, &nginx.Config{}, &plus.NginxAPIController{}, &nginx.TemplateExecutor{})
 	lbc := LoadBalancerController{
 		client:       fakeClient,
 		ingressClass: "nginx",

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -60,6 +60,9 @@ type Config struct {
 	MainServerSSLDHParam             string
 	MainServerSSLDHParamFileContent  *string
 
+	MainTemplate    *string
+	IngressTemplate *string
+
 	JWTRealm    string
 	JWTKey      string
 	JWTToken    string
@@ -336,6 +339,12 @@ func ParseConfigMap(cfgm *api_v1.ConfigMap, nginxPlus bool) *Config {
 	}
 	if failTimeout, exists := cfgm.Data["fail-timeout"]; exists {
 		cfg.FailTimeout = failTimeout
+	}
+	if mainTemplate, exists := cfgm.Data["main-template"]; exists {
+		cfg.MainTemplate = &mainTemplate
+	}
+	if ingressTemplate, exists := cfgm.Data["ingress-template"]; exists {
+		cfg.IngressTemplate = &ingressTemplate
 	}
 	return cfg
 }

--- a/nginx-controller/nginx/template_executor.go
+++ b/nginx-controller/nginx/template_executor.go
@@ -1,0 +1,70 @@
+package nginx
+
+import (
+	"bytes"
+	"path"
+	"text/template"
+)
+
+// TemplateExecutor executes NGINX configuration templates
+type TemplateExecutor struct {
+	HealthStatus    bool
+	mainTemplate    *template.Template
+	ingressTemplate *template.Template
+}
+
+// NewTemplateExecutor creates a TemplateExecutor
+func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, healthStatus bool) (*TemplateExecutor, error) {
+	// template name must be the base name of the template file https://golang.org/pkg/text/template/#Template.ParseFiles
+	nginxTemplate, err := template.New(path.Base(mainTemplatePath)).ParseFiles(mainTemplatePath)
+	if err != nil {
+		return nil, err
+	}
+
+	ingressTemplate, err := template.New(path.Base(ingressTemplatePath)).ParseFiles(ingressTemplatePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TemplateExecutor{mainTemplate: nginxTemplate, ingressTemplate: ingressTemplate, HealthStatus: healthStatus}, nil
+}
+
+// UpdateMainTemplate updates the main NGINX template
+func (te *TemplateExecutor) UpdateMainTemplate(templateString *string) error {
+	newTemplate, err := template.New("nginxTemplate").Parse(*templateString)
+	if err != nil {
+		return err
+	}
+	te.mainTemplate = newTemplate
+
+	return nil
+}
+
+// UpdateIngressTemplate updates the ingress template
+func (te *TemplateExecutor) UpdateIngressTemplate(templateString *string) error {
+	newTemplate, err := template.New("ingressTemplate").Parse(*templateString)
+	if err != nil {
+		return err
+	}
+	te.ingressTemplate = newTemplate
+
+	return nil
+}
+
+// ExecuteMainConfigTemplate generates the content of the main NGINX configuration file
+func (te *TemplateExecutor) ExecuteMainConfigTemplate(cfg *NginxMainConfig) ([]byte, error) {
+	cfg.HealthStatus = te.HealthStatus
+
+	var configBuffer bytes.Buffer
+	err := te.mainTemplate.Execute(&configBuffer, cfg)
+
+	return configBuffer.Bytes(), err
+}
+
+// ExecuteIngressConfigTemplate generates the content of a NGINX configuration file for an Ingress resource
+func (te *TemplateExecutor) ExecuteIngressConfigTemplate(cfg *IngressNginxConfig) ([]byte, error) {
+	var configBuffer bytes.Buffer
+	err := te.ingressTemplate.Execute(&configBuffer, cfg)
+
+	return configBuffer.Bytes(), err
+}


### PR DESCRIPTION
Custom templates can now be set on startup or updated via ConfigMap

- [x] Custom template via ConfigMap on startup
- [x] Custom template via ConfigMap update
- [x] [Example in documentation](https://github.com/nginxinc/kubernetes-ingress/tree/template-configmap/examples/custom-templates)
- [x] Updated [ConfigMap/Annotations table](https://github.com/nginxinc/kubernetes-ingress/tree/template-configmap/examples/customization#customization-of-nginx-configuration)

- Invalid template or invalid NGINX configuration on startup causes Ingress Controller to stop, and logs the error.
- Invalid template or invalid NGINX configuration update does not apply any configuration changes, and logs the error.