### PR TITLE
Enforce annotations inheritance in minions

### DIFF
--- a/examples/mergeable-ingress-types/README.md
+++ b/examples/mergeable-ingress-types/README.md
@@ -13,6 +13,7 @@ ingress resource.
 Masters cannot contain the following annotations:
 * nginx.org/rewrites
 * nginx.org/ssl-services
+* nginx.org/grpc-services
 * nginx.org/websocket-services
 * nginx.com/sticky-cookie-services
 * nginx.com/health-checks
@@ -39,6 +40,21 @@ Minions cannot contain the following annotations:
 * nginx.com/jwt-realm
 * nginx.com/jwt-token
 * nginx.com/jwt-login-url
+* nginx.org/server-snippets
+
+Minions inherent the following annotations from the master, unless they override them:
+* nginx.org/proxy-connect-timeout
+* nginx.org/proxy-read-timeout
+* nginx.org/client-max-body-size
+* nginx.org/proxy-buffering
+* nginx.org/proxy-buffers
+* nginx.org/proxy-buffer-size
+* nginx.org/proxy-max-temp-file-size
+* nginx.org/location-snippets
+* nginx.org/lb-method
+* nginx.org/keepalive
+* nginx.org/max-fails
+* nginx.org/fail-timeout
 
 Note: Ingress Resources with more than one host cannot be used.
 

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -993,7 +993,7 @@ func filterMasterAnnotations(annotations map[string]string) []string {
 	var removedAnnotations []string
 
 	for key, _ := range annotations {
-		if _, ok := masterBlacklist[key]; ok {
+		if _, notAllowed := masterBlacklist[key]; notAllowed {
 			removedAnnotations = append(removedAnnotations, key)
 			delete(annotations, key)
 		}
@@ -1006,7 +1006,7 @@ func filterMinionAnnotations(annotations map[string]string) []string {
 	var removedAnnotations []string
 
 	for key, _ := range annotations {
-		if _, ok := minionBlacklist[key]; ok {
+		if _, notAllowed := minionBlacklist[key]; notAllowed {
 			removedAnnotations = append(removedAnnotations, key)
 			delete(annotations, key)
 		}
@@ -1017,8 +1017,8 @@ func filterMinionAnnotations(annotations map[string]string) []string {
 
 func mergeMasterAnnotationsIntoMinion(minionAnnotations map[string]string, masterAnnotations map[string]string) {
 	for key, val := range masterAnnotations {
-		if _, ok := minionAnnotations[key]; !ok {
-			if _, ok := minionBlacklist[key]; !ok {
+		if _, exists := minionAnnotations[key]; !exists {
+			if _, allowed := minionInheritanceList[key]; allowed {
 				minionAnnotations[key] = val
 			}
 		}

--- a/nginx-controller/nginx/configurator_test.go
+++ b/nginx-controller/nginx/configurator_test.go
@@ -134,6 +134,7 @@ func TestMergeMasterAnnotationsIntoMinion(t *testing.T) {
 		"nginx.org/hsts":                  "True",
 		"nginx.org/hsts-max-age":          "2700000",
 		"nginx.org/proxy-connect-timeout": "50s",
+		"nginx.com/jwt-token":             "$cookie_auth_token",
 	}
 	minionAnnotations := map[string]string{
 		"nginx.org/client-max-body-size":  "2m",

--- a/nginx-controller/nginx/ingress.go
+++ b/nginx-controller/nginx/ingress.go
@@ -23,6 +23,7 @@ type MergeableIngresses struct {
 var masterBlacklist = map[string]bool{
 	"nginx.org/rewrites":                      true,
 	"nginx.org/ssl-services":                  true,
+	"nginx.org/grpc-services":                 true,
 	"nginx.org/websocket-services":            true,
 	"nginx.com/sticky-cookie-services":        true,
 	"nginx.com/health-checks":                 true,
@@ -45,4 +46,20 @@ var minionBlacklist = map[string]bool{
 	"nginx.com/jwt-realm":                true,
 	"nginx.com/jwt-token":                true,
 	"nginx.com/jwt-login-url":            true,
+	"nginx.org/server-snippets":          true,
+}
+
+var minionInheritanceList = map[string]bool{
+	"nginx.org/proxy-connect-timeout":    true,
+	"nginx.org/proxy-read-timeout":       true,
+	"nginx.org/client-max-body-size":     true,
+	"nginx.org/proxy-buffering":          true,
+	"nginx.org/proxy-buffers":            true,
+	"nginx.org/proxy-buffer-size":        true,
+	"nginx.org/proxy-max-temp-file-size": true,
+	"nginx.org/location-snippets":        true,
+	"nginx.org/lb-method":                true,
+	"nginx.org/keepalive":                true,
+	"nginx.org/max-fails":                true,
+	"nginx.org/fail-timeout":             true,
 }


### PR DESCRIPTION
- minions are only allowed to inherent certain annotations from their
master

Additional changes:
- nginx.org/grpc-services is not allowed in the master anymore
- nginx.org/server-snippets is not allowed in the minion anymore

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
