### PR TITLE
Improve parsing nginx.org/rewrites annotation

### DIFF
--- a/internal/nginx/configurator.go
+++ b/internal/nginx/configurator.go
@@ -637,7 +637,7 @@ func getRewrites(ingEx *IngressEx) map[string]string {
 }
 
 func parseRewrites(service string) (serviceName string, rewrite string, err error) {
-	parts := strings.SplitN(service, " ", 2)
+	parts := strings.SplitN(strings.TrimSpace(service), " ", 2)
 
 	if len(parts) != 2 {
 		return "", "", fmt.Errorf("Invalid rewrite format: %s", service)

--- a/internal/nginx/configurator_test.go
+++ b/internal/nginx/configurator_test.go
@@ -42,6 +42,19 @@ func TestParseRewrites(t *testing.T) {
 	}
 }
 
+func TestParseRewritesWithLeadingAndTrailingWhitespace(t *testing.T) {
+	serviceName := "coffee-svc"
+	serviceNamePart := "serviceName=" + serviceName
+	rewritePath := "/beans/"
+	rewritePathPart := "rewrite=" + rewritePath
+	rewriteService := "\t\n " + serviceNamePart + " " + rewritePathPart + " \t\n"
+
+	serviceNameActual, rewritePathActual, err := parseRewrites(rewriteService)
+	if serviceName != serviceNameActual || rewritePath != rewritePathActual || err != nil {
+		t.Errorf("parseRewrites(%s) should return %q, %q, nil; got %q, %q, %v", rewriteService, serviceName, rewritePath, serviceNameActual, rewritePathActual, err)
+	}
+}
+
 func TestParseRewritesInvalidFormat(t *testing.T) {
 	rewriteService := "serviceNamecoffee-svc rewrite=/"
 


### PR DESCRIPTION
### Proposed changes
Handle leading and trailing whitespace when parsing rewrites
for a service.

Based on https://github.com/nginxinc/kubernetes-ingress/issues/388

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
