### PR TITLE
Add prometheus exporter support to helm chart

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.2.0
 description: NGINX Ingress Controller
 sources:

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -82,6 +82,11 @@ Parameter | Description | Default
 `controller.watchNamespace` | Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces. | ""
 `controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress controller. | false
 `rbac.create` | Configures RBAC. | true
+`prometheues.create` | Deploys a Prometheus exporter container within the Ingress controller pod. Requires NGINX Plus. `controller.nginxplus` must be set to `true`. | false
+`prometheus.port` | Configures the port to scrape the metrics. | 9113
+`prometheus.image.repository` | The image repository of the Prometheus exporter. | nginx/nginx-prometheus-exporter
+`prometheus.image.tag` | The tag of the Prometheus exporter image. | 0.1.0
+`prometheus.image.pullPolicy` | The pull policy for the Prometheus exporter image. | IfNotPresent
 
 Example:
 ```

--- a/helm-chart/templates/controller-daemonset.yaml
+++ b/helm-chart/templates/controller-daemonset.yaml
@@ -16,6 +16,11 @@ spec:
     metadata:
       labels:
         app: {{ .Values.controller.name | trunc 63 }}
+{{- if and (.Values.controller.nginxplus)  (.Values.prometheus.create) }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.prometheus.port }}"
+{{- end }}
     spec:
 {{- if .Values.controller.serviceAccountName }}
       serviceAccountName: {{ .Values.controller.serviceAccountName }}
@@ -71,5 +76,19 @@ spec:
 {{- end }}
 {{- if .Values.controller.healthStatus }}
           - -health-status
+{{- end }}
+{{- if and (.Values.controller.nginxplus)  (.Values.prometheus.create) }}
+      - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
+        imagePullPolicy: "{{ .Values.prometheus.image.pullPolicy }}"
+        name: nginx-prometheus-exporter
+        ports:
+        - name: prometheus
+          containerPort: {{ .Values.prometheus.port }}
+        args:
+          - -web.listen-address
+          - :{{ .Values.prometheus.port }}
+          - -nginx.plus
+          - -nginx.scrape-uri
+          - http://127.0.0.1:8080/api
 {{- end }}
 {{- end }}

--- a/helm-chart/templates/controller-deployment.yaml
+++ b/helm-chart/templates/controller-deployment.yaml
@@ -17,6 +17,11 @@ spec:
     metadata:
       labels:
         app: {{ .Values.controller.name | trunc 63 }}
+{{- if and (.Values.controller.nginxplus)  (.Values.prometheus.create) }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.prometheus.port }}"
+{{- end }}
     spec:
 {{- if .Values.controller.serviceAccountName }}
       serviceAccountName: {{ .Values.controller.serviceAccountName }}
@@ -57,5 +62,19 @@ spec:
 {{- end }}
 {{- if .Values.controller.healthStatus }}
           - -health-status
+{{- end }}
+{{- if and (.Values.controller.nginxplus)  (.Values.prometheus.create) }}
+      - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
+        name: nginx-prometheus-exporter
+        imagePullPolicy: "{{ .Values.prometheus.image.pullPolicy }}"
+        ports:
+        - name: prometheus
+          containerPort: {{ .Values.prometheus.port }}
+        args:
+          - -web.listen-address
+          - :{{ .Values.prometheus.port }}
+          - -nginx.plus
+          - -nginx.scrape-uri
+          - http://127.0.0.1:8080/api
 {{- end }}
 {{- end }}

--- a/helm-chart/values-plus.yaml
+++ b/helm-chart/values-plus.yaml
@@ -30,3 +30,10 @@ controller:
   serviceAccountName: nginx-ingress
 rbac:
   create: true
+prometheus:
+  create: false
+  port: 9113
+  image:
+    repository: nginx/nginx-prometheus-exporter
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
Added Prometheus exporter support to NGINX Plus Ingress Controller

Disabled by default.
Exporter image, repository and scraping port are configurable.
Minor chart version increment