### PR TITLE
Fix installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ Make sure you have access to the Ingress controller image:
 
 The installation manifests are located in the [deployments](../deployments) folder. In the steps below we assume that you will be running the commands from that folder.
 
-## 1. Create a Namespace, a SA and the Default Secret.
+## 1. Create a Namespace, a SA, the Default Secret and the Customization Config Map.
 
 1. Create a namespace and a service account for the Ingress controller:
     ```
@@ -24,7 +24,7 @@ The installation manifests are located in the [deployments](../deployments) fold
 
     **Note**: The default server returns the Not Found page with the 404 status code for all requests for domains for which there are no Ingress rules defined. For testing purposes we include a self-signed certificate and key that we generated. However, we recommend that you use your own certificate and key.
 
-1. *Optional*. Create a config map for customizing NGINX configuration (read more about customization [here](../examples/customization)):
+1. Create a config map for customizing NGINX configuration (read more about customization [here](../examples/customization)):
     ```
     $ kubectl apply -f common/nginx-config.yaml
     ```


### PR DESCRIPTION
Remove "optional" from the description of the create a configmap step (1.3). 
The manifests for the Ingress Controller set -nginx-configmaps argument. That is why step 1.3. is not optional.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
