### PR TITLE
Verify reloads & cache secrets

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -214,6 +214,7 @@ func main() {
 		glog.Fatalf("Error generating NGINX main config: %v", err)
 	}
 	ngxc.UpdateMainConfigFile(content)
+	ngxc.UpdateConfigVersionFile()
 
 	nginxDone := make(chan error, 1)
 	ngxc.Start(nginxDone)

--- a/internal/nginx/configurator.go
+++ b/internal/nginx/configurator.go
@@ -1041,7 +1041,7 @@ func (cnf *Configurator) updatePlusEndpoints(ingEx *IngressEx) error {
 		name := getNameForUpstream(ingEx.Ingress, emptyHost, ingEx.Ingress.Spec.Backend)
 		endps, exists := ingEx.Endpoints[ingEx.Ingress.Spec.Backend.ServiceName+ingEx.Ingress.Spec.Backend.ServicePort.String()]
 		if exists {
-			err := cnf.nginxAPI.UpdateServers(name, endps, cfg)
+			err := cnf.nginxAPI.UpdateServers(name, endps, cfg, cnf.nginx.configVersion)
 			if err != nil {
 				return fmt.Errorf("Couldn't update the endpoints for %v: %v", name, err)
 			}
@@ -1055,7 +1055,7 @@ func (cnf *Configurator) updatePlusEndpoints(ingEx *IngressEx) error {
 			name := getNameForUpstream(ingEx.Ingress, rule.Host, &path.Backend)
 			endps, exists := ingEx.Endpoints[path.Backend.ServiceName+path.Backend.ServicePort.String()]
 			if exists {
-				err := cnf.nginxAPI.UpdateServers(name, endps, cfg)
+				err := cnf.nginxAPI.UpdateServers(name, endps, cfg, cnf.nginx.configVersion)
 				if err != nil {
 					return fmt.Errorf("Couldn't update the endpoints for %v: %v", name, err)
 				}
@@ -1117,14 +1117,14 @@ func GenerateNginxMainConfig(config *Config) *MainConfig {
 		SSLCiphers:                config.MainServerSSLCiphers,
 		SSLDHParam:                config.MainServerSSLDHParam,
 		SSLPreferServerCiphers:    config.MainServerSSLPreferServerCiphers,
-		HTTP2:                 config.HTTP2,
-		ServerTokens:          config.ServerTokens,
-		ProxyProtocol:         config.ProxyProtocol,
-		WorkerProcesses:       config.MainWorkerProcesses,
-		WorkerCPUAffinity:     config.MainWorkerCPUAffinity,
-		WorkerShutdownTimeout: config.MainWorkerShutdownTimeout,
-		WorkerConnections:     config.MainWorkerConnections,
-		WorkerRlimitNofile:    config.MainWorkerRlimitNofile,
+		HTTP2:                     config.HTTP2,
+		ServerTokens:              config.ServerTokens,
+		ProxyProtocol:             config.ProxyProtocol,
+		WorkerProcesses:           config.MainWorkerProcesses,
+		WorkerCPUAffinity:         config.MainWorkerCPUAffinity,
+		WorkerShutdownTimeout:     config.MainWorkerShutdownTimeout,
+		WorkerConnections:         config.MainWorkerConnections,
+		WorkerRlimitNofile:        config.MainWorkerRlimitNofile,
 	}
 	return nginxCfg
 }

--- a/internal/nginx/templates/nginx-plus.tmpl
+++ b/internal/nginx/templates/nginx-plus.tmpl
@@ -111,11 +111,20 @@ http {
         listen unix:/var/run/nginx-plus-api.sock;
         access_log off;
 
+        # $config_version_mismatch is defined in /etc/nginx/config-version.conf
+        location /configVersionCheck {
+            if ($config_version_mismatch) {
+                return 503;
+            }
+            return 200;
+        }
+
         location /api {
             api write=on;
         }
     }
 
+    include /etc/nginx/config-version.conf;
     include /etc/nginx/conf.d/*.conf;
 }
 

--- a/internal/nginx/templates/nginx.tmpl
+++ b/internal/nginx/templates/nginx.tmpl
@@ -96,7 +96,7 @@ http {
     }
     {{- end }}
 
-
+    include /etc/nginx/config-version.conf;
     include /etc/nginx/conf.d/*.conf;
 }
 

--- a/internal/nginx/verify/client_test.go
+++ b/internal/nginx/verify/client_test.go
@@ -1,0 +1,51 @@
+package verify
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+type Transport struct {
+}
+
+func (c Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(bytes.NewBufferString("42")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func getTestHTTPClient() *http.Client {
+	ts := Transport{}
+	tClient := &http.Client{
+		Transport: ts,
+	}
+	return tClient
+}
+
+func TestVerifyClient(t *testing.T) {
+
+	c := Client{
+		client: getTestHTTPClient(),
+	}
+
+	configVersion, err := c.GetConfigVersion()
+	if err != nil {
+		t.Errorf("error getting config version: %v", err)
+	}
+	if configVersion != 42 {
+		t.Errorf("got bad config version, expected 42 got %v", configVersion)
+	}
+
+	err = c.WaitForCorrectVersion(43)
+	if err == nil {
+		t.Error("expected error from WaitForCorrectVersion ")
+	}
+	err = c.WaitForCorrectVersion(42)
+	if err != nil {
+		t.Errorf("error waiting for config version: %v", err)
+	}
+}

--- a/internal/nginx/verify/config.go
+++ b/internal/nginx/verify/config.go
@@ -1,0 +1,51 @@
+package verify
+
+import (
+	"bytes"
+	"html/template"
+)
+
+const configVersionTemplateString = `server {
+    listen unix:/var/run/nginx-config-version.sock;
+    access_log off;
+
+    location /configVersion {
+        return 200 {{.ConfigVersion}};
+    }
+}
+map $http_x_expected_config_version $config_version_mismatch {
+	"{{.ConfigVersion}}" "";
+	default "mismatch";
+}`
+
+// ConfigGenerator handles generating and writing the config version file.
+type ConfigGenerator struct {
+	configVersionTemplate *template.Template
+}
+
+// NewConfigGenerator builds a new ConfigWriter - primarily parsing the config version template.
+func NewConfigGenerator() (*ConfigGenerator, error) {
+	configVersionTemplate, err := template.New("configVersionTemplate").Parse(configVersionTemplateString)
+	if err != nil {
+		return nil, err
+	}
+	return &ConfigGenerator{
+		configVersionTemplate: configVersionTemplate,
+	}, nil
+}
+
+// GenerateVersionConfig generates the config version file.
+func (c *ConfigGenerator) GenerateVersionConfig(configVersion int) ([]byte, error) {
+	var configBuffer bytes.Buffer
+	templateValues := struct {
+		ConfigVersion int
+	}{
+		configVersion,
+	}
+	err := c.configVersionTemplate.Execute(&configBuffer, templateValues)
+	if err != nil {
+		return nil, err
+	}
+
+	return configBuffer.Bytes(), nil
+}

--- a/internal/nginx/verify/config_test.go
+++ b/internal/nginx/verify/config_test.go
@@ -1,0 +1,20 @@
+package verify
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigWriter(t *testing.T) {
+	cw, err := NewConfigGenerator()
+	if err != nil {
+		t.Fatalf("error instantiating ConfigWriter: %v", err)
+	}
+	config, err := cw.GenerateVersionConfig(1)
+	if err != nil {
+		t.Errorf("error generating version config: %v", err)
+	}
+	if !strings.Contains(string(config), "configVersion") {
+		t.Errorf("configVersion endpoint not set. config contents: %v", string(config))
+	}
+}


### PR DESCRIPTION
When calling `nginx -s reload` block until we verify that the new config has been loaded.

- Cache secrets to improve performance.
- Adds a new config file to hold config version.
- Adds a verify client that fetches the version.
- Protects the Plus API from making changes on a worker process with old config.
- Skips `nginx -t`, since it's done by `nginx -s reload`.

Reload performance is worse after this change since we block after reloading. However with the secrets cache fix overall performance is improved.

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
