### PR TITLE
Fix configmap update

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -427,8 +427,8 @@ func (lbc *LoadBalancerController) GetManagedIngresses() ([]extensions.Ingress, 
 
 func (lbc *LoadBalancerController) ingressesToIngressExes(ings []extensions.Ingress) []*nginx.IngressEx {
 	var ingExes []*nginx.IngressEx
-	for _, ing := range ings {
-		ingEx, err := lbc.createIngress(&ing)
+	for i := range ings {
+		ingEx, err := lbc.createIngress(&ings[i])
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
The update of the configmap with NGINX customization was not handled
properly by the Ingress Controller:
- If the user had more than one Ingress resource with TLS termination
conifgured, the Ingress Controller would crash.
- If the user had more than one Ingress resource without TLS
termination, the Ingress Controller would update the config for only
one Ingress resource.

The bug appeared in a552bd0.

This commit fixes the bug.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
