### PR TITLE
Fix Configmap/Mergeable Ingress Add/Update event logging

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -528,16 +528,16 @@ func (lbc *LoadBalancerController) syncIng(task queue.Task) {
 			// record correct eventType and message depending on the error
 			eventTitle := "AddedOrUpdated"
 			eventType := api_v1.EventTypeNormal
-			eventWarningMessage := ""
+			eventWarningMessageAndError := ""
 
 			if addErr != nil {
 				eventTitle = "AddedOrUpdatedWithError"
 				eventType = api_v1.EventTypeWarning
-				eventWarningMessage = "but was not applied"
+				eventWarningMessageAndError = fmt.Sprintf("but was not applied: %v", addErr)
 			}
-			lbc.recorder.Eventf(ing, eventType, eventTitle, "Configuration for %v(Master) was added or updated %s: %v", key, eventWarningMessage, err)
+			lbc.recorder.Eventf(ing, eventType, eventTitle, "Configuration for %v(Master) was added or updated %s: %v", key, eventWarningMessageAndError)
 			for _, minion := range mergeableIngExs.Minions {
-				lbc.recorder.Eventf(ing, eventType, eventTitle, "Configuration for %v/%v(Minion) was added or updated %s: %v", minion.Ingress.Namespace, minion.Ingress.Name, eventWarningMessage, err)
+				lbc.recorder.Eventf(ing, eventType, eventTitle, "Configuration for %v/%v(Minion) was added or updated %s: %v", minion.Ingress.Namespace, minion.Ingress.Name, eventWarningMessageAndError)
 			}
 
 			if lbc.reportStatusEnabled() {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -363,27 +363,27 @@ func (lbc *LoadBalancerController) syncConfig(task queue.Task) {
 
 	eventTitle := "Updated"
 	eventType := api_v1.EventTypeNormal
-	eventWarningMessage := ""
+	eventWarningMessageAndError := ""
 
 	if updateErr != nil {
 		eventTitle = "UpdatedWithError"
 		eventType = api_v1.EventTypeWarning
-		eventWarningMessage = "but was not applied"
+		eventWarningMessageAndError = fmt.Sprintf("but was not applied: %v", updateErr)
 	}
 	if configExists {
 		cfgm := obj.(*api_v1.ConfigMap)
-		lbc.recorder.Eventf(cfgm, eventType, eventTitle, "Configuration from %v was updated %s: %v", key, eventWarningMessage, err)
+		lbc.recorder.Eventf(cfgm, eventType, eventTitle, "Configuration from %v was updated %s", key, eventWarningMessageAndError)
 	}
 	for _, ingEx := range ingExes {
-		lbc.recorder.Eventf(ingEx.Ingress, eventType, eventTitle, "Configuration for %v/%v was updated %s: %v",
-			ingEx.Ingress.Namespace, ingEx.Ingress.Name, eventWarningMessage, err)
+		lbc.recorder.Eventf(ingEx.Ingress, eventType, eventTitle, "Configuration for %v/%v was updated %s",
+			ingEx.Ingress.Namespace, ingEx.Ingress.Name, eventWarningMessageAndError)
 	}
 	for _, mergeableIng := range mergeableIngresses {
 		master := mergeableIng.Master
-		lbc.recorder.Eventf(master.Ingress, eventType, eventTitle, "Configuration for %v/%v(Master) was updated %s: %v", master.Ingress.Namespace, master.Ingress.Name, eventWarningMessage, err)
+		lbc.recorder.Eventf(master.Ingress, eventType, eventTitle, "Configuration for %v/%v(Master) was updated %s", master.Ingress.Namespace, master.Ingress.Name, eventWarningMessageAndError)
 		for _, minion := range mergeableIng.Minions {
-			lbc.recorder.Eventf(minion.Ingress, eventType, eventTitle, "Configuration for %v/%v(Minion) was updated %s: %v",
-				minion.Ingress.Namespace, minion.Ingress.Name, eventWarningMessage, err)
+			lbc.recorder.Eventf(minion.Ingress, eventType, eventTitle, "Configuration for %v/%v(Minion) was updated %s",
+				minion.Ingress.Namespace, minion.Ingress.Name)
 		}
 	}
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -363,27 +363,27 @@ func (lbc *LoadBalancerController) syncConfig(task queue.Task) {
 
 	eventTitle := "Updated"
 	eventType := api_v1.EventTypeNormal
-	eventWarningMessageAndError := ""
+	eventWarningMessage := ""
 
 	if updateErr != nil {
 		eventTitle = "UpdatedWithError"
 		eventType = api_v1.EventTypeWarning
-		eventWarningMessageAndError = fmt.Sprintf("but was not applied: %v", updateErr)
+		eventWarningMessage = fmt.Sprintf("but was not applied: %v", updateErr)
 	}
 	if configExists {
 		cfgm := obj.(*api_v1.ConfigMap)
-		lbc.recorder.Eventf(cfgm, eventType, eventTitle, "Configuration from %v was updated %s", key, eventWarningMessageAndError)
+		lbc.recorder.Eventf(cfgm, eventType, eventTitle, "Configuration from %v was updated %s", key, eventWarningMessage)
 	}
 	for _, ingEx := range ingExes {
 		lbc.recorder.Eventf(ingEx.Ingress, eventType, eventTitle, "Configuration for %v/%v was updated %s",
-			ingEx.Ingress.Namespace, ingEx.Ingress.Name, eventWarningMessageAndError)
+			ingEx.Ingress.Namespace, ingEx.Ingress.Name, eventWarningMessage)
 	}
 	for _, mergeableIng := range mergeableIngresses {
 		master := mergeableIng.Master
-		lbc.recorder.Eventf(master.Ingress, eventType, eventTitle, "Configuration for %v/%v(Master) was updated %s", master.Ingress.Namespace, master.Ingress.Name, eventWarningMessageAndError)
+		lbc.recorder.Eventf(master.Ingress, eventType, eventTitle, "Configuration for %v/%v(Master) was updated %s", master.Ingress.Namespace, master.Ingress.Name, eventWarningMessage)
 		for _, minion := range mergeableIng.Minions {
 			lbc.recorder.Eventf(minion.Ingress, eventType, eventTitle, "Configuration for %v/%v(Minion) was updated %s",
-				minion.Ingress.Namespace, minion.Ingress.Name)
+				minion.Ingress.Namespace, minion.Ingress.Name, eventWarningMessage)
 		}
 	}
 }
@@ -528,16 +528,16 @@ func (lbc *LoadBalancerController) syncIng(task queue.Task) {
 			// record correct eventType and message depending on the error
 			eventTitle := "AddedOrUpdated"
 			eventType := api_v1.EventTypeNormal
-			eventWarningMessageAndError := ""
+			eventWarningMessage := ""
 
 			if addErr != nil {
 				eventTitle = "AddedOrUpdatedWithError"
 				eventType = api_v1.EventTypeWarning
-				eventWarningMessageAndError = fmt.Sprintf("but was not applied: %v", addErr)
+				eventWarningMessage = fmt.Sprintf("but was not applied: %v", addErr)
 			}
-			lbc.recorder.Eventf(ing, eventType, eventTitle, "Configuration for %v(Master) was added or updated %s: %v", key, eventWarningMessageAndError)
+			lbc.recorder.Eventf(ing, eventType, eventTitle, "Configuration for %v(Master) was added or updated %s", key, eventWarningMessage)
 			for _, minion := range mergeableIngExs.Minions {
-				lbc.recorder.Eventf(ing, eventType, eventTitle, "Configuration for %v/%v(Minion) was added or updated %s: %v", minion.Ingress.Namespace, minion.Ingress.Name, eventWarningMessageAndError)
+				lbc.recorder.Eventf(ing, eventType, eventTitle, "Configuration for %v/%v(Minion) was added or updated %s", minion.Ingress.Namespace, minion.Ingress.Name, eventWarningMessage)
 			}
 
 			if lbc.reportStatusEnabled() {


### PR DESCRIPTION
### Proposed changes
* When an ingress resource is updated with invalid changes, warning event is now correctly logged
    * When there is no warning, trailing `nil` is no longer printed
* When a ConfigMap resource is updated with an invalid changes, warning event is now correctly logged
    * When there is no warning, trailing `nil` is no longer printed

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
