### PR TITLE
Update default lb-method to be random two least_conn

### DIFF
--- a/examples/customization/README.md
+++ b/examples/customization/README.md
@@ -42,7 +42,7 @@ The table below summarizes all of the options. For some of them, there are examp
 | N/A | `ingress-template` | Sets the NGINX configuration template for an Ingress resource. | By default the template is read from the file on the container. | [Custom Templates](../custom-templates). |
 | `nginx.org/location-snippets` | `location-snippets` | Sets a custom snippet in location context. | N/A | |
 | `nginx.org/server-snippets` | `server-snippets` | Sets a custom snippet in server context. | N/A | |
-| `nginx.org/lb-method` | `lb-method` | Sets the [load balancing method](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#choosing-a-load-balancing-method). To use the round-robin method, specify `"round_robin"`. | `"least_conn"` | |
+| `nginx.org/lb-method` | `lb-method` | Sets the [load balancing method](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#choosing-a-load-balancing-method). To use the round-robin method, specify `"round_robin"`. | `"random two least_conn"` | |
 | `nginx.org/listen-ports` | N/A | Configures HTTP ports that NGINX will listen on. | `[80]` | |
 | `nginx.org/listen-ports-ssl` | N/A | Configures HTTPS ports that NGINX will listen on. | `[443]` | |
 | N/A | `worker-processes` | Sets the value of the [worker_processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes) directive. | `auto` | |

--- a/examples/customization/nginx-config.yaml
+++ b/examples/customization/nginx-config.yaml
@@ -45,7 +45,7 @@ data:
     if ($new_uri) {
         rewrite ^ $new_uri permanent;
     }
-  lb-method: "round_robin" # default is least_conn. Sets the load balancing method for upstreams. See https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#choosing-a-load-balancing-method
+  lb-method: "round_robin" # default is random two least_conn. Sets the load balancing method for upstreams. See https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#choosing-a-load-balancing-method
   location-snippets: | # No default. Pipe is used for multiple line snippets. Make sure the snippet is not a default value, in order to avoid duplication.
     proxy_temp_path  /var/nginx/proxy_temp;
     charset  koi8-r;

--- a/internal/nginx/config.go
+++ b/internal/nginx/config.go
@@ -92,7 +92,7 @@ func NewDefaultConfig() *Config {
 		SSLPorts:                   []int{443},
 		MaxFails:                   1,
 		FailTimeout:                "10s",
-		LBMethod:                   "least_conn",
+		LBMethod:                   "random two least_conn",
 		MainErrorLogLevel:          "notice",
 	}
 }

--- a/internal/nginx/configurator_test.go
+++ b/internal/nginx/configurator_test.go
@@ -234,7 +234,7 @@ func createCafeIngressEx() IngressEx {
 func createExpectedConfigForCafeIngressEx() IngressNginxConfig {
 	coffeeUpstream := Upstream{
 		Name:     "default-cafe-ingress-cafe.example.com-coffee-svc-80",
-		LBMethod: "least_conn",
+		LBMethod: "random two least_conn",
 		UpstreamServers: []UpstreamServer{
 			{
 				Address:     "10.0.0.1",
@@ -246,7 +246,7 @@ func createExpectedConfigForCafeIngressEx() IngressNginxConfig {
 	}
 	teaUpstream := Upstream{
 		Name:     "default-cafe-ingress-cafe.example.com-tea-svc-80",
-		LBMethod: "least_conn",
+		LBMethod: "random two least_conn",
 		UpstreamServers: []UpstreamServer{
 			{
 				Address:     "10.0.0.2",
@@ -434,7 +434,7 @@ func createMergeableCafeIngress() *MergeableIngresses {
 func createExpectedConfigForMergeableCafeIngress() IngressNginxConfig {
 	coffeeUpstream := Upstream{
 		Name:     "default-cafe-ingress-coffee-minion-cafe.example.com-coffee-svc-80",
-		LBMethod: "least_conn",
+		LBMethod: "random two least_conn",
 		UpstreamServers: []UpstreamServer{
 			{
 				Address:     "10.0.0.1",
@@ -446,7 +446,7 @@ func createExpectedConfigForMergeableCafeIngress() IngressNginxConfig {
 	}
 	teaUpstream := Upstream{
 		Name:     "default-cafe-ingress-tea-minion-cafe.example.com-tea-svc-80",
-		LBMethod: "least_conn",
+		LBMethod: "random two least_conn",
 		UpstreamServers: []UpstreamServer{
 			{
 				Address:     "10.0.0.2",


### PR DESCRIPTION
### Proposed changes
* Random two least_conn is now the default lb-method as implemented in https://github.com/nginxinc/kubernetes-ingress/commit/5c7be23b502a447e1f9849fee6e37c4eebbcffbe

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
