### PR TITLE
Make socket address obvious

### DIFF
--- a/nginx-controller/main.go
+++ b/nginx-controller/main.go
@@ -220,8 +220,7 @@ func main() {
 	if *nginxPlus {
 		time.Sleep(500 * time.Millisecond)
 		httpClient := getSocketClient()
-		apiURL := fmt.Sprintf("http://127.0.0.1:%v/api", *nginxStatusPort)
-		nginxAPI, err = plus.NewNginxAPIController(&httpClient, apiURL, local)
+		nginxAPI, err = plus.NewNginxAPIController(&httpClient, "http://nginx-plus-api/api", local)
 		if err != nil {
 			glog.Fatalf("Failed to create NginxAPIController: %v", err)
 		}


### PR DESCRIPTION
We don't need a valid http host for the nginx api when we use a socket.
The host is ignored. This change makes it more obvious that the host is
unnecessary.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
