### PR TITLE
Add CLI option `-nginx-status-allow-cidrs` to allow easily restricting access to sensitive endpoints via CLI argument.

### DIFF
--- a/cmd/nginx-ingress/main_test.go
+++ b/cmd/nginx-ingress/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -21,4 +22,78 @@ func TestValidateStatusPort(t *testing.T) {
 		}
 	}
 
+}
+
+func TestParseNginxStatusAllowCIDRs(t *testing.T) {
+
+	var tests = []struct {
+		input         string
+		expected      []string
+		expectedError error
+	}{
+		{"earth, ,,furball",
+			[]string{},
+			errors.New("invalid IP address: earth")},
+		{"127.0.0.1",
+			[]string{"127.0.0.1"},
+			nil},
+		{"10.0.1.0/24",
+			[]string{"10.0.1.0/24"},
+			nil},
+		{"127.0.0.1,10.0.1.0/24,68.121.233.214 , 24.24.24.24/32",
+			[]string{"127.0.0.1", "10.0.1.0/24", "68.121.233.214", "24.24.24.24/32"}, nil},
+		{"127.0.0.1,10.0.1.0/24, ,,furball",
+			[]string{"127.0.0.1", "10.0.1.0/24"},
+			errors.New("invalid CIDR address: an empty string is an invalid CIDR block or IP address")},
+		{"false",
+			[]string{},
+			errors.New("invalid IP address: false")},
+	}
+
+	for _, test := range tests {
+		splitArray, err := parseNginxStatusAllowCIDRs(test.input)
+		if err != test.expectedError {
+			if test.expectedError == nil {
+				t.Errorf("parseNginxStatusAllowCIDRs(%q) returned an error %q when it should not have returned an error.", test.input, err.Error())
+			} else if err == nil {
+				t.Errorf("parseNginxStatusAllowCIDRs(%q) returned no error when it should have returned error %q", test.input, test.expectedError)
+			} else if err.Error() != test.expectedError.Error() {
+				t.Errorf("parseNginxStatusAllowCIDRs(%q) returned error %q when it should have returned error %q", test.input, err.Error(), test.expectedError)
+			}
+		}
+
+		for _, expectedEntry := range test.expected {
+			if !contains(splitArray, expectedEntry) {
+				t.Errorf("parseNginxStatusAllowCIDRs(%q) did not include %q but returned %q", test.input, expectedEntry, splitArray)
+			}
+		}
+	}
+
+}
+
+func TestValidateCIDRorIP(t *testing.T) {
+	badCIDRs := []string{"localhost", "thing", "~", "!!!", "", " ", "-1"}
+	for _, badCIDR := range badCIDRs {
+		err := validateCIDRorIP(badCIDR)
+		if err == nil {
+			t.Errorf(`Expected error for invalid CIDR "%v"\n`, badCIDR)
+		}
+	}
+
+	goodCIDRs := []string{"0.0.0.0/32", "0.0.0.0/0", "127.0.0.1/32", "127.0.0.0/24", "23.232.65.42"}
+	for _, goodCIDR := range goodCIDRs {
+		err := validateCIDRorIP(goodCIDR)
+		if err != nil {
+			t.Errorf("Error for valid CIDR: %v err: %v\n", goodCIDR, err)
+		}
+	}
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -41,6 +41,9 @@ Usage of ./nginx-ingress:
     	Enable support for NGINX Plus
   -nginx-status
     	Enable the NGINX stub_status, or the NGINX Plus API. (default true)
+  -nginx-status-allow-cidrs
+        Whitelist IPv4 IP/CIDR blocks to allow access to NGINX stub_status or the NGINX Plus API.
+        Separate multiple IP/CIDR by commas.
   -nginx-status-port int
     	Set the port where the NGINX stub_status or the NGINX Plus API is exposed. [1023 - 65535] (default 8080)
   -proxy string

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -926,7 +926,7 @@ func TestFindIngressesForSecret(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset()
 
-			templateExecutor, err := nginx.NewTemplateExecutor("../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl", true, true, 8080)
+			templateExecutor, err := nginx.NewTemplateExecutor("../nginx/templates/nginx-plus.tmpl", "../nginx/templates/nginx-plus.ingress.tmpl", true, true, []string{"127.0.0.1"}, 8080)
 			if err != nil {
 				t.Fatalf("templateExecuter could not start: %v", err)
 			}

--- a/internal/nginx/configurator_test.go
+++ b/internal/nginx/configurator_test.go
@@ -524,7 +524,7 @@ func createExpectedConfigForMergeableCafeIngress() IngressNginxConfig {
 }
 
 func createTestConfigurator() (*Configurator, error) {
-	templateExecutor, err := NewTemplateExecutor("templates/nginx-plus.tmpl", "templates/nginx-plus.ingress.tmpl", true, true, 8080)
+	templateExecutor, err := NewTemplateExecutor("templates/nginx-plus.tmpl", "templates/nginx-plus.ingress.tmpl", true, true, []string{"127.0.0.1"}, 8080)
 	if err != nil {
 		return nil, err
 	}
@@ -537,7 +537,7 @@ func createTestConfigurator() (*Configurator, error) {
 }
 
 func createTestConfiguratorInvalidIngressTemplate() (*Configurator, error) {
-	templateExecutor, err := NewTemplateExecutor("templates/nginx-plus.tmpl", "templates/nginx-plus.ingress.tmpl", true, true, 8080)
+	templateExecutor, err := NewTemplateExecutor("templates/nginx-plus.tmpl", "templates/nginx-plus.ingress.tmpl", true, true, []string{"127.0.0.1"}, 8080)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/nginx/nginx.go
+++ b/internal/nginx/nginx.go
@@ -154,6 +154,7 @@ type MainConfig struct {
 	StreamLogFormat           string
 	HealthStatus              bool
 	NginxStatus               bool
+	NginxStatusAllowCIDRs     []string
 	NginxStatusPort           int
 	MainSnippets              []string
 	HTTPSnippets              []string

--- a/internal/nginx/template_executor.go
+++ b/internal/nginx/template_executor.go
@@ -8,15 +8,16 @@ import (
 
 // TemplateExecutor executes NGINX configuration templates
 type TemplateExecutor struct {
-	HealthStatus    bool
-	NginxStatus     bool
-	NginxStatusPort int
-	mainTemplate    *template.Template
-	ingressTemplate *template.Template
+	HealthStatus          bool
+	NginxStatus           bool
+	NginxStatusAllowCIDRs []string
+	NginxStatusPort       int
+	mainTemplate          *template.Template
+	ingressTemplate       *template.Template
 }
 
 // NewTemplateExecutor creates a TemplateExecutor
-func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, healthStatus bool, nginxStatus bool, nginxStatusPort int) (*TemplateExecutor, error) {
+func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, healthStatus bool, nginxStatus bool, nginxStatusAllowCIDRs []string, nginxStatusPort int) (*TemplateExecutor, error) {
 	// template name must be the base name of the template file https://golang.org/pkg/text/template/#Template.ParseFiles
 	nginxTemplate, err := template.New(path.Base(mainTemplatePath)).ParseFiles(mainTemplatePath)
 	if err != nil {
@@ -29,11 +30,12 @@ func NewTemplateExecutor(mainTemplatePath string, ingressTemplatePath string, he
 	}
 
 	return &TemplateExecutor{
-		mainTemplate:    nginxTemplate,
-		ingressTemplate: ingressTemplate,
-		HealthStatus:    healthStatus,
-		NginxStatus:     nginxStatus,
-		NginxStatusPort: nginxStatusPort,
+		mainTemplate:          nginxTemplate,
+		ingressTemplate:       ingressTemplate,
+		HealthStatus:          healthStatus,
+		NginxStatus:           nginxStatus,
+		NginxStatusAllowCIDRs: nginxStatusAllowCIDRs,
+		NginxStatusPort:       nginxStatusPort,
 	}, nil
 }
 
@@ -63,6 +65,7 @@ func (te *TemplateExecutor) UpdateIngressTemplate(templateString *string) error 
 func (te *TemplateExecutor) ExecuteMainConfigTemplate(cfg *MainConfig) ([]byte, error) {
 	cfg.HealthStatus = te.HealthStatus
 	cfg.NginxStatus = te.NginxStatus
+	cfg.NginxStatusAllowCIDRs = te.NginxStatusAllowCIDRs
 	cfg.NginxStatusPort = te.NginxStatusPort
 
 	var configBuffer bytes.Buffer

--- a/internal/nginx/templates/nginx-plus.tmpl
+++ b/internal/nginx/templates/nginx-plus.tmpl
@@ -96,10 +96,10 @@ http {
 
         location  = /dashboard.html {
         }
-
-        allow 127.0.0.1;
+        {{ range $value := .NginxStatusAllowCIDRs }}{{ if ne $value "" }}
+        allow {{$value}};{{ end }}
+        {{end}}
         deny all;
-
         location /api {
             api write=off;
         }

--- a/internal/nginx/templates/nginx.tmpl
+++ b/internal/nginx/templates/nginx.tmpl
@@ -86,10 +86,10 @@ http {
     # stub_status
     server {
         listen {{.NginxStatusPort}};
-
-        allow 127.0.0.1;
+        {{ range $value := .NginxStatusAllowCIDRs }}{{ if ne $value "" }}
+        allow {{$value}};{{ end }}
+        {{end}}
         deny all;
-
         location /stub_status {
             stub_status;
         }


### PR DESCRIPTION
Add CLI option `-nginx-status-allow-cidrs` to allow easily restricting access to sensitive endpoints via CLI argument.

### Proposed changes
This implements #355 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
