### PR TITLE
Remove package no longer needed

### DIFF
--- a/nginx-plus-controller/README.md
+++ b/nginx-plus-controller/README.md
@@ -1,3 +1,0 @@
-# NGINX Plus Ingress Controller
-
-The Ingress controller implementation for NGINX Plus has been merged with the implementation for NGINX. You can read instructions on how to build the Ingress controller image for NGINX Plus [here](../nginx-controller).


### PR DESCRIPTION
The nginx plus code was merged into the same package as the open source code in /nginx-controller. This package has been empty for nearly a year now and should be removed to avoid confusion.