### PR TITLE
add log-level to the templates in order to injecting the log level from config map

### DIFF
--- a/examples/customization/README.md
+++ b/examples/customization/README.md
@@ -23,6 +23,7 @@ The table below summarizes all of the options. For some of them, there are examp
 | N/A | `http2` | Enables HTTP/2 in servers with SSL enabled. | `False` |
 | `nginx.org/redirect-to-https` | `redirect-to-https` | Sets the 301 redirect rule based on the value of the `http_x_forwarded_proto` header on the server block to force incoming traffic to be over HTTPS. Useful when terminating SSL in a load balancer in front of the Ingress controller — see [115](https://github.com/nginxinc/kubernetes-ingress/issues/115) | `False` | |
 | `ingress.kubernetes.io/ssl-redirect` | `ssl-redirect` | Sets an unconditional 301 redirect rule for all incoming HTTP traffic to force incoming traffic over HTTPS. | `True` | |
+| N/A | `error-log-level` | Sets the global [error log level](http://nginx.org/en/docs/ngx_core_module.html#error_log) for NGINX.  | `notice` | |
 | N/A | `log-format` | Sets the custom [log format](http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format).  | See the [template file](../../nginx-controller/nginx/nginx.conf.tmpl). | |
 | `nginx.org/hsts` | `hsts` | Enables [HTTP Strict Transport Security (HSTS)](https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/): the HSTS header is added to the responses from backends. The `preload` directive is included in the header. | `False` | |
 | `nginx.org/hsts-max-age` | `hsts-max-age` | Sets the value of the `max-age` directive of the HSTS header. | `2592000` (1 month) |

--- a/examples/customization/nginx-config.yaml
+++ b/examples/customization/nginx-config.yaml
@@ -57,6 +57,7 @@ data:
   keepalive: "32" # default is 0. When > 0, sets the value of the keepalive directive and adds 'proxy_set_header Connection "";' to a location block. See http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
   max-fails: "0" # default is 1. Sets the value of the max_fails parameter of the `server` directive. See https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_fails
   fail-timeout: "5s" # default is 10s. Sets the value of the fail_timeout parameter of the `server` directive. See https://nginx.org/en/docs/http/ngx_http_upstream_module.html#fail_timeout
+  error-log-level: "crit" # default is "notice". Sets the value of the error-log-level directive. Can be debug, info, notice, warn, error, crit, alert, or emerg. See http://nginx.org/en/docs/ngx_core_module.html#error_log
   stream-log-format: "$remote_addr $protocol" # stream-log-format default is set in the nginx.conf.tmpl file. Also see http://nginx.org/en/docs/stream/ngx_stream_log_module.html#log_format 
   stream-snippets: |
     upstream tcp-coffee {

--- a/nginx-controller/nginx/config.go
+++ b/nginx-controller/nginx/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	MainServerNamesHashBucketSize string
 	MainServerNamesHashMaxSize    string
 	MainLogFormat                 string
+	MainErrorLogLevel             string
 	MainStreamLogFormat           string
 	ProxyBuffering                bool
 	ProxyBuffers                  string
@@ -92,6 +93,7 @@ func NewDefaultConfig() *Config {
 		MaxFails:                   1,
 		FailTimeout:                "10s",
 		LBMethod:                   "least_conn",
+		MainErrorLogLevel:          "notice",
 	}
 }
 
@@ -257,7 +259,9 @@ func ParseConfigMap(cfgm *api_v1.ConfigMap, nginxPlus bool) *Config {
 		sslDHParamFile = strings.Trim(sslDHParamFile, "\n")
 		cfg.MainServerSSLDHParamFileContent = &sslDHParamFile
 	}
-
+	if errorLogLevel, exists := cfgm.Data["error-log-level"]; exists {
+		cfg.MainErrorLogLevel = errorLogLevel
+	}
 	if logFormat, exists := cfgm.Data["log-format"]; exists {
 		cfg.MainLogFormat = logFormat
 	}

--- a/nginx-controller/nginx/configurator.go
+++ b/nginx-controller/nginx/configurator.go
@@ -1086,6 +1086,7 @@ func GenerateNginxMainConfig(config *Config) *NginxMainConfig {
 		ServerNamesHashBucketSize: config.MainServerNamesHashBucketSize,
 		ServerNamesHashMaxSize:    config.MainServerNamesHashMaxSize,
 		LogFormat:                 config.MainLogFormat,
+		ErrorLogLevel:             config.MainErrorLogLevel,
 		StreamLogFormat:           config.MainStreamLogFormat,
 		SSLProtocols:              config.MainServerSSLProtocols,
 		SSLCiphers:                config.MainServerSSLCiphers,

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -142,6 +142,7 @@ type NginxMainConfig struct {
 	ServerNamesHashBucketSize string
 	ServerNamesHashMaxSize    string
 	LogFormat                 string
+	ErrorLogLevel             string
 	StreamLogFormat           string
 	HealthStatus              bool
 	MainSnippets              []string

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -10,7 +10,7 @@ worker_shutdown_timeout {{.WorkerShutdownTimeout}};{{end}}
 
 daemon off;
 
-error_log  /var/log/nginx/error.log notice;
+error_log  /var/log/nginx/error.log {{.ErrorLogLevel}};
 pid        /var/run/nginx.pid;
 
 {{- if .MainSnippets}}

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -9,7 +9,7 @@ worker_cpu_affinity {{.WorkerCPUAffinity}};{{end}}
 worker_shutdown_timeout {{.WorkerShutdownTimeout}};{{end}}
 daemon off;
 
-error_log  /var/log/nginx/error.log warn;
+error_log  /var/log/nginx/error.log {{.ErrorLogLevel}};
 pid        /var/run/nginx.pid;
 
 {{- if .MainSnippets}}


### PR DESCRIPTION
### Proposed changes
The log level in NGINX templates was hard coded. This PR allows you to inject the log level from K8s config map. The default value will be "notice". I also updated the example config. Tested and works well in K8s. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [✔] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [✔] I have added tests that prove my fix is effective or that my feature works
- [✔] I have checked that all unit tests pass after adding my changes
- [✔] I have updated necessary documentation
- [✔] I have rebased my branch onto master
- [✔] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
