### PR TITLE
Don't enqueue ingress for some service changes

### DIFF
--- a/internal/handlers/service_test.go
+++ b/internal/handlers/service_test.go
@@ -139,9 +139,9 @@ func TestHasServicePortChanges(t *testing.T) {
 				Port: 80,
 			}},
 			[]v1.ServicePort{{
-				Name: "foo",
-			}, {
 				Port: 80,
+			}, {
+				Name: "foo",
 			}},
 			false,
 			"Some names some ports",
@@ -150,7 +150,7 @@ func TestHasServicePortChanges(t *testing.T) {
 
 	for _, c := range cases {
 		if c.result != hasServicePortChanges(c.a, c.b) {
-			t.Error(c.reason)
+			t.Errorf("hasServicePortChanges returned %v, but expected %v for %q case", c.result, !c.result, c.reason)
 		}
 	}
 }

--- a/internal/handlers/service_test.go
+++ b/internal/handlers/service_test.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestHasServicePortChanges(t *testing.T) {
+	cases := []struct {
+		a      []v1.ServicePort
+		b      []v1.ServicePort
+		result bool
+		reason string
+	}{
+		{
+			[]v1.ServicePort{},
+			[]v1.ServicePort{},
+			false,
+			"Empty should report no changes",
+		},
+		{
+			[]v1.ServicePort{{
+				Port: 80,
+			}},
+			[]v1.ServicePort{{
+				Port: 8080,
+			}},
+			true,
+			"Different Ports",
+		},
+		{
+			[]v1.ServicePort{{
+				Port: 80,
+			}},
+			[]v1.ServicePort{{
+				Port: 80,
+			}},
+			false,
+			"Same Ports",
+		},
+		{
+			[]v1.ServicePort{{
+				Name: "asdf",
+				Port: 80,
+			}},
+			[]v1.ServicePort{{
+				Name: "asdf",
+				Port: 80,
+			}},
+			false,
+			"Same Port and Name",
+		},
+		{
+			[]v1.ServicePort{{
+				Name: "foo",
+				Port: 80,
+			}},
+			[]v1.ServicePort{{
+				Name: "bar",
+				Port: 80,
+			}},
+			true,
+			"Different Name same Port",
+		},
+		{
+			[]v1.ServicePort{{
+				Name: "foo",
+				Port: 8080,
+			}},
+			[]v1.ServicePort{{
+				Name: "bar",
+				Port: 80,
+			}},
+			true,
+			"Different Name different Port",
+		},
+		{
+			[]v1.ServicePort{{
+				Name: "foo",
+			}},
+			[]v1.ServicePort{{
+				Name: "fooo",
+			}},
+			true,
+			"Very similar Name",
+		},
+		{
+			[]v1.ServicePort{{
+				Name: "asdf",
+				Port: 80,
+				TargetPort: intstr.IntOrString{
+					IntVal: 80,
+				},
+			}},
+			[]v1.ServicePort{{
+				Name: "asdf",
+				Port: 80,
+				TargetPort: intstr.IntOrString{
+					IntVal: 8080,
+				},
+			}},
+			false,
+			"TargetPort should be ignored",
+		},
+		{
+			[]v1.ServicePort{{
+				Name: "foo",
+			}, {
+				Name: "bar",
+			}},
+			[]v1.ServicePort{{
+				Name: "foo",
+			}, {
+				Name: "bar",
+			}},
+			false,
+			"Multiple same names",
+		},
+		{
+			[]v1.ServicePort{{
+				Name: "foo",
+			}, {
+				Name: "bar",
+			}},
+			[]v1.ServicePort{{
+				Name: "foo",
+			}, {
+				Name: "bars",
+			}},
+			true,
+			"Multiple different names",
+		},
+		{
+			[]v1.ServicePort{{
+				Name: "foo",
+			}, {
+				Port: 80,
+			}},
+			[]v1.ServicePort{{
+				Name: "foo",
+			}, {
+				Port: 80,
+			}},
+			false,
+			"Some names some ports",
+		},
+	}
+
+	for _, c := range cases {
+		if c.result != hasServicePortChanges(c.a, c.b) {
+			t.Error(c.reason)
+		}
+	}
+}


### PR DESCRIPTION
When a service changes we get a service change event and an endpoint change event. Previously we'd enqueue the associated ingresses for all service changes. Now we only enqueue it when the service changes in a way that won't be covered by the endpoint changes.

Specifically for Service.spec.selector changes, which users sometimes use to do blue/green deployments, we will no longer enqueue an ingress - instead the changes will be handled (correctly) by the endpoint handler.

Fix for https://github.com/nginxinc/kubernetes-ingress/issues/306.

Bonus: Fewer reloads.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
