### PR TITLE
Support for TCP/UDP load balancing via stream-snippets 

### DIFF
--- a/examples/customization/README.md
+++ b/examples/customization/README.md
@@ -67,6 +67,8 @@ The table below summarizes all of the options. For some of them, there are examp
 | `nginx.com/health-checks-mandatory-queue` | N/A | When active health checks are mandatory, configures a queue for temporary storing incoming requests during the time when NGINX Plus is checking the health of the endpoints after a configuration reload. | `0` | [Support for Active Health Checks](../health-checks). |
 | `nginx.com/slow-start` | N/A | Sets the upstream server [slow-start period](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#server-slow-start). By default, slow-start is activated after a server becomes [available](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-health-check/#passive-health-checks) or [healthy](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-health-check/#active-health-checks). To enable slow-start for newly added servers, configure [mandatory active health checks](../health-checks). | `"0s"` | |
 | N/A | `external-status-address` | Sets the address to be reported in the status of Ingress resources. Requires the `-report-status` command-line argument. Overrides the `-external-service` argument. | N/A | [Report Ingress Status](../../docs/report-ingress-status.md). |
+| N/A | `stream-snippets` | Sets a custom snippet in stream context. | N/A | |
+| N/A | `stream-log-format` | Sets the custom [log format](http://nginx.org/en/docs/stream/ngx_stream_log_module.html#log_format) for TCP/UDP load balancing.  | See the [template file](../../nginx-controller/nginx/nginx.conf.tmpl). | |
 
 ## Using ConfigMaps
 

--- a/examples/customization/nginx-config.yaml
+++ b/examples/customization/nginx-config.yaml
@@ -57,3 +57,12 @@ data:
   keepalive: "32" # default is 0. When > 0, sets the value of the keepalive directive and adds 'proxy_set_header Connection "";' to a location block. See http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
   max-fails: "0" # default is 1. Sets the value of the max_fails parameter of the `server` directive. See https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_fails
   fail-timeout: "5s" # default is 10s. Sets the value of the fail_timeout parameter of the `server` directive. See https://nginx.org/en/docs/http/ngx_http_upstream_module.html#fail_timeout
+  stream-log-format: "$remote_addr $protocol" # stream-log-format default is set in the nginx.conf.tmpl file. Also see http://nginx.org/en/docs/stream/ngx_stream_log_module.html#log_format 
+  stream-snippets: |
+    upstream tcp-coffee {
+      server coffee-svc.default.svc.cluster.local:80;
+    }
+    server {
+      listen 4456;
+      proxy_pass tcp-tea;
+    }

--- a/nginx-controller/Dockerfile
+++ b/nginx-controller/Dockerfile
@@ -3,6 +3,7 @@ FROM nginx:1.15.2
 # forward nginx access and error logs to stdout and stderr of the ingress
 # controller process
 RUN ln -sf /proc/1/fd/1 /var/log/nginx/access.log \
+	&& ln -sf /proc/1/fd/1 /var/log/nginx/stream-access.log \
 	&& ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 COPY nginx-ingress nginx/templates/nginx.ingress.tmpl nginx/templates/nginx.tmpl /

--- a/nginx-controller/DockerfileForAlpine
+++ b/nginx-controller/DockerfileForAlpine
@@ -3,6 +3,7 @@ FROM nginx:1.15.2-alpine
 # forward nginx access and error logs to stdout and stderr of the ingress
 # controller process
 RUN ln -sf /proc/1/fd/1 /var/log/nginx/access.log \
+	&& ln -sf /proc/1/fd/1 /var/log/nginx/stream-access.log \
 	&& ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 COPY nginx-ingress nginx/templates/nginx.ingress.tmpl nginx/templates/nginx.tmpl /

--- a/nginx-controller/DockerfileForPlus
+++ b/nginx-controller/DockerfileForPlus
@@ -44,6 +44,7 @@ RUN set -x \
 # forward nginx access and error logs to stdout and stderr of the ingress
 # controller process
 RUN ln -sf /proc/1/fd/1 /var/log/nginx/access.log \
+	&& ln -sf /proc/1/fd/1 /var/log/nginx/stream-access.log \
 	&& ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	SSLRedirect                   bool
 	MainMainSnippets              []string
 	MainHTTPSnippets              []string
+	MainStreamSnippets            []string
 	MainServerNamesHashBucketSize string
 	MainServerNamesHashMaxSize    string
 	MainLogFormat                 string
@@ -345,6 +346,13 @@ func ParseConfigMap(cfgm *api_v1.ConfigMap, nginxPlus bool) *Config {
 	}
 	if ingressTemplate, exists := cfgm.Data["ingress-template"]; exists {
 		cfg.IngressTemplate = &ingressTemplate
+	}
+	if mainStreamSnippets, exists, err := GetMapKeyAsStringSlice(cfgm.Data, "stream-snippets", cfgm, "\n"); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfg.MainStreamSnippets = mainStreamSnippets
+		}
 	}
 	return cfg
 }

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	MainServerNamesHashBucketSize string
 	MainServerNamesHashMaxSize    string
 	MainLogFormat                 string
+	MainStreamLogFormat           string
 	ProxyBuffering                bool
 	ProxyBuffers                  string
 	ProxyBufferSize               string
@@ -259,6 +260,9 @@ func ParseConfigMap(cfgm *api_v1.ConfigMap, nginxPlus bool) *Config {
 
 	if logFormat, exists := cfgm.Data["log-format"]; exists {
 		cfg.MainLogFormat = logFormat
+	}
+	if streamLogFormat, exists := cfgm.Data["stream-log-format"]; exists {
+		cfg.MainStreamLogFormat = streamLogFormat
 	}
 	if proxyBuffering, exists, err := GetMapKeyAsBool(cfgm.Data, "proxy-buffering", cfgm); exists {
 		if err != nil {

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -1082,6 +1082,7 @@ func GenerateNginxMainConfig(config *Config) *NginxMainConfig {
 	nginxCfg := &NginxMainConfig{
 		MainSnippets:              config.MainMainSnippets,
 		HTTPSnippets:              config.MainHTTPSnippets,
+		StreamSnippets:            config.MainStreamSnippets,
 		ServerNamesHashBucketSize: config.MainServerNamesHashBucketSize,
 		ServerNamesHashMaxSize:    config.MainServerNamesHashMaxSize,
 		LogFormat:                 config.MainLogFormat,

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -1086,6 +1086,7 @@ func GenerateNginxMainConfig(config *Config) *NginxMainConfig {
 		ServerNamesHashBucketSize: config.MainServerNamesHashBucketSize,
 		ServerNamesHashMaxSize:    config.MainServerNamesHashMaxSize,
 		LogFormat:                 config.MainLogFormat,
+		StreamLogFormat:           config.MainStreamLogFormat,
 		SSLProtocols:              config.MainServerSSLProtocols,
 		SSLCiphers:                config.MainServerSSLCiphers,
 		SSLDHParam:                config.MainServerSSLDHParam,

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -142,6 +142,7 @@ type NginxMainConfig struct {
 	ServerNamesHashBucketSize string
 	ServerNamesHashMaxSize    string
 	LogFormat                 string
+	StreamLogFormat           string
 	HealthStatus              bool
 	MainSnippets              []string
 	HTTPSnippets              []string

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -145,6 +145,7 @@ type NginxMainConfig struct {
 	HealthStatus              bool
 	MainSnippets              []string
 	HTTPSnippets              []string
+	StreamSnippets            []string
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html
 	SSLProtocols           string
 	SSLPreferServerCiphers bool

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -110,6 +110,16 @@ http {
 }
 
 stream {
+    {{if .StreamLogFormat -}}
+    log_format  stream-main  '{{.StreamLogFormat}}';
+    {{- else -}}
+    log_format  stream-main  '$remote_addr [$time_local] '
+                      '$protocol $status $bytes_sent $bytes_received '
+                      '$session_time';
+    {{- end }}
+
+    access_log  /var/log/nginx/stream-access.log  stream-main;
+
     {{range $value := .StreamSnippets}}
     {{$value}}
     {{end}} 

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -108,3 +108,9 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
 }
+
+stream {
+    {{range $value := .StreamSnippets}}
+    {{$value}}
+    {{end}} 
+}

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -86,6 +86,16 @@ http {
 }
 
 stream {
+    {{if .StreamLogFormat -}}
+    log_format  stream-main  '{{.StreamLogFormat}}';
+    {{- else -}}
+    log_format  stream-main  '$remote_addr [$time_local] '
+                      '$protocol $status $bytes_sent $bytes_received '
+                      '$session_time';
+    {{- end }}
+
+    access_log  /var/log/nginx/stream-access.log  stream-main;
+
     {{range $value := .StreamSnippets}}
     {{$value}}
     {{end}} 

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -84,3 +84,9 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
 }
+
+stream {
+    {{range $value := .StreamSnippets}}
+    {{$value}}
+    {{end}} 
+}

--- a/nginx-controller/nginx/templates/templates_test.go
+++ b/nginx-controller/nginx/templates/templates_test.go
@@ -89,6 +89,7 @@ var mainCfg = nginx.NginxMainConfig{
 	WorkerConnections:      "1024",
 	WorkerRlimitNofile:     "65536",
 	StreamSnippets:         []string{"# comment"},
+	StreamLogFormat:        "$remote_addr",
 }
 
 func TestIngressForNGINXPlus(t *testing.T) {

--- a/nginx-controller/nginx/templates/templates_test.go
+++ b/nginx-controller/nginx/templates/templates_test.go
@@ -88,6 +88,7 @@ var mainCfg = nginx.NginxMainConfig{
 	WorkerShutdownTimeout:  "1m",
 	WorkerConnections:      "1024",
 	WorkerRlimitNofile:     "65536",
+	StreamSnippets:         []string{"# comment"},
 }
 
 func TestIngressForNGINXPlus(t *testing.T) {


### PR DESCRIPTION
### Proposed changes
This PR introduces two ConfigMap keys:
- `stream-snippets`, which sets a custom snippet in stream context.
- `stream-log-format`, which sets a custom log format for TCP/UDP load balancing in stream context.

With `stream-snippets` it is possible to support TCP or UPD load balancing:

For NGINX OSS:
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: nginx-config
  namespace: nginx-ingress
data:
    stream-snippets: |
      upstream tcp-coffee {
          server coffee-svc.default.svc.cluster.local:80;
      }

      server {
          listen 4455;
          proxy_pass tcp-coffee;
      }

      upstream tcp-tea {
          server tea-svc.default.svc.cluster.local:80;
      }

      server {
          listen 4456;
          proxy_pass tcp-tea;
      }
```
Notes for NGINX:
* If a DNS name such as `coffee-svc.default.svc.cluster.local` cannot be resolved, NGINX will fail to reload
* NGINX resolves a DNS name only once. The next time the name will be resolved is during the next config reload.

For NGINX Plus:
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: nginx-config
  namespace: nginx-ingress
data:
    stream-snippets: |
      resolver kube-dns.kube-system.svc.cluster.local valid=5s;

      upstream tcp-coffee {
          zone tcp-coffee 64k;
          server coffee-svc.default.svc.cluster.local service=_http._tcp resolve;
      }

      server {
          listen 4455;
          proxy_pass tcp-coffee;
          status_zone coffee-stream;
      }

      upstream tcp-tea {
          zone tcp-tea 64k;
          server tea-svc.default.svc.cluster.local service=_http._tcp resolve;
      }

      server {
          listen 4456;
          proxy_pass tcp-tea;
          status_zone tea-stream;
      }
```
Notes for NGINX Plus:  
* Here were use dynamic DNS service discovery and port discovery via SRV records. See https://www.nginx.com/blog/dns-service-discovery-nginx-plus/
* To make NGINX Plus discover all the IP addresses of pods instead of the virtual IP of a service, create the service as headless. See https://kubernetes.io/docs/concepts/services-networking/service/#headless-services and https://www.nginx.com/blog/load-balancing-kubernetes-services-nginx-plus/

To apply the ConfigMap run:
```
$ kubectl apply -f nginx-config.yaml
```
You can also check if the config was applied successfully:
```
$  kubectl describe configmap nginx-config -n nginx-ingress
. . .
Events:
  Type    Reason   Age                From                      Message
  ----    ------   ----               ----                      -------
  Normal  Updated  17s (x2 over 28s)  nginx-ingress-controller  Configuration from nginx-ingress/nginx-config was updated
```


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
