### PR TITLE
Fix find ingress for secret ns bug

### DIFF
--- a/nginx-controller/controller/controller_test.go
+++ b/nginx-controller/controller/controller_test.go
@@ -831,109 +831,160 @@ func TestGetServicePortForIngressPort(t *testing.T) {
 
 func TestFindIngressesForSecret(t *testing.T) {
 	testCases := []struct {
-		secretName       string
-		secretNamespace  string
-		ingressName      string
-		ingressNamespace string
-		tlsSecretName    string
-		expectResult     bool
+		secret         v1.Secret
+		ingress        extensions.Ingress
+		expectedToFind bool
+		desc           string
 	}{
-		{"tls-secret1", "namespace1", "my-ingress1", "namespace1", "tls-secret1", true},  // Try find secret in correct namespace - pass
-		{"tls-secret2", "namespace1", "my-ingress2", "namespace2", "tls-secret2", false}, // Try find secret in wrong namespace - err
-		{"no-match3", "namespace1", "not-ingress3", "namespace1", "tls-xxx3", false},     // Try find secret that doesn't exist - err
-	}
-
-	for _, test := range testCases {
-		fakeClient := fake.NewSimpleClientset()
-
-		templateExecutor, err := nginx.NewTemplateExecutor("../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl", true)
-		if err != nil {
-			t.Errorf("templateExecuter could not start: %v", err)
-		}
-		ngxc, err := nginx.NewNginxController("/etc/nginx", true, true, "../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl")
-		if err != nil {
-			t.Errorf("NGINX Controller could not start: %v", err)
-		}
-		apiCtrl, err := plus.NewNginxAPIController(&http.Client{}, "", true)
-		if err != nil {
-			t.Errorf("NGINX API Controller could not start: %v", err)
-		}
-
-		cnf := nginx.NewConfigurator(ngxc, &nginx.Config{}, apiCtrl, templateExecutor)
-		lbc := LoadBalancerController{
-			client:       fakeClient,
-			ingressClass: "nginx",
-			cnf:          cnf,
-			nginxPlus:    true,
-		}
-
-		lbc.ingLister.Store, _ = cache.NewInformer(
-			cache.NewListWatchFromClient(lbc.client.ExtensionsV1beta1().RESTClient(), "ingresses", "default", fields.Everything()),
-			&extensions.Ingress{}, time.Duration(1), nil)
-
-		lbc.secrLister.Store, lbc.secrController = cache.NewInformer(
-			cache.NewListWatchFromClient(lbc.client.Core().RESTClient(), "secrets", "default", fields.Everything()),
-			&v1.Secret{}, time.Duration(1), nil)
-
-		var testIngresses = []extensions.Ingress{
-			{
+		{
+			secret: v1.Secret{
 				ObjectMeta: meta_v1.ObjectMeta{
-					Name:      test.ingressName,
-					Namespace: test.ingressNamespace,
+					Name:      "my-tls-secret",
+					Namespace: "namespace-1",
+				},
+			},
+			ingress: extensions.Ingress{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "my-ingress",
+					Namespace: "namespace-1",
 				},
 				Spec: extensions.IngressSpec{
 					TLS: []extensions.IngressTLS{
 						extensions.IngressTLS{
-							SecretName: test.tlsSecretName,
+							SecretName: "my-tls-secret",
 						},
 					},
 				},
 			},
-			{
+			expectedToFind: true,
+			desc:           "an Ingress references a TLS Secret that exists in the Ingress namespace",
+		},
+		{
+			secret: v1.Secret{
 				ObjectMeta: meta_v1.ObjectMeta{
-					Name:      test.ingressName,
-					Namespace: test.ingressNamespace,
-					Annotations: map[string]string{
-						nginx.JWTKeyAnnotation: test.tlsSecretName,
+					Name:      "my-tls-secret",
+					Namespace: "namespace-1",
+				},
+			},
+			ingress: extensions.Ingress{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "my-ingress",
+					Namespace: "namespace-2",
+				},
+				Spec: extensions.IngressSpec{
+					TLS: []extensions.IngressTLS{
+						extensions.IngressTLS{
+							SecretName: "my-tls-secret",
+						},
 					},
 				},
 			},
-		}
-
-		for _, ing := range testIngresses {
-			ngxIngress := &nginx.IngressEx{Ingress: &ing}
-
-			secret := &v1.Secret{
+			expectedToFind: false,
+			desc:           "an Ingress references a TLS Secret that exists in a different namespace",
+		},
+		{
+			secret: v1.Secret{
 				ObjectMeta: meta_v1.ObjectMeta{
-					Name:      test.secretName,
-					Namespace: test.secretNamespace,
+					Name:      "my-jwk-secret",
+					Namespace: "namespace-1",
+				},
+			},
+			ingress: extensions.Ingress{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "my-ingress",
+					Namespace: "namespace-1",
+					Annotations: map[string]string{
+						nginx.JWTKeyAnnotation: "my-jwk-secret",
+					},
+				},
+			},
+			expectedToFind: true,
+			desc:           "an Ingress references a JWK Secret that exists in the Ingress namespace",
+		},
+		{
+			secret: v1.Secret{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "my-jwk-secret",
+					Namespace: "namespace-1",
+				},
+			},
+			ingress: extensions.Ingress{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "my-ingress",
+					Namespace: "namespace-2",
+					Annotations: map[string]string{
+						nginx.JWTKeyAnnotation: "my-jwk-secret",
+					},
+				},
+			},
+			expectedToFind: false,
+			desc:           "an Ingress references a JWK secret that exists in a different namespace",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset()
+
+			templateExecutor, err := nginx.NewTemplateExecutor("../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl", true)
+			if err != nil {
+				t.Errorf("templateExecuter could not start: %v", err)
+			}
+			ngxc, err := nginx.NewNginxController("/etc/nginx", true, true, "../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl")
+			if err != nil {
+				t.Errorf("NGINX Controller could not start: %v", err)
+			}
+			apiCtrl, err := plus.NewNginxAPIController(&http.Client{}, "", true)
+			if err != nil {
+				t.Errorf("NGINX API Controller could not start: %v", err)
+			}
+
+			cnf := nginx.NewConfigurator(ngxc, &nginx.Config{}, apiCtrl, templateExecutor)
+			lbc := LoadBalancerController{
+				client:       fakeClient,
+				ingressClass: "nginx",
+				cnf:          cnf,
+				nginxPlus:    true,
+			}
+
+			lbc.ingLister.Store, _ = cache.NewInformer(
+				cache.NewListWatchFromClient(lbc.client.ExtensionsV1beta1().RESTClient(), "ingresses", "default", fields.Everything()),
+				&extensions.Ingress{}, time.Duration(1), nil)
+
+			lbc.secrLister.Store, lbc.secrController = cache.NewInformer(
+				cache.NewListWatchFromClient(lbc.client.Core().RESTClient(), "secrets", "default", fields.Everything()),
+				&v1.Secret{}, time.Duration(1), nil)
+
+			ngxIngress := &nginx.IngressEx{
+				Ingress: &test.ingress,
+				TLSSecrets: map[string]*v1.Secret{
+					test.secret.ObjectMeta.Name: &test.secret,
 				},
 			}
-			ngxIngress.TLSSecrets = make(map[string]*v1.Secret)
-			ngxIngress.TLSSecrets[test.tlsSecretName] = secret
 
 			err = cnf.AddOrUpdateIngress(ngxIngress)
 			if err != nil {
 				t.Errorf("Ingress was not added: %v", err)
 			}
 
-			lbc.ingLister.Add(&ing)
+			lbc.ingLister.Add(&test.ingress)
+			lbc.secrLister.Add(&test.secret)
 
-			ingresses, err := lbc.findIngressesForSecret(test.secretNamespace, test.secretName)
+			ingresses, err := lbc.findIngressesForSecret(test.secret.ObjectMeta.Namespace, test.secret.ObjectMeta.Name)
 			if err != nil {
 				t.Errorf("Couldn't list Ingress resource: %v", err)
 			}
 
 			if len(ingresses) > 0 {
-				if !test.expectResult {
+				if !test.expectedToFind {
 					t.Errorf("Expected no ingresses. Got: %v/%v", ingresses[0].Namespace, ingresses[0].Name)
 				}
-				if ingresses[0].Name != test.ingressName || ingresses[0].Namespace != test.ingressNamespace {
-					t.Errorf("Expected: %v/%v. Got: %v/%v.", test.ingressNamespace, test.ingressName, ingresses[0].Namespace, ingresses[0].Name)
+				if ingresses[0].Name != test.ingress.ObjectMeta.Name || ingresses[0].Namespace != test.ingress.ObjectMeta.Namespace {
+					t.Errorf("Expected: %v/%v. Got: %v/%v.", test.ingress.ObjectMeta.Namespace, test.ingress.ObjectMeta.Name, ingresses[0].Namespace, ingresses[0].Name)
 				}
-			} else if test.expectResult {
-				t.Errorf("Expected %v/%v. Got: No ingresses. %v", test.ingressNamespace, test.ingressName, err)
+			} else if test.expectedToFind {
+				t.Errorf("Expected %v/%v. Got: No ingresses. %v", test.ingress.ObjectMeta.Namespace, test.ingress.ObjectMeta.Name, err)
 			}
-		}
+		})
 	}
 }


### PR DESCRIPTION
### Proposed changes
findIngressForSecret now ensures that it searches for an ingress in the same namespace as the passed in secret

Included in this pr are:
* Ingress and secret namespace check
* Unit test validating this change works - also includes jwt validation test

No documentation changes were required in this PR

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation - **(None necessary)**
- [x] I have rebased my branch onto master
