### PR TITLE
Expose API/stub_status on a custom port

### DIFF
--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -42,7 +42,7 @@ Usage of ./nginx-ingress:
   -nginx-status
     	Enable the NGINX stub_status, or the NGINX Plus API. (default true)
   -nginx-status-port int
-    	Set the port where the NGINX stub_status or the NGINX Plus API is exposed. Cannot be 80 or 443. (default 8080)
+    	Set the port where the NGINX stub_status or the NGINX Plus API is exposed. [1023 - 65535] (default 8080)
   -proxy string
         Use a proxy server to connect to Kubernetes API started by "kubectl proxy" command. For testing purposes only.
         The Ingress controller does not start NGINX and does not write any generated NGINX configuration files to disk

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -39,6 +39,10 @@ Usage of ./nginx-ingress:
 	Format: <namespace>/<name>
   -nginx-plus
     	Enable support for NGINX Plus
+  -nginx-status
+    	Enable the NGINX stub_status, or the NGINX Plus API. (default true)
+  -nginx-status-port int
+    	Set the port where the NGINX stub_status or the NGINX Plus API is exposed. Cannot be 80 or 443. (default 8080)
   -proxy string
         Use a proxy server to connect to Kubernetes API started by "kubectl proxy" command. For testing purposes only.
         The Ingress controller does not start NGINX and does not write any generated NGINX configuration files to disk

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -144,10 +144,21 @@ The public IP can be reported in the status of an ingress resource. To enable:
 
 Read more about the type LoadBalancer [here](https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer).
 
-## 5. Access the Live Activity Monitoring Dashboard
+## 5. Access the Live Activity Monitoring Dashboard / Stub_status Page
+For NGINX, you can access the [stub_status page](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html):
+1. Stub_status is enabled by default. Ensure that the `nginx-status` command-line argument is not set to false.
+2. Stub_status is available on port 8080 by default. It is customizable by the `nginx-status-port` command-line argument. If yours is not on 8080, modify the kubectl proxy command below.
+1. Use the `kubectl port-forward` command to forward connections to port 8080 on your local machine to port 8080 of an NGINX Ingress controller pod (replace `<nginx-ingress-pod>` with the actual name of a pod):.
+    ```
+    $ kuebctl port-forward <nginx-ingress-pod> 8080:8080 --namespace=nginx-ingress
+    ```
+Open your browser at http://127.0.0.1:8080/stub_status to access the status.
+
 
 For NGINX Plus, you can access the live activity monitoring dashboard:
-1. Use `kubectl port-forward` command to forward connections to port 8080 on your local machine to port 8080 of an NGINX Plus Ingress controller pod (replace <nginx-plus-ingress-pod> with the actual name of a pod):
+1. The dashboard is enabled by default. Ensure that the `nginx-status` command-line argument is not set to false.
+1. The dashboard is available on port 8080 by default. It is customizable by the `nginx-status-port` command-line argument. If yours is not on 8080, modify the kubectl proxy command below.
+1. Use the `kubectl port-forward` command to forward connections to port 8080 on your local machine to port 8080 of an NGINX Plus Ingress controller pod (replace `<nginx-plus-ingress-pod>` with the actual name of a pod):
     ```
     $ kubectl port-forward <nginx-plus-ingress-pod> 8080:8080 --namespace=nginx-ingress
     ```

--- a/examples/complete-example/README.md
+++ b/examples/complete-example/README.md
@@ -55,7 +55,7 @@ certificate and the --resolve option to set the Host header of a request with ``
     Server name: tea-7cd44fcb4d-xfw2x
     ...
     ```
-    
-1. If you're using NGINX Plus, you can open the live activity monitoring dashboard:
-    1. Follow the [instructions](../../docs/installation.md#5-access-the-live-activity-monitoring-dashboard) to access the dashboard. 
-    1. If you go to the Upstream tab, you'll see: ![dashboard](dashboard.png)
+
+1. You can view an NGINX status page, either stub_status for NGINX, or the Live Activity Monitoring Dashboard for NGINX Plus:
+    1. Follow the [instructions](../../docs/installation.md#5-access-the-live-activity-monitoring-dashboard--stub_status-page) to access the status page.
+    1. For NGINX Plus, If you go to the Upstream tab, you'll see: ![dashboard](dashboard.png)

--- a/nginx-controller/controller/controller_test.go
+++ b/nginx-controller/controller/controller_test.go
@@ -926,7 +926,7 @@ func TestFindIngressesForSecret(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset()
 
-			templateExecutor, err := nginx.NewTemplateExecutor("../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl", true)
+			templateExecutor, err := nginx.NewTemplateExecutor("../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl", true, true, 8080)
 			if err != nil {
 				t.Fatalf("templateExecuter could not start: %v", err)
 			}

--- a/nginx-controller/main.go
+++ b/nginx-controller/main.go
@@ -82,7 +82,7 @@ The external address of the service is used when reporting the status of Ingress
 		"Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources -- only one replica will report status. See -report-ingress-status flag.")
 
 	nginxStatusPort = flag.Int("nginx-status-port", 8080,
-		"Set the port where the NGINX stub_status or the NGINX Plus API is exposed. Cannot be 80 or 443.")
+		"Set the port where the NGINX stub_status or the NGINX Plus API is exposed. [1023 - 65535]")
 
 	nginxStatus = flag.Bool("nginx-status", true,
 		"Enable the NGINX stub_status, or the NGINX Plus API.")
@@ -300,9 +300,6 @@ func getSocketClient() http.Client {
 }
 
 func validateStatusPort(nginxStatusPort int) error {
-	if nginxStatusPort == 80 || nginxStatusPort == 443 {
-		return fmt.Errorf("ports 80 and 443 are forbidden: %v", nginxStatusPort)
-	}
 	if nginxStatusPort < 1023 || nginxStatusPort > 65535 {
 		return fmt.Errorf("port outside of valid port range [1023 - 65535]: %v", nginxStatusPort)
 	}

--- a/nginx-controller/main_test.go
+++ b/nginx-controller/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestValidateStatusPort(t *testing.T) {
+	badPorts := []int{80, 443, 1, 1022, 65536}
+	for _, badPort := range badPorts {
+		err := validateStatusPort(badPort)
+		if err == nil {
+			t.Errorf("Expected error for port %v\n", badPort)
+		}
+	}
+
+	goodPorts := []int{8080, 8081, 8082, 1023, 65535}
+	for _, goodPort := range goodPorts {
+		err := validateStatusPort(goodPort)
+		if err != nil {
+			t.Errorf("Error for valid port:  %v err: %v\n", goodPort, err)
+		}
+	}
+
+}

--- a/nginx-controller/nginx/configurator_test.go
+++ b/nginx-controller/nginx/configurator_test.go
@@ -483,7 +483,7 @@ func createExpectedConfigForMergeableCafeIngress() IngressNginxConfig {
 }
 
 func createTestConfigurator() *Configurator {
-	templateExecutor, _ := NewTemplateExecutor("templates/nginx-plus.tmpl", "templates/nginx-plus.ingress.tmpl", true)
+	templateExecutor, _ := NewTemplateExecutor("templates/nginx-plus.tmpl", "templates/nginx-plus.ingress.tmpl", true, true, 8080)
 	ngxc := NewNginxController("/etc/nginx", true)
 	apiCtrl, _ := plus.NewNginxAPIController(&http.Client{}, "", true)
 	return NewConfigurator(ngxc, NewDefaultConfig(), apiCtrl, templateExecutor)

--- a/nginx-controller/nginx/nginx.go
+++ b/nginx-controller/nginx/nginx.go
@@ -145,6 +145,8 @@ type NginxMainConfig struct {
 	ErrorLogLevel             string
 	StreamLogFormat           string
 	HealthStatus              bool
+	NginxStatus               bool
+	NginxStatusPort           int
 	MainSnippets              []string
 	HTTPSnippets              []string
 	StreamSnippets            []string

--- a/nginx-controller/nginx/template_executor.go
+++ b/nginx-controller/nginx/template_executor.go
@@ -9,12 +9,14 @@ import (
 // TemplateExecutor executes NGINX configuration templates
 type TemplateExecutor struct {
 	HealthStatus    bool
+	NginxStatus     bool
+	NginxStatusPort int
 	mainTemplate    *template.Template
 	ingressTemplate *template.Template
 }
 
 // NewTemplateExecutor creates a TemplateExecutor
-func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, healthStatus bool) (*TemplateExecutor, error) {
+func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, healthStatus bool, nginxStatus bool, nginxStatusPort int) (*TemplateExecutor, error) {
 	// template name must be the base name of the template file https://golang.org/pkg/text/template/#Template.ParseFiles
 	nginxTemplate, err := template.New(path.Base(mainTemplatePath)).ParseFiles(mainTemplatePath)
 	if err != nil {
@@ -26,7 +28,13 @@ func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, he
 		return nil, err
 	}
 
-	return &TemplateExecutor{mainTemplate: nginxTemplate, ingressTemplate: ingressTemplate, HealthStatus: healthStatus}, nil
+	return &TemplateExecutor{
+		mainTemplate:    nginxTemplate,
+		ingressTemplate: ingressTemplate,
+		HealthStatus:    healthStatus,
+		NginxStatus:     nginxStatus,
+		NginxStatusPort: nginxStatusPort,
+	}, nil
 }
 
 // UpdateMainTemplate updates the main NGINX template
@@ -54,6 +62,8 @@ func (te *TemplateExecutor) UpdateIngressTemplate(templateString *string) error 
 // ExecuteMainConfigTemplate generates the content of the main NGINX configuration file
 func (te *TemplateExecutor) ExecuteMainConfigTemplate(cfg *NginxMainConfig) ([]byte, error) {
 	cfg.HealthStatus = te.HealthStatus
+	cfg.NginxStatus = te.NginxStatus
+	cfg.NginxStatusPort = te.NginxStatusPort
 
 	var configBuffer bytes.Buffer
 	err := te.mainTemplate.Execute(&configBuffer, cfg)

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -101,8 +101,6 @@ http {
         deny all;
 
         location /api {
-            limit_except GET {
-            }
             api write=off;
         }
     }

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -84,14 +84,11 @@ http {
            return 404;
         }
     }
-  
+
+    {{- if .NginxStatus }}
     # NGINX Plus APIs
     server {
-        {{- if .NginxStatus }}
         listen {{.NginxStatusPort}};
-        {{- else }}
-        listen unix:/var/run/nginx.sock;
-        {{- end }}
 
         root /usr/share/nginx/html;
 
@@ -101,12 +98,18 @@ http {
         }
 
         location /api {
-            {{- if .NginxStatus }}
-            limit_except GET {
-                allow 127.0.0.1;
-                deny all;
-            }
-            {{- end }}
+            api write=off;
+        }
+    }
+    {{- end }}
+
+    # NGINX Plus API over unix socket
+    server {
+        listen unix:/var/run/nginx-plus-api.sock;
+        root /usr/share/nginx/html;
+        access_log off;
+
+        location /api {
             api write=on;
         }
     }

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -85,10 +85,13 @@ http {
         }
     }
   
-
     # NGINX Plus APIs
     server {
-        listen 8080;
+        {{- if .NginxStatus }}
+        listen {{.NginxStatusPort}};
+        {{- else }}
+        listen unix:/var/run/nginx.sock;
+        {{- end }}
 
         root /usr/share/nginx/html;
 
@@ -98,10 +101,12 @@ http {
         }
 
         location /api {
+            {{- if .NginxStatus }}
             limit_except GET {
                 allow 127.0.0.1;
                 deny all;
             }
+            {{- end }}
             api write=on;
         }
     }

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -97,10 +97,11 @@ http {
         location  = /dashboard.html {
         }
 
+        allow 127.0.0.1;
+        deny all;
+
         location /api {
             limit_except GET {
-                allow 127.0.0.1;
-                deny all;
             }
             api write=off;
         }

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -98,6 +98,10 @@ http {
         }
 
         location /api {
+            limit_except GET {
+                allow 127.0.0.1;
+                deny all;
+            }
             api write=off;
         }
     }
@@ -106,7 +110,6 @@ http {
     # NGINX Plus API over unix socket
     server {
         listen unix:/var/run/nginx-plus-api.sock;
-        root /usr/share/nginx/html;
         access_log off;
 
         location /api {

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -82,20 +82,18 @@ http {
         }
     }
 
+    {{- if .NginxStatus }}
     # stub_status
     server {
-        {{- if .NginxStatus }}
         listen {{.NginxStatusPort}};
-        {{- else }}
         listen unix:/var/run/nginx.sock;
-        {{- end }}
 
         location /nginx_status {
             stub_status;
-            allow 127.0.0.1;
-            deny all;
         }
     }
+    {{- end }}
+
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -87,10 +87,11 @@ http {
     server {
         listen {{.NginxStatusPort}};
 
-        location /nginx_status {
+        allow 127.0.0.1;
+        deny all;
+
+        location /stub_status {
             limit_except GET {
-                allow 127.0.0.1;
-                deny all;
             }
             stub_status;
         }

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -91,8 +91,6 @@ http {
         deny all;
 
         location /stub_status {
-            limit_except GET {
-            }
             stub_status;
         }
     }

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -82,6 +82,21 @@ http {
         }
     }
 
+    # stub_status
+    server {
+        {{- if .NginxStatus }}
+        listen {{.NginxStatusPort}};
+        {{- else }}
+        listen unix:/var/run/nginx.sock;
+        {{- end }}
+
+        location /nginx_status {
+            stub_status;
+            allow 127.0.0.1;
+            deny all;
+        }
+    }
+
     include /etc/nginx/conf.d/*.conf;
 }
 

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -86,9 +86,12 @@ http {
     # stub_status
     server {
         listen {{.NginxStatusPort}};
-        listen unix:/var/run/nginx.sock;
 
         location /nginx_status {
+            limit_except GET {
+                allow 127.0.0.1;
+                deny all;
+            }
             stub_status;
         }
     }


### PR DESCRIPTION
NGINX Plus will listen on a socket, `/var/run/nginx-plus-api.sock`, so the Ingress Controller can still connect to modify upstream servers when the API is disabled.

Adds command-line arguments:
- `-nginx-status` to enable/disable status & stub_status
- `-nginx-status-port` the port

Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
