### PR TITLE
Stub status

### DIFF
--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -17,6 +17,10 @@ Usage of ./nginx-ingress:
   -health-status
     	Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request.
 	Useful for external health-checking of the Ingress controller
+  -stub-status
+        Add a location "/stub_status" to the default server. The location responds with the stats from stub status
+    module for any request.
+    Useful in tandem with nginx-prometheus-exporter for monitoring of the Ingress controller
   -ingress-class string
     	A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its class
 	- i.e. have the annotation "kubernetes.io/ingress.class" equal to the class. Additionally,

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -82,6 +82,7 @@ Parameter | Description | Default
 `controller.watchNamespace` | Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces. | ""
 `controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress controller. | false
 `controller.stubStatus` | Add a location "/stub-status" to the default server. The location responds with the stats from stub status module for any request. Useful in tandem with nginx-prometheus-exporter for monitoring of the Ingress controller. | false
+`controller.statusAllowIp` | Define the IP the "/nginx-health" and "/stub-status" endpoints are allowed for. Defaults to open to everyone. | ""
 `rbac.create` | Configures RBAC. | true
 `prometheues.create` | Deploys a Prometheus exporter container within the Ingress controller pod. Requires NGINX Plus. `controller.nginxplus` must be set to `true`. | false
 `prometheus.port` | Configures the port to scrape the metrics. | 9113

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -81,6 +81,7 @@ Parameter | Description | Default
 `controller.useIngressClassOnly` | Ignore Ingress resources without the `"kubernetes.io/ingress.class"` annotation. | false
 `controller.watchNamespace` | Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces. | ""
 `controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress controller. | false
+`controller.stubStatus` | Add a location "/stub-status" to the default server. The location responds with the stats from stub status module for any request. Useful in tandem with nginx-prometheus-exporter for monitoring of the Ingress controller. | false
 `rbac.create` | Configures RBAC. | true
 `prometheues.create` | Deploys a Prometheus exporter container within the Ingress controller pod. Requires NGINX Plus. `controller.nginxplus` must be set to `true`. | false
 `prometheus.port` | Configures the port to scrape the metrics. | 9113

--- a/helm-chart/templates/controller-daemonset.yaml
+++ b/helm-chart/templates/controller-daemonset.yaml
@@ -86,6 +86,9 @@ spec:
 {{- if .Values.controller.stubStatus }}
           - -stub-status
 {{- end }}
+{{- if .Values.controller.statusAllowIp }}
+          - -status-allow-ip={{ .Values.controller.statusAllowIp }}
+{{- end }}
 {{- if .Values.prometheus }}
 {{- if and (.Values.controller.nginxplus)  (.Values.prometheus.create) }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"

--- a/helm-chart/templates/controller-daemonset.yaml
+++ b/helm-chart/templates/controller-daemonset.yaml
@@ -83,6 +83,9 @@ spec:
 {{- if .Values.controller.healthStatus }}
           - -health-status
 {{- end }}
+{{- if .Values.controller.stubStatus }}
+          - -stub-status
+{{- end }}
 {{- if .Values.prometheus }}
 {{- if and (.Values.controller.nginxplus)  (.Values.prometheus.create) }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"

--- a/helm-chart/templates/controller-deployment.yaml
+++ b/helm-chart/templates/controller-deployment.yaml
@@ -72,6 +72,9 @@ spec:
 {{- if .Values.controller.stubStatus }}
           - -stub-status
 {{- end }}
+{{- if .Values.controller.statusAllowIp }}
+          - -status-allow-ip={{ .Values.controller.statusAllowIp }}
+{{- end }}
 {{- if .Values.prometheus }}
 {{- if and (.Values.controller.nginxplus)  (.Values.prometheus.create) }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"

--- a/helm-chart/templates/controller-deployment.yaml
+++ b/helm-chart/templates/controller-deployment.yaml
@@ -69,6 +69,9 @@ spec:
 {{- if .Values.controller.healthStatus }}
           - -health-status
 {{- end }}
+{{- if .Values.controller.stubStatus }}
+          - -stub-status
+{{- end }}
 {{- if .Values.prometheus }}
 {{- if and (.Values.controller.nginxplus)  (.Values.prometheus.create) }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"

--- a/helm-chart/values-plus.yaml
+++ b/helm-chart/values-plus.yaml
@@ -22,6 +22,7 @@ controller:
   useIngressClassOnly: false
   watchNamespace: ""
   healthStatus: false
+  stubStatus: false
   service:
     create: true
     type: LoadBalancer

--- a/helm-chart/values-plus.yaml
+++ b/helm-chart/values-plus.yaml
@@ -23,6 +23,7 @@ controller:
   watchNamespace: ""
   healthStatus: false
   stubStatus: false
+  statusAllowIp: ""
   service:
     create: true
     type: LoadBalancer

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -22,6 +22,7 @@ controller:
   useIngressClassOnly: false
   watchNamespace: ""
   healthStatus: false
+  stubStatus: false
   service:
     create: true
     type: LoadBalancer

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -23,6 +23,7 @@ controller:
   watchNamespace: ""
   healthStatus: false
   stubStatus: false
+  statusAllowIp: ""
   service:
     create: true
     type: LoadBalancer

--- a/nginx-controller/controller/controller_test.go
+++ b/nginx-controller/controller/controller_test.go
@@ -926,7 +926,7 @@ func TestFindIngressesForSecret(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset()
 
-			templateExecutor, err := nginx.NewTemplateExecutor("../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl", true, true)
+			templateExecutor, err := nginx.NewTemplateExecutor("../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl", true, true, "127.0.0.1")
 			if err != nil {
 				t.Fatalf("templateExecuter could not start: %v", err)
 			}

--- a/nginx-controller/controller/controller_test.go
+++ b/nginx-controller/controller/controller_test.go
@@ -926,7 +926,7 @@ func TestFindIngressesForSecret(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset()
 
-			templateExecutor, err := nginx.NewTemplateExecutor("../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl", true)
+			templateExecutor, err := nginx.NewTemplateExecutor("../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl", true, true)
 			if err != nil {
 				t.Fatalf("templateExecuter could not start: %v", err)
 			}

--- a/nginx-controller/main.go
+++ b/nginx-controller/main.go
@@ -36,6 +36,10 @@ var (
     module for any request.
 	Useful in tandem with nginx-prometheus-exporter for monitoring of the Ingress controller`)
 
+	statusAllowIp = flag.String("status-allow-ip", "",
+	    `Define ip to allow while denying all others for stub_status and health_status endpoints. To close off status
+	    endpoints from the world set as an IP (such as "127.0.0.1"). Defaults to "" to be disabled.`)
+
 	proxyURL = flag.String("proxy", "",
 		`Use a proxy server to connect to Kubernetes API started by "kubectl proxy" command. For testing purposes only.
 	The Ingress controller does not start NGINX and does not write any generated NGINX configuration files to disk`)
@@ -136,7 +140,7 @@ func main() {
 		nginxIngressTemplatePath = *ingressTemplatePath
 	}
 
-	templateExecutor, err := nginx.NewTemplateExecutor(nginxConfTemplatePath, nginxIngressTemplatePath, *healthStatus, *stubStatus)
+	templateExecutor, err := nginx.NewTemplateExecutor(nginxConfTemplatePath, nginxIngressTemplatePath, *healthStatus, *stubStatus, *statusAllowIp)
 	if err != nil {
 		glog.Fatalf("Error creating TemplateExecutor: %v", err)
 	}

--- a/nginx-controller/main.go
+++ b/nginx-controller/main.go
@@ -31,6 +31,11 @@ var (
 		`Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request.
 	Useful for external health-checking of the Ingress controller`)
 
+	stubStatus = flag.Bool("stub-status", false,
+		`Add a location "/stub_status" to the default server. The location responds with the stats from stub status
+    module for any request.
+	Useful in tandem with nginx-prometheus-exporter for monitoring of the Ingress controller`)
+
 	proxyURL = flag.String("proxy", "",
 		`Use a proxy server to connect to Kubernetes API started by "kubectl proxy" command. For testing purposes only.
 	The Ingress controller does not start NGINX and does not write any generated NGINX configuration files to disk`)
@@ -131,7 +136,7 @@ func main() {
 		nginxIngressTemplatePath = *ingressTemplatePath
 	}
 
-	templateExecutor, err := nginx.NewTemplateExecutor(nginxConfTemplatePath, nginxIngressTemplatePath, *healthStatus)
+	templateExecutor, err := nginx.NewTemplateExecutor(nginxConfTemplatePath, nginxIngressTemplatePath, *healthStatus, *stubStatus)
 	if err != nil {
 		glog.Fatalf("Error creating TemplateExecutor: %v", err)
 	}

--- a/nginx-controller/nginx/configurator_test.go
+++ b/nginx-controller/nginx/configurator_test.go
@@ -483,7 +483,7 @@ func createExpectedConfigForMergeableCafeIngress() IngressNginxConfig {
 }
 
 func createTestConfigurator() *Configurator {
-	templateExecutor, _ := NewTemplateExecutor("templates/nginx-plus.tmpl", "templates/nginx-plus.ingress.tmpl", true)
+	templateExecutor, _ := NewTemplateExecutor("templates/nginx-plus.tmpl", "templates/nginx-plus.ingress.tmpl", true, true)
 	ngxc := NewNginxController("/etc/nginx", true)
 	apiCtrl, _ := plus.NewNginxAPIController(&http.Client{}, "", true)
 	return NewConfigurator(ngxc, NewDefaultConfig(), apiCtrl, templateExecutor)

--- a/nginx-controller/nginx/configurator_test.go
+++ b/nginx-controller/nginx/configurator_test.go
@@ -483,7 +483,7 @@ func createExpectedConfigForMergeableCafeIngress() IngressNginxConfig {
 }
 
 func createTestConfigurator() *Configurator {
-	templateExecutor, _ := NewTemplateExecutor("templates/nginx-plus.tmpl", "templates/nginx-plus.ingress.tmpl", true, true)
+	templateExecutor, _ := NewTemplateExecutor("templates/nginx-plus.tmpl", "templates/nginx-plus.ingress.tmpl", true, true, "")
 	ngxc := NewNginxController("/etc/nginx", true)
 	apiCtrl, _ := plus.NewNginxAPIController(&http.Client{}, "", true)
 	return NewConfigurator(ngxc, NewDefaultConfig(), apiCtrl, templateExecutor)

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -144,6 +144,7 @@ type NginxMainConfig struct {
 	LogFormat                 string
 	HealthStatus              bool
 	StubStatus                bool
+	StatusAllowIp             string
 	MainSnippets              []string
 	HTTPSnippets              []string
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -143,6 +143,7 @@ type NginxMainConfig struct {
 	ServerNamesHashMaxSize    string
 	LogFormat                 string
 	HealthStatus              bool
+	StubStatus                bool
 	MainSnippets              []string
 	HTTPSnippets              []string
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html

--- a/nginx-controller/nginx/template_executor.go
+++ b/nginx-controller/nginx/template_executor.go
@@ -10,12 +10,13 @@ import (
 type TemplateExecutor struct {
 	HealthStatus    bool
 	StubStatus      bool
+	StatusAllowIp   string
 	mainTemplate    *template.Template
 	ingressTemplate *template.Template
 }
 
 // NewTemplateExecutor creates a TemplateExecutor
-func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, healthStatus bool, stubStatus bool) (*TemplateExecutor, error) {
+func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, healthStatus bool, stubStatus bool, statusAllowIp string) (*TemplateExecutor, error) {
 	// template name must be the base name of the template file https://golang.org/pkg/text/template/#Template.ParseFiles
 	nginxTemplate, err := template.New(path.Base(mainTemplatePath)).ParseFiles(mainTemplatePath)
 	if err != nil {
@@ -27,7 +28,7 @@ func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, he
 		return nil, err
 	}
 
-	return &TemplateExecutor{mainTemplate: nginxTemplate, ingressTemplate: ingressTemplate, HealthStatus: healthStatus, StubStatus: stubStatus}, nil
+	return &TemplateExecutor{mainTemplate: nginxTemplate, ingressTemplate: ingressTemplate, HealthStatus: healthStatus, StubStatus: stubStatus, StatusAllowIp: statusAllowIp}, nil
 }
 
 // UpdateMainTemplate updates the main NGINX template
@@ -56,6 +57,7 @@ func (te *TemplateExecutor) UpdateIngressTemplate(templateString *string) error 
 func (te *TemplateExecutor) ExecuteMainConfigTemplate(cfg *NginxMainConfig) ([]byte, error) {
 	cfg.HealthStatus = te.HealthStatus
 	cfg.StubStatus = te.StubStatus
+	cfg.StatusAllowIp = te.StatusAllowIp
 
 	var configBuffer bytes.Buffer
 	err := te.mainTemplate.Execute(&configBuffer, cfg)

--- a/nginx-controller/nginx/template_executor.go
+++ b/nginx-controller/nginx/template_executor.go
@@ -9,12 +9,13 @@ import (
 // TemplateExecutor executes NGINX configuration templates
 type TemplateExecutor struct {
 	HealthStatus    bool
+	StubStatus      bool
 	mainTemplate    *template.Template
 	ingressTemplate *template.Template
 }
 
 // NewTemplateExecutor creates a TemplateExecutor
-func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, healthStatus bool) (*TemplateExecutor, error) {
+func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, healthStatus bool, stubStatus bool) (*TemplateExecutor, error) {
 	// template name must be the base name of the template file https://golang.org/pkg/text/template/#Template.ParseFiles
 	nginxTemplate, err := template.New(path.Base(mainTemplatePath)).ParseFiles(mainTemplatePath)
 	if err != nil {
@@ -26,7 +27,7 @@ func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, he
 		return nil, err
 	}
 
-	return &TemplateExecutor{mainTemplate: nginxTemplate, ingressTemplate: ingressTemplate, HealthStatus: healthStatus}, nil
+	return &TemplateExecutor{mainTemplate: nginxTemplate, ingressTemplate: ingressTemplate, HealthStatus: healthStatus, StubStatus: stubStatus}, nil
 }
 
 // UpdateMainTemplate updates the main NGINX template
@@ -54,6 +55,7 @@ func (te *TemplateExecutor) UpdateIngressTemplate(templateString *string) error 
 // ExecuteMainConfigTemplate generates the content of the main NGINX configuration file
 func (te *TemplateExecutor) ExecuteMainConfigTemplate(cfg *NginxMainConfig) ([]byte, error) {
 	cfg.HealthStatus = te.HealthStatus
+	cfg.StubStatus = te.StubStatus
 
 	var configBuffer bytes.Buffer
 	err := te.mainTemplate.Execute(&configBuffer, cfg)

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -80,6 +80,12 @@ http {
         }
         {{end}}
 
+        {{if .StubStatus}}
+        location /stub_status {
+            stub_status;
+        }
+        {{end}}
+
         location / {
            return 404;
         }

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -75,26 +75,12 @@ http {
 
         {{if .HealthStatus}}
         location /nginx-health {
-            {{if ne .StatusAllowIp ""}}
-            access_log off;
+{{if ne .StatusAllowIp ""}}            access_log off;
             allow {{.StatusAllowIp}};
-            deny all;
-            {{end}}
+            deny all;{{end}}
 
             default_type text/plain;
             return 200 "healthy\n";
-        }
-        {{end}}
-
-        {{if .StubStatus}}
-        location /stub_status {
-            stub_status;
-
-            {{if ne .StatusAllowIp ""}}
-            access_log off;
-            allow {{.StatusAllowIp}};
-            deny all;
-            {{end}}
         }
         {{end}}
 

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -75,6 +75,12 @@ http {
 
         {{if .HealthStatus}}
         location /nginx-health {
+            {{if ne .StatusAllowIp ""}}
+            access_log off;
+            allow {{.StatusAllowIp}};
+            deny all;
+            {{end}}
+
             default_type text/plain;
             return 200 "healthy\n";
         }
@@ -83,6 +89,12 @@ http {
         {{if .StubStatus}}
         location /stub_status {
             stub_status;
+
+            {{if ne .StatusAllowIp ""}}
+            access_log off;
+            allow {{.StatusAllowIp}};
+            deny all;
+            {{end}}
         }
         {{end}}
 

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -77,6 +77,12 @@ http {
         }
         {{end}}
 
+        {{if .StubStatus}}
+        location /stub_status {
+            stub_status;
+        }
+        {{end}}
+
         location / {
            return 404;
         }

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -72,12 +72,10 @@ http {
 
         {{if .HealthStatus}}
         location /nginx-health {
-            {{if ne .StatusAllowIp ""}}
-            access_log off;
+{{if ne .StatusAllowIp ""}}            access_log off;
             allow {{.StatusAllowIp}};
-            deny all;
-            {{end}}
-            
+            deny all;{{end}}
+
             default_type text/plain;
             return 200 "healthy\n";
         }
@@ -87,11 +85,9 @@ http {
         location /stub_status {
             stub_status;
 
-            {{if ne .StatusAllowIp ""}}
-            access_log off;
+{{if ne .StatusAllowIp ""}}            access_log off;
             allow {{.StatusAllowIp}};
-            deny all;
-            {{end}}
+            deny all;{{end}}
         }
         {{end}}
 

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -72,6 +72,12 @@ http {
 
         {{if .HealthStatus}}
         location /nginx-health {
+            {{if ne .StatusAllowIp ""}}
+            access_log off;
+            allow {{.StatusAllowIp}};
+            deny all;
+            {{end}}
+            
             default_type text/plain;
             return 200 "healthy\n";
         }
@@ -80,6 +86,12 @@ http {
         {{if .StubStatus}}
         location /stub_status {
             stub_status;
+
+            {{if ne .StatusAllowIp ""}}
+            access_log off;
+            allow {{.StatusAllowIp}};
+            deny all;
+            {{end}}
         }
         {{end}}
 

--- a/nginx-controller/nginx/templates/templates_test.go
+++ b/nginx-controller/nginx/templates/templates_test.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -80,15 +81,30 @@ var ingCfg = nginx.IngressNginxConfig{
 	Keepalive: "16",
 }
 
-var mainCfg = nginx.NginxMainConfig{
-	ServerNamesHashMaxSize: "512",
-	ServerTokens:           "off",
-	WorkerProcesses:        "auto",
-	WorkerCPUAffinity:      "auto",
-	WorkerShutdownTimeout:  "1m",
-	WorkerConnections:      "1024",
-	WorkerRlimitNofile:     "65536",
+func generateNginxMainConfigVars() nginx.NginxMainConfig {
+    mainCfg := nginx.NginxMainConfig{
+    	ServerNamesHashMaxSize: "512",
+    	ServerTokens:           "off",
+    	WorkerProcesses:        "auto",
+    	WorkerCPUAffinity:      "auto",
+    	WorkerShutdownTimeout:  "1m",
+    	WorkerConnections:      "1024",
+    	WorkerRlimitNofile:     "65536",
+    }
+    return mainCfg;
 }
+
+func disableHealthStatusAndStubStatus(cfg nginx.NginxMainConfig) nginx.NginxMainConfig {
+    cfg.HealthStatus = false
+    cfg.StubStatus = false
+    return cfg;
+}
+func enableHealthStatusAndStubStatus(cfg nginx.NginxMainConfig) nginx.NginxMainConfig  {
+    cfg.HealthStatus = true
+    cfg.StubStatus = true
+    return cfg;
+}
+
 
 func TestIngressForNGINXPlus(t *testing.T) {
 	tmpl, err := template.New(nginxPlusIngressTmpl).ParseFiles(nginxPlusIngressTmpl)
@@ -126,6 +142,8 @@ func TestMainForNGINXPlus(t *testing.T) {
 		t.Fatalf("Failed to parse template file: %v", err)
 	}
 
+    mainCfg := generateNginxMainConfigVars()
+
 	var buf bytes.Buffer
 
 	err = tmpl.Execute(&buf, mainCfg)
@@ -141,11 +159,337 @@ func TestMainForNGINX(t *testing.T) {
 		t.Fatalf("Failed to parse template file: %v", err)
 	}
 
+    mainCfg := generateNginxMainConfigVars()
+
 	var buf bytes.Buffer
 
 	err = tmpl.Execute(&buf, mainCfg)
 	t.Log(string(buf.Bytes()))
 	if err != nil {
 		t.Fatalf("Failed to write template %v", err)
+	}
+}
+
+func loadNginxMainTemplate(t *testing.T) *template.Template {
+	tmpl, err := template.New(nginxMainTmpl).ParseFiles(nginxMainTmpl)
+	if err != nil {
+		t.Fatalf("Failed to parse template file: %v", err)
+	}
+	return tmpl;
+}
+
+func loadNginxPlusMainTemplate(t *testing.T) *template.Template {
+	tmpl, err := template.New(nginxPlusMainTmpl).ParseFiles(nginxPlusMainTmpl)
+	if err != nil {
+		t.Fatalf("Failed to parse template file: %v", err)
+	}
+	return tmpl;
+}
+
+func TestNoStatusAllowIpForNGINXPlus(t *testing.T) {
+    tmpl := loadNginxPlusMainTemplate(t);
+    mainCfg := generateNginxMainConfigVars()
+
+    mainCfg = enableHealthStatusAndStubStatus(mainCfg);
+
+	var buf bytes.Buffer
+
+	err := tmpl.Execute(&buf, mainCfg)
+	if err != nil {
+		t.Fatalf("Failed to write template %v", err)
+	}
+
+	generatedConfig := buf.String()
+
+	if strings.Count(generatedConfig, "location /api") == 0 {
+		t.Errorf("Generated Nginx main template returned no location /api directives, expected one.")
+	}
+
+	if strings.Count(generatedConfig, "location /api") > 1 {
+		t.Errorf("Generated Nginx main template returned more than one location /api directives, expected one.")
+	}
+
+	if !strings.Contains(generatedConfig, `location /nginx-health {
+
+
+            default_type text/plain;
+            return 200 "healthy\n";
+        }`) {
+        t.Log(string(buf.Bytes()))
+		t.Errorf("Generated Nginx main template was supposed to contain unrestricted location /nginx-health.")
+	}
+
+	if strings.Contains(generatedConfig, `location /nginx-health {
+            access_log off;
+            allow 1.2.3.4;
+            deny all;
+
+            default_type text/plain;
+            return 200 "healthy\n";
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template was not supposed to contain restricted location /nginx-health.")
+	}
+}
+
+func TestDefaultStatusAllowIpForNGINXPlus(t *testing.T) {
+    tmpl := loadNginxPlusMainTemplate(t);
+    mainCfg := generateNginxMainConfigVars()
+
+    mainCfg.StatusAllowIp = ""
+    mainCfg = enableHealthStatusAndStubStatus(mainCfg);
+
+
+	var buf bytes.Buffer
+
+	err := tmpl.Execute(&buf, mainCfg)
+	if err != nil {
+		t.Fatalf("Failed to write template %v", err)
+	}
+
+	generatedConfig := buf.String()
+
+	if strings.Count(generatedConfig, "location /api") == 0 {
+		t.Errorf("Generated Nginx main template returned no location /api directives, expected one.")
+	}
+
+	if strings.Count(generatedConfig, "location /api") > 1 {
+		t.Errorf("Generated Nginx main template returned more than one location /api directives, expected one.")
+	}
+
+	if strings.Contains(generatedConfig, `location /nginx-health {
+            access_log off;
+            allow 1.2.3.4;
+            deny all;
+
+            default_type text/plain;
+            return 200 "healthy\n";
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template was not supposed to contain the restricted location /nginx-health.")
+	}
+}
+
+func TestGivenStatusAllowIpForNGINXPlus(t *testing.T) {
+    tmpl := loadNginxPlusMainTemplate(t);
+    mainCfg := generateNginxMainConfigVars()
+
+    mainCfg = enableHealthStatusAndStubStatus(mainCfg);
+    mainCfg.StatusAllowIp = "1.2.3.4"
+
+	var buf bytes.Buffer
+
+	err := tmpl.Execute(&buf, mainCfg)
+	if err != nil {
+		t.Fatalf("Failed to write template %v", err)
+	}
+
+	generatedConfig := buf.String()
+
+	if !strings.Contains(generatedConfig, "location /nginx-health") {
+		t.Errorf("Generated Nginx main template did not contain a location /nginx-health.")
+	}
+
+	if !strings.Contains(generatedConfig, `location /nginx-health {
+            access_log off;
+            allow 1.2.3.4;
+            deny all;
+
+            default_type text/plain;
+            return 200 "healthy\n";
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template was supposed to contain the restricted location /nginx-health.")
+	}
+
+
+
+	if strings.Contains(generatedConfig, "location /stub_status") {
+		t.Errorf("Generated Nginx main template should not contain a location /stub_status directive.")
+	}
+
+	if strings.Count(generatedConfig, "location /api") == 0 {
+		t.Errorf("Generated Nginx main template returned no location /api directives, expected one.")
+	}
+
+	if strings.Count(generatedConfig, "location /api") > 1 {
+		t.Errorf("Generated Nginx main template returned more than one location /api directives, expected one.")
+	}
+}
+
+
+func TestNoStatusAllowIpForNGINX(t *testing.T) {
+    tmpl := loadNginxMainTemplate(t);
+    mainCfg := generateNginxMainConfigVars()
+
+    mainCfg = enableHealthStatusAndStubStatus(mainCfg);
+
+	var buf bytes.Buffer
+
+	err := tmpl.Execute(&buf, mainCfg)
+	if err != nil {
+		t.Fatalf("Failed to write template %v", err)
+	}
+
+	generatedConfig := buf.String()
+
+	if !strings.Contains(generatedConfig, "location /nginx-health") {
+		t.Errorf("Generated Nginx main template did not contain a location /nginx-health.")
+	}
+	if !strings.Contains(generatedConfig, "location /stub_status") {
+		t.Errorf("Generated Nginx main template did not contain a location /stub_status directive.")
+	}
+
+	if strings.Contains(generatedConfig, `location /stub_status {
+            stub_status;
+
+            access_log off;
+            allow 1.2.3.4;
+            deny all;
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template was not supposed to contain the restricted location /stub_status directive.")
+	}
+
+	if !strings.Contains(generatedConfig, `location /stub_status {
+            stub_status;
+
+
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template did not contain an opened location /stub_status directive.")
+	}
+}
+
+func TestDefaultStatusAllowIpForNGINX(t *testing.T) {
+    tmpl := loadNginxMainTemplate(t);
+    mainCfg := generateNginxMainConfigVars()
+
+    mainCfg = enableHealthStatusAndStubStatus(mainCfg);
+    mainCfg.StatusAllowIp = ""
+
+	var buf bytes.Buffer
+
+	err := tmpl.Execute(&buf, mainCfg)
+	if err != nil {
+		t.Fatalf("Failed to write template %v", err)
+	}
+
+	generatedConfig := buf.String()
+
+	if !strings.Contains(generatedConfig, "location /nginx-health") {
+		t.Errorf("Generated Nginx main template did not contain a location /nginx-health.")
+	}
+
+	if !strings.Contains(generatedConfig, "location /stub_status") {
+		t.Errorf("Generated Nginx main template did not contain a location /stub_status directive.")
+	}
+
+	if strings.Contains(generatedConfig, `location /stub_status {
+            stub_status;
+
+            access_log off;
+            allow 1.2.3.4;
+            deny all;
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template was not supposed to contain the restricted location /stub_status directive.")
+	}
+
+	if !strings.Contains(generatedConfig, `location /stub_status {
+            stub_status;
+
+
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template did not contain an opened location /stub_status directive.")
+	}
+}
+
+func TestGivenStatusWithoutAllowIpForNGINX(t *testing.T) {
+    tmpl := loadNginxMainTemplate(t);
+    mainCfg := generateNginxMainConfigVars()
+
+    mainCfg = enableHealthStatusAndStubStatus(mainCfg);
+    mainCfg.StatusAllowIp = ""
+
+	var buf bytes.Buffer
+
+	err := tmpl.Execute(&buf, mainCfg)
+	if err != nil {
+		t.Fatalf("Failed to write template %v", err)
+	}
+
+	generatedConfig := buf.String()
+
+	if !strings.Contains(generatedConfig, "location /nginx-health") {
+		t.Errorf("Generated Nginx main template did not contain a location /nginx-health.")
+	}
+	if !strings.Contains(generatedConfig, "location /stub_status") {
+		t.Errorf("Generated Nginx main template did not contain a location /stub_status directive.")
+	}
+
+	if strings.Contains(generatedConfig, `location /stub_status {
+            stub_status;
+
+            access_log off;
+            allow 1.2.3.4;
+            deny all;
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template was not supposed to contain the restricted location /stub_status directive.")
+	}
+
+	if !strings.Contains(generatedConfig, `location /stub_status {
+            stub_status;
+
+
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template did not contain an opened location /stub_status directive.")
+	}
+}
+
+func TestGivenStatusAllowIpForNGINX(t *testing.T) {
+    tmpl := loadNginxMainTemplate(t);
+    mainCfg := generateNginxMainConfigVars()
+
+    mainCfg = enableHealthStatusAndStubStatus(mainCfg);
+    mainCfg.StatusAllowIp = "1.2.3.4"
+
+	var buf bytes.Buffer
+
+	err := tmpl.Execute(&buf, mainCfg)
+	if err != nil {
+		t.Fatalf("Failed to write template %v", err)
+	}
+
+	generatedConfig := buf.String()
+
+	if !strings.Contains(generatedConfig, "location /nginx-health") {
+		t.Errorf("Generated Nginx main template did not contain a location /nginx-health.")
+	}
+	if !strings.Contains(generatedConfig, "location /stub_status") {
+		t.Errorf("Generated Nginx main template did not contain a location /stub_status directive.")
+	}
+
+	if !strings.Contains(generatedConfig, `location /stub_status {
+            stub_status;
+
+            access_log off;
+            allow 1.2.3.4;
+            deny all;
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template did not contain the restricted location /stub_status directive.2")
+	}
+
+	if strings.Contains(generatedConfig, `location /stub_status {
+            stub_status;
+
+
+        }`) {
+        t.Log(generatedConfig)
+		t.Errorf("Generated Nginx main template was not supposed to contain an opened location /stub_status directive.")
 	}
 }


### PR DESCRIPTION
### Proposed changes
Not too long ago a `health-status` command line argument was added to add a base location that offers a 200 "healthy" endpoint.

Recently, [nginx-prometheus-exporter](https://github.com/nginxinc/nginx-prometheus-exporter) appeared and supports both Nginx and Nginx Plus!

For Nginx basic, it needs access to a stub_status endpoint. I was unable to use `location-snippets` to accomplish this as the accompanying `proxypass` directives seem to over-ride the `stub_status` directive.

So I decided to follow suit with the health-status and add a `stub-status` command line argument to add another base `server` location that offers a *stub_status*-powered endpoint.

This change worked for my needs and seemed good. I then felt that leaving that status page wide open was a scarier proposition than leaving open a 200 "Healthy" endpoint, so I also added a `status-allow-ip` command line argument that defaults to Off but allows defining an IP to use for allowing and denying everything else in the status routes.

I'm not sure if command line argument is still the best home for these, but since it is is server-wide it very well may be. I also am not sure if we would want to customize things such as the endpoint's path, so I just went with the default one that the nginx-prometheus-exporter uses by default.

For Nginx Plus, instead of stub_status we are to use api as described by nginx-prometheus-exporter but the Plus config already generates an /api route. So I changed my "stub-status" flag to no-op on Nginx Plus. So for Nginx Plus this change just allows locking down the health endpoint via `status-allow-ip`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
