### PR TITLE
Add IC_HTTPS_PORT in the examples

### DIFF
--- a/examples/complete-example/README.md
+++ b/examples/complete-example/README.md
@@ -48,7 +48,7 @@ certificate and the --resolve option to set the Host header of a request with ``
     Server name: coffee-7586895968-r26zn
     ...
     ```
-    If your rather prefer tea:
+    If your prefer tea:
     ```
     $ curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/tea --insecure
     Server address: 10.12.0.19:80

--- a/examples/complete-example/README.md
+++ b/examples/complete-example/README.md
@@ -8,9 +8,13 @@ In this example we deploy the NGINX or NGINX Plus Ingress controller, a simple w
 
 1. Follow the installation [instructions](../../docs/installation.md) to deploy the Ingress controller.
 
-1. Save the public IP address of the Ingress controller into a shell variable:
+2. Save the public IP address of the Ingress controller into a shell variable:
     ```
     $ IC_IP=XXX.YYY.ZZZ.III
+    ```
+3. Save the HTTPS port of the Ingress controller into a shell variable:
+    ```
+    $ IC_HTTPS_PORT=<port number>
     ```
 
 ## 2. Deploy the Cafe Application
@@ -39,21 +43,19 @@ certificate and the --resolve option to set the Host header of a request with ``
     
     To get coffee:
     ```
-    $ curl --resolve cafe.example.com:443:$IC_IP https://cafe.example.com/coffee --insecure
+    $ curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/coffee --insecure
     Server address: 10.12.0.18:80
     Server name: coffee-7586895968-r26zn
     ...
     ```
     If your rather prefer tea:
     ```
-    $ curl --resolve cafe.example.com:443:$IC_IP https://cafe.example.com/tea --insecure
+    $ curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/tea --insecure
     Server address: 10.12.0.19:80
     Server name: tea-7cd44fcb4d-xfw2x
     ...
     ```
-
-    **Note**: If you're using a NodePort service to expose the Ingress controller, replace port 443 in the commands above with the node port that corresponds to port 443.
-
+    
 1. If you're using NGINX Plus, you can open the live activity monitoring dashboard:
     1. Follow the [instructions](../../docs/installation.md#5-access-the-live-activity-monitoring-dashboard) to access the dashboard. 
     1. If you go to the Upstream tab, you'll see: ![dashboard](dashboard.png)

--- a/examples/mergeable-ingress-types/README.md
+++ b/examples/mergeable-ingress-types/README.md
@@ -57,6 +57,10 @@ load balancing for that application using Ingress resources with the `nginx.org/
     ```
     $ IC_IP=XXX.YYY.ZZZ.III
     ```
+3. Save the HTTPS port of the Ingress controller into a shell variable:
+    ```
+    $ IC_HTTPS_PORT=<port number>
+    ```
 
 ## 2. Deploy the Cafe Application
 
@@ -94,20 +98,18 @@ certificate and the --resolve option to set the Host header of a request with ``
     
     To get coffee:
     ```
-    $ curl --resolve cafe.example.com:443:$IC_IP https://cafe.example.com/coffee --insecure
+    $ curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/coffee --insecure
     Server address: 10.12.0.18:80
     Server name: coffee-7586895968-r26zn
     ...
     ```
     If you prefer tea:
     ```
-    $ curl --resolve cafe.example.com:443:$IC_IP https://cafe.example.com/tea --insecure
+    $ curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/tea --insecure
     Server address: 10.12.0.19:80
     Server name: tea-7cd44fcb4d-xfw2x
     ...
     ```
-
-    **Note**: If you're using a NodePort service to expose the Ingress controller, replace port 443 in the commands above with the node port that corresponds to port 443.
     
 ## 5. Examine the Configuration
 


### PR DESCRIPTION
Adds `$IC_HTTPS_PORT` variable to the complete example. 

Allows the setting of an port other than 443. This is useful for cases where the user exposes the Ingress Controller via a NodePort service