### PR TITLE
Add nginx status parameters to helm chart

### DIFF
--- a/deployments/helm-chart/Chart.yaml
+++ b/deployments/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.1.2
+version: 0.1.3
 appVersion: edge
 description: NGINX Ingress Controller
 sources:

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -81,11 +81,13 @@ Parameter | Description | Default
 `controller.useIngressClassOnly` | Ignore Ingress resources without the `"kubernetes.io/ingress.class"` annotation. | false
 `controller.watchNamespace` | Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces. | ""
 `controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress controller. | false
+`controller.nginxStatus.enable` | Enable the NGINX stub_status, or the NGINX Plus API. | true 
+`controller.nginxStatus.port` | Set the port where the NGINX stub_status or the NGINX Plus API is exposed. | 8080
 `controller.reportIngressStatus.enable` | Update the address field in the status of Ingresses resources with an external address of the Ingress controller. You must also specify the source of the external address either through an external service via `controller.reportIngressStatus.externalService` or the `external-status-address` entry in the ConfigMap via `controller.config.entries`. **Note:** `controller.config.entries.external-status-address` takes precedence if both are set. | true
 `controller.reportIngressStatus.externalService` | Specifies the name of the service with the type LoadBalancer through which the Ingress controller is exposed externally. The external address of the service is used when reporting the status of Ingress resources. `controller.reportIngressStatus.enable` must be set to `true`. | nginx-ingress
 `controller.reportIngressStatus.enableLeaderElection` | Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources. `controller.reportIngressStatus.enable` must be set to `true`. | true
 `rbac.create` | Configures RBAC. | true
-`prometheues.create` | Deploys a Prometheus exporter container within the Ingress controller pod. | false
+`prometheues.create` | Deploys a Prometheus exporter container within the Ingress controller pod. Requires NGINX status enabled via `controller.nginxStatus.enable`. Note: the exporter will use the port specified by `controller.nginxStatus.port`.| false
 `prometheus.port` | Configures the port to scrape the metrics. | 9113
 `prometheus.image.repository` | The image repository of the Prometheus exporter. | nginx/nginx-prometheus-exporter
 `prometheus.image.tag` | The tag of the Prometheus exporter image. | 0.1.0

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -83,6 +83,10 @@ spec:
 {{- if .Values.controller.healthStatus }}
           - -health-status
 {{- end }}
+{{- if .Values.controller.nginxStatus }}
+          - -nginx-status={{ .Values.controller.nginxStatus.enable }}
+          - -nginx-status-port={{ .Values.controller.nginxStatus.port }}
+{{- end }}
 {{- if .Values.controller.reportIngressStatus.enable }}
           - -report-ingress-status
 {{- if .Values.controller.reportIngressStatus.externalService }}
@@ -92,7 +96,7 @@ spec:
           - -enable-leader-election
 {{- end }}
 {{- end }}
-{{- if .Values.prometheus }}
+{{- if and .Values.prometheus .Values.controller.nginxStatus }}
 {{- if .Values.prometheus.create }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
         imagePullPolicy: "{{ .Values.prometheus.image.pullPolicy }}"
@@ -108,9 +112,9 @@ spec:
 {{- end }}
           - -nginx.scrape-uri
 {{- if .Values.controller.nginxplus }}
-          - http://127.0.0.1:8080/api
+          - http://127.0.0.1:{{ .Values.controller.nginxStatus.port }}/api
 {{ else }}
-          - http://127.0.0.1:8080/stub_status
+          - http://127.0.0.1:{{ .Values.controller.nginxStatus.port }}/stub_status
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -69,6 +69,10 @@ spec:
 {{- if .Values.controller.healthStatus }}
           - -health-status
 {{- end }}
+{{- if .Values.controller.nginxStatus }}
+          - -nginx-status={{ .Values.controller.nginxStatus.enable }}
+          - -nginx-status-port={{ .Values.controller.nginxStatus.port }}
+{{- end }}
 {{- if .Values.controller.reportIngressStatus.enable }}
           - -report-ingress-status
 {{- if .Values.controller.reportIngressStatus.externalService }}
@@ -78,7 +82,7 @@ spec:
           - -enable-leader-election
 {{- end }}
 {{- end }}
-{{- if .Values.prometheus }}
+{{- if and .Values.prometheus .Values.controller.nginxStatus }}
 {{- if .Values.prometheus.create }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
         name: nginx-prometheus-exporter
@@ -94,9 +98,9 @@ spec:
 {{- end }}
           - -nginx.scrape-uri
 {{- if .Values.controller.nginxplus }}
-          - http://127.0.0.1:8080/api
+          - http://127.0.0.1:{{ .Values.controller.nginxStatus.port }}/api
 {{ else }}
-          - http://127.0.0.1:8080/stub_status
+          - http://127.0.0.1:{{  .Values.controller.nginxStatus.port }}/stub_status
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deployments/helm-chart/values-plus.yaml
+++ b/deployments/helm-chart/values-plus.yaml
@@ -22,6 +22,9 @@ controller:
   useIngressClassOnly: false
   watchNamespace: ""
   healthStatus: false
+  nginxStatus:
+    enable: true
+    port: 8080
   service:
     create: true
     type: LoadBalancer

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -22,6 +22,9 @@ controller:
   useIngressClassOnly: false
   watchNamespace: ""
   healthStatus: false
+  nginxStatus:
+    enable: true
+    port: 8080
   service:
     create: true
     type: LoadBalancer


### PR DESCRIPTION
### Proposed changes

Add controller.nginxStatus.enable and controller.nginxStatus.port
parameters to the Helm chart, which control -nginx-status and
-nginx-status-port Ingress Controller cli arguments.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
