### PR TITLE
Reduce reloads

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -278,7 +278,7 @@ func (lbc *LoadBalancerController) syncEndpoint(task queue.Task) {
 		ings := lbc.getIngressForEndpoints(obj)
 
 		var ingExes []*nginx.IngressEx
-		var mergableIngresses []*nginx.MergeableIngresses
+		var mergableIngressesBatch []*nginx.MergeableIngresses
 
 		for i := range ings {
 			if !lbc.isNginxIngress(&ings[i]) {
@@ -299,7 +299,7 @@ func (lbc *LoadBalancerController) syncEndpoint(task queue.Task) {
 					continue
 				}
 
-				mergableIngExes = append(mergableIngExes, mergableIngresses)
+				mergableIngressesBatch = append(mergableIngressesBatch, mergeableIngresses)
 				continue
 			}
 			if !lbc.cnf.HasIngress(&ings[i]) {
@@ -322,10 +322,10 @@ func (lbc *LoadBalancerController) syncEndpoint(task queue.Task) {
 		if err != nil {
 			glog.Errorf("Error updating endpoints for %v: %v", ingExes, err)
 		}
-		glog.V(3).Infof("Updating Endpoints for %v", mergableIngresses)
-		// TODO FIX err = lbc.cnf.UpdateEndpointsMergeableIngress(mergeableIngresses)
+		glog.V(3).Infof("Updating Endpoints for %v", mergableIngressesBatch)
+		err = lbc.cnf.UpdateEndpointsMergeableIngress(mergableIngressesBatch)
 		if err != nil {
-			glog.Errorf("Error updating endpoints for %v/%v: %v", ing.Namespace, ing.Name, err)
+			glog.Errorf("Error updating endpoints for %v: %v", mergableIngressesBatch, err)
 		}
 	}
 }

--- a/internal/nginx/configurator.go
+++ b/internal/nginx/configurator.go
@@ -962,27 +962,37 @@ func (cnf *Configurator) DeleteIngress(key string) error {
 	return nil
 }
 
-// UpdateEndpoints updates endpoints in NGINX configuration for the Ingress resource
-func (cnf *Configurator) UpdateEndpoints(ingEx *IngressEx) error {
-	err := cnf.addOrUpdateIngress(ingEx)
-	if err != nil {
-		return fmt.Errorf("Error adding or updating ingress %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+// UpdateEndpoints updates endpoints in NGINX configuration for the Ingress resources
+func (cnf *Configurator) UpdateEndpoints(ingExes []*IngressEx) error {
+	reloadPlus := false
+
+	for _, ingEx := range ingExes {
+		err := cnf.addOrUpdateIngress(ingEx)
+		if err != nil {
+			return fmt.Errorf("Error adding or updating ingress %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+		}
+
+		if cnf.isPlus() {
+			err := cnf.updatePlusEndpoints(ingEx)
+			if err != nil {
+				glog.Warningf("Couldn't update the endpoints via the API: %v; reloading configuration instead", err)
+				reloadPlus = true
+			}
+		}
 	}
 
-	if cnf.isPlus() {
-		err = cnf.updatePlusEndpoints(ingEx)
-		if err == nil {
-			return nil
-		}
-		glog.Warningf("Couldn't update the endpoints via the API: %v; reloading configuration instead", err)
+	if cnf.isPlus() && !reloadPlus {
+		return nil
 	}
+
 	if err := cnf.nginx.Reload(); err != nil {
-		return fmt.Errorf("Error reloading NGINX when updating endpoints for %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+		return fmt.Errorf("Error reloading NGINX when updating endpoints: %v", err)
 	}
 
 	return nil
 }
 
+// TODO FIX
 // UpdateEndpointsMergeableIngress updates endpoints in NGINX configuration for a mergeable Ingress resource
 func (cnf *Configurator) UpdateEndpointsMergeableIngress(mergeableIngs *MergeableIngresses) error {
 	err := cnf.addOrUpdateMergeableIngress(mergeableIngs)

--- a/internal/nginx/configurator_test.go
+++ b/internal/nginx/configurator_test.go
@@ -718,14 +718,15 @@ func TestUpdateEndpoints(t *testing.T) {
 	}
 
 	ingress := createCafeIngressEx()
-	err = cnf.UpdateEndpoints(&ingress)
+	ingresses := []*IngressEx{&ingress}
+	err = cnf.UpdateEndpoints(ingresses)
 	if err != nil {
 		t.Errorf("UpdateEndpoints returned\n%v, but expected \n%v", err, nil)
 	}
 
 	// test with OSS Configurator
 	cnf.nginxAPI = nil
-	err = cnf.UpdateEndpoints(&ingress)
+	err = cnf.UpdateEndpoints(ingresses)
 	if err != nil {
 		t.Errorf("UpdateEndpoints returned\n%v, but expected \n%v", err, nil)
 	}
@@ -738,14 +739,15 @@ func TestUpdateEndpointsMergeableIngress(t *testing.T) {
 	}
 
 	mergeableIngress := createMergeableCafeIngress()
-	err = cnf.UpdateEndpointsMergeableIngress(mergeableIngress)
+	mergeableIngresses := []*MergeableIngresses{mergeableIngress}
+	err = cnf.UpdateEndpointsMergeableIngress(mergeableIngresses)
 	if err != nil {
 		t.Errorf("UpdateEndpointsMergeableIngress returned \n%v, but expected \n%v", err, nil)
 	}
 
 	// test with OSS Configurator
 	cnf.nginxAPI = nil
-	err = cnf.UpdateEndpointsMergeableIngress(mergeableIngress)
+	err = cnf.UpdateEndpointsMergeableIngress(mergeableIngresses)
 	if err != nil {
 		t.Errorf("UpdateEndpointsMergeableIngress returned \n%v, but expected \n%v", err, nil)
 	}
@@ -758,7 +760,8 @@ func TestUpdateEndpointsFailsWithInvalidTemplate(t *testing.T) {
 	}
 
 	ingress := createCafeIngressEx()
-	err = cnf.UpdateEndpoints(&ingress)
+	ingresses := []*IngressEx{&ingress}
+	err = cnf.UpdateEndpoints(ingresses)
 	if err == nil {
 		t.Errorf("UpdateEndpoints returned\n%v, but expected \n%v", nil, "template execution error")
 	}
@@ -771,7 +774,8 @@ func TestUpdateEndpointsMergeableIngressFailsWithInvalidTemplate(t *testing.T) {
 	}
 
 	mergeableIngress := createMergeableCafeIngress()
-	err = cnf.UpdateEndpointsMergeableIngress(mergeableIngress)
+	mergeableIngresses := []*MergeableIngresses{mergeableIngress}
+	err = cnf.UpdateEndpointsMergeableIngress(mergeableIngresses)
 	if err == nil {
 		t.Errorf("UpdateEndpointsMergeableIngress returned \n%v, but expected \n%v", nil, "template execution error")
 	}

--- a/internal/nginx/ingress.go
+++ b/internal/nginx/ingress.go
@@ -1,6 +1,8 @@
 package nginx
 
 import (
+	"fmt"
+
 	api_v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 )
@@ -59,4 +61,12 @@ var minionInheritanceList = map[string]bool{
 	"nginx.org/keepalive":                true,
 	"nginx.org/max-fails":                true,
 	"nginx.org/fail-timeout":             true,
+}
+
+func (ingEx *IngressEx) String() string {
+	if ingEx.Ingress == nil {
+		return "IngressEx has no Ingress"
+	}
+
+	return fmt.Sprintf("%v/%v", ingEx.Ingress.Namespace, ingEx.Ingress.Name)
 }


### PR DESCRIPTION
Reduce the number of reloads for endpoint changes by batching the ingresses to be updated, writing the config files and (in the case of Plus) updating UpstreamServers via the API, before finally reloading NGINX at the end.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
