### PR TITLE
NGINX configuration template custom path support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,6 @@ osx-nginx-plus-ingress
 nginx-plus-ingress
 nginx-controller/nginx-controller
 
-# Ingress Controller templates
-nginx-controller/nginx-plus.ingress.tmpl
-nginx-controller/nginx-plus.tmpl
-
 # NGINX Plus license files
 *.crt
 *.key
@@ -41,4 +37,3 @@ nginx-controller/nginx-plus.tmpl
 
 # Default certificate and key
 default.pem
-

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -17,12 +17,17 @@ Usage of ./nginx-ingress:
 	- i.e. have the annotation "kubernetes.io/ingress.class" equal to the class. Additionally,
 	the Ingress controller processes Ingress resources that do not have that annotation,
 	which can be disabled by setting the "-use-ingress-class-only" flag (default "nginx")
+  -ingress-template-path string
+    	Path to the ingress NGINX configuration template for an ingress resource.
+	(default for NGINX "nginx.ingress.tmpl"; default for NGINX Plus "nginx-plus.ingress.tmpl")
   -log_backtrace_at value
     	when logging hits line file:N, emit a stack trace
   -log_dir string
     	If non-empty, write log files in this directory
   -logtostderr
     	log to standard error instead of files
+  -main-template-path string
+    	Path to the main NGINX configuration template. (default for NGINX "nginx.tmpl"; default for NGINX Plus "nginx-plus.tmpl")
   -nginx-configmaps string
     	A ConfigMap resource for customizing NGINX configuration. If a ConfigMap is set,
 	but the Ingress controller is not able to fetch it from Kubernetes API, the Ingress controller will fail to start.

--- a/nginx-controller/main.go
+++ b/nginx-controller/main.go
@@ -61,6 +61,13 @@ var (
 	the file "/etc/nginx/secrets/default" does not exist, the Ingress controller will fail to start`)
 
 	versionFlag = flag.Bool("version", false, "Print the version and git-commit hash and exit")
+
+	mainTemplatePath = flag.String("main-template-path", "",
+		`Path to the main NGINX configuration template. (default for NGINX "nginx.tmpl"; default for NGINX Plus "nginx-plus.tmpl")`)
+
+	ingressTemplatePath = flag.String("ingress-template-path", "",
+		`Path to the ingress NGINX configuration template for an ingress resource.
+	(default for NGINX "nginx.ingress.tmpl"; default for NGINX Plus "nginx-plus.ingress.tmpl")`)
 )
 
 func main() {
@@ -106,6 +113,14 @@ func main() {
 		nginxConfTemplatePath = "nginx-plus.tmpl"
 		nginxIngressTemplatePath = "nginx-plus.ingress.tmpl"
 	}
+
+	if *mainTemplatePath != "" {
+		nginxConfTemplatePath = *mainTemplatePath
+	}
+	if *ingressTemplatePath != "" {
+		nginxIngressTemplatePath = *ingressTemplatePath
+	}
+
 	templateExecutor, err := nginx.NewTemplateExecutor(nginxConfTemplatePath, nginxIngressTemplatePath, *healthStatus)
 	if err != nil {
 		glog.Fatalf("Error creating TemplateExecutor: %v", err)


### PR DESCRIPTION
Add support for specifying the path to NGINX configuration template files via cli argument.

- Add cli arguments
- Update [cli-arguments](https://github.com/nginxinc/kubernetes-ingress/blob/master/docs/cli-arguments.md#ingress-controller-command-line-arguments) documentation