### PR TITLE
Allow the http2 directive for non-SSL ports

### DIFF
--- a/nginx-controller/nginx/templates/nginx-plus.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.ingress.tmpl
@@ -22,7 +22,7 @@ upstream {{$upstream.Name}} {
 server {
 	{{if not $server.GRPCOnly}}
 	{{range $port := $server.Ports}}
-	listen {{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	listen {{$port}}{{if $server.HTTP2}} http2{{end}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
 	{{- end}}
 	{{end}}
 	{{if $server.SSL}}

--- a/nginx-controller/nginx/templates/nginx-plus.tmpl
+++ b/nginx-controller/nginx/templates/nginx-plus.tmpl
@@ -63,7 +63,7 @@ http {
 
  
     server {
-        listen 80 default_server{{if .ProxyProtocol}} proxy_protocol{{end}};
+        listen 80 default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};
         listen 443 ssl default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};
 
         ssl_certificate /etc/nginx/secrets/default;

--- a/nginx-controller/nginx/templates/nginx.ingress.tmpl
+++ b/nginx-controller/nginx/templates/nginx.ingress.tmpl
@@ -11,7 +11,7 @@ upstream {{$upstream.Name}} {
 server {
 	{{if not $server.GRPCOnly}}
 	{{range $port := $server.Ports}}
-	listen {{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	listen {{$port}}{{if $server.HTTP2}} http2{{end}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
 	{{- end}}
 	{{end}}
 	{{if $server.SSL}}

--- a/nginx-controller/nginx/templates/nginx.tmpl
+++ b/nginx-controller/nginx/templates/nginx.tmpl
@@ -60,7 +60,7 @@ http {
     {{if .SSLDHParam}}ssl_dhparam {{.SSLDHParam}};{{end}}
 
     server {
-        listen 80 default_server{{if .ProxyProtocol}} proxy_protocol{{end}};
+        listen 80 default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};
         listen 443 ssl default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};
 
         ssl_certificate /etc/nginx/secrets/default;


### PR DESCRIPTION
### Proposed changes
Currently the `http2` directive only gets added to SSL ports; this change will also add the directive to non-SSL ports if the ConfigMap value has been set.

I saw that this feature was added for SSL ports in #65, but didn't see a reason why it was not enabled for normal ports as well. Seems to me like a trivial change, but, if for some reason this was excluded deliberately, feel free to close.