### PR TITLE
Add loadBalancerIP parameter to helm chat

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -76,6 +76,7 @@ Parameter | Description | Default
 `controller.service.type` | The type of service to create for the Ingress controller. | LoadBalancer
 `controller.service.externalTrafficPolicy` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | Local
 `controller.service.annotations` | The annotations of the Ingress controller service. | { }
+`controller.service.loadBalancerIP` | The static IP address for the load balancer. Requires `controller.service.type` set to `LoadBalancer`.  | None
 `controller.serviceAccountName` | The serviceAccountName of the Ingress controller pods. Used for RBAC. | nginx-ingress
 `controller.ingressClass` | A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its class - i.e. have the annotation `"kubernetes.io/ingress.class"` equal to the class. Additionally, the Ingress controller processes Ingress resources that do not have that annotation which can be disabled by setting the "-use-ingress-class-only" flag. | nginx
 `controller.useIngressClassOnly` | Ignore Ingress resources without the `"kubernetes.io/ingress.class"` annotation. | false

--- a/deployments/helm-chart/templates/controller-service.yaml
+++ b/deployments/helm-chart/templates/controller-service.yaml
@@ -17,6 +17,9 @@ spec:
   {{- if .Values.controller.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.controller.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if (eq .Values.controller.service.type "LoadBalancer") .Values.controller.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.controller.service.loadBalancerIP }}
+  {{- end }}
 {{- end }}
   type: {{ .Values.controller.service.type }}
   ports:

--- a/deployments/helm-chart/values-plus.yaml
+++ b/deployments/helm-chart/values-plus.yaml
@@ -30,6 +30,7 @@ controller:
     type: LoadBalancer
     externalTrafficPolicy: Local
     annotations: {}
+    loadBalancerIP: ""
   serviceAccountName: nginx-ingress
   reportIngressStatus:
     enable: true

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -30,6 +30,7 @@ controller:
     type: LoadBalancer
     externalTrafficPolicy: Local
     annotations: {}
+    loadBalancerIP: ""
   serviceAccountName: nginx-ingress
   reportIngressStatus:
     enable: true


### PR DESCRIPTION
### Proposed changes
Add controller.service.loadBalancerIP parameter to the helm chart.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
