### PR TITLE
Add `nginx-status-allow-cidrs` and service externalIPs to Helm chart

### DIFF
--- a/deployments/helm-chart/Chart.yaml
+++ b/deployments/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.1.3
+version: 0.1.4
 appVersion: edge
 description: NGINX Ingress Controller
 sources:

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -85,10 +85,10 @@ Parameter | Description | Default
 `controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress controller. | false
 `controller.nginxStatus.enable` | Enable the NGINX stub_status, or the NGINX Plus API. | true
 `controller.nginxStatus.port` | Set the port where the NGINX stub_status or the NGINX Plus API is exposed. | 8080
+`controller.nginxStatus.allowCidrs` | Whitelist IPv4 IP/CIDR blocks to allow access to NGINX stub_status or the NGINX Plus API. Separate multiple IP/CIDR by commas. | 127.0.0.1
 `controller.reportIngressStatus.enable` | Update the address field in the status of Ingresses resources with an external address of the Ingress controller. You must also specify the source of the external address either through an external service via `controller.reportIngressStatus.externalService` or the `external-status-address` entry in the ConfigMap via `controller.config.entries`. **Note:** `controller.config.entries.external-status-address` takes precedence if both are set. | true
 `controller.reportIngressStatus.externalService` | Specifies the name of the service with the type LoadBalancer through which the Ingress controller is exposed externally. The external address of the service is used when reporting the status of Ingress resources. `controller.reportIngressStatus.enable` must be set to `true`. | nginx-ingress
 `controller.reportIngressStatus.enableLeaderElection` | Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources. `controller.reportIngressStatus.enable` must be set to `true`. | true
-`controller.nginxStatusAllowCidrs` | Whitelist IPv4 IP/CIDR blocks to allow access to NGINX stub_status or the NGINX Plus API. Separate multiple IP/CIDR by commas. | 127.0.0.1
 `rbac.create` | Configures RBAC. | true
 `prometheues.create` | Deploys a Prometheus exporter container within the Ingress controller pod. Requires NGINX status enabled via `controller.nginxStatus.enable`. Note: the exporter will use the port specified by `controller.nginxStatus.port`.| false
 `prometheus.port` | Configures the port to scrape the metrics. | 9113

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -77,16 +77,18 @@ Parameter | Description | Default
 `controller.service.externalTrafficPolicy` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | Local
 `controller.service.annotations` | The annotations of the Ingress controller service. | { }
 `controller.service.loadBalancerIP` | The static IP address for the load balancer. Requires `controller.service.type` set to `LoadBalancer`.  | None
+`controller.service.externalIPs` | Traffic that ingresses into the cluster with the external IP (as destination IP), on the service port, will be routed to the Ingress Controller service endpoints. externalIPs are not managed by Kubernetes and are the responsibility of the cluster administrator. | []
 `controller.serviceAccountName` | The serviceAccountName of the Ingress controller pods. Used for RBAC. | nginx-ingress
 `controller.ingressClass` | A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its class - i.e. have the annotation `"kubernetes.io/ingress.class"` equal to the class. Additionally, the Ingress controller processes Ingress resources that do not have that annotation which can be disabled by setting the "-use-ingress-class-only" flag. | nginx
 `controller.useIngressClassOnly` | Ignore Ingress resources without the `"kubernetes.io/ingress.class"` annotation. | false
 `controller.watchNamespace` | Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces. | ""
 `controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress controller. | false
-`controller.nginxStatus.enable` | Enable the NGINX stub_status, or the NGINX Plus API. | true 
+`controller.nginxStatus.enable` | Enable the NGINX stub_status, or the NGINX Plus API. | true
 `controller.nginxStatus.port` | Set the port where the NGINX stub_status or the NGINX Plus API is exposed. | 8080
 `controller.reportIngressStatus.enable` | Update the address field in the status of Ingresses resources with an external address of the Ingress controller. You must also specify the source of the external address either through an external service via `controller.reportIngressStatus.externalService` or the `external-status-address` entry in the ConfigMap via `controller.config.entries`. **Note:** `controller.config.entries.external-status-address` takes precedence if both are set. | true
 `controller.reportIngressStatus.externalService` | Specifies the name of the service with the type LoadBalancer through which the Ingress controller is exposed externally. The external address of the service is used when reporting the status of Ingress resources. `controller.reportIngressStatus.enable` must be set to `true`. | nginx-ingress
 `controller.reportIngressStatus.enableLeaderElection` | Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources. `controller.reportIngressStatus.enable` must be set to `true`. | true
+`controller.nginxStatusAllowCidrs` | Whitelist IPv4 IP/CIDR blocks to allow access to NGINX stub_status or the NGINX Plus API. Separate multiple IP/CIDR by commas. | 127.0.0.1
 `rbac.create` | Configures RBAC. | true
 `prometheues.create` | Deploys a Prometheus exporter container within the Ingress controller pod. Requires NGINX status enabled via `controller.nginxStatus.enable`. Note: the exporter will use the port specified by `controller.nginxStatus.port`.| false
 `prometheus.port` | Configures the port to scrape the metrics. | 9113

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -77,7 +77,7 @@ Parameter | Description | Default
 `controller.service.externalTrafficPolicy` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | Local
 `controller.service.annotations` | The annotations of the Ingress controller service. | { }
 `controller.service.loadBalancerIP` | The static IP address for the load balancer. Requires `controller.service.type` set to `LoadBalancer`.  | None
-`controller.service.externalIPs` | Traffic that ingresses into the cluster with the external IP (as destination IP), on the service port, will be routed to the Ingress Controller service endpoints. externalIPs are not managed by Kubernetes and are the responsibility of the cluster administrator. | []
+`controller.service.externalIPs` | The list of external IPs for the Ingress controller service. | []
 `controller.serviceAccountName` | The serviceAccountName of the Ingress controller pods. Used for RBAC. | nginx-ingress
 `controller.ingressClass` | A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its class - i.e. have the annotation `"kubernetes.io/ingress.class"` equal to the class. Additionally, the Ingress controller processes Ingress resources that do not have that annotation which can be disabled by setting the "-use-ingress-class-only" flag. | nginx
 `controller.useIngressClassOnly` | Ignore Ingress resources without the `"kubernetes.io/ingress.class"` annotation. | false

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -79,8 +79,6 @@ spec:
           - -report-ingress-status
           - -external-service={{ .Values.controller.reportIngressStatus.externalService }}
           - -enable-leader-election={{ .Values.controller.reportIngressStatus.enableLeaderElection }}
-{{- end }}
-{{- if .Values.controller.nginxStatus.allowCidrs }}
           - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatus.allowCidrs }}
 {{- end }}
 {{- if and .Values.prometheus.create .Values.controller.nginxStatus.enable }}

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -80,6 +80,9 @@ spec:
           - -external-service={{ .Values.controller.reportIngressStatus.externalService }}
           - -enable-leader-election={{ .Values.controller.reportIngressStatus.enableLeaderElection }}
 {{- end }}
+{{- if .Values.controller.nginxStatus.allowCidrs }}
+          - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatus.allowCidrs }}
+{{- end }}
 {{- if and .Values.prometheus.create .Values.controller.nginxStatus.enable }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
         name: nginx-prometheus-exporter

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -74,12 +74,12 @@ spec:
 {{- if .Values.controller.nginxStatus.enable }}
           - -nginx-status
           - -nginx-status-port={{ .Values.controller.nginxStatus.port }}
+          - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatus.allowCidrs }}
 {{- end }}
 {{- if .Values.controller.reportIngressStatus.enable }}
           - -report-ingress-status
           - -external-service={{ .Values.controller.reportIngressStatus.externalService }}
           - -enable-leader-election={{ .Values.controller.reportIngressStatus.enableLeaderElection }}
-          - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatus.allowCidrs }}
 {{- end }}
 {{- if and .Values.prometheus.create .Values.controller.nginxStatus.enable }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -66,8 +66,8 @@ spec:
           - -external-service={{ .Values.controller.reportIngressStatus.externalService }}
           - -enable-leader-election={{ .Values.controller.reportIngressStatus.enableLeaderElection }}
 {{- end }}
-{{- if .Values.controller.nginxStatusAllowCidrs }}
-          - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatusAllowCidrs }}
+{{- if .Values.controller.nginxStatus.allowCidrs }}
+          - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatus.allowCidrs }}
 {{- end }}
 {{- if and .Values.prometheus.create .Values.controller.nginxStatus.enable }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -60,12 +60,12 @@ spec:
 {{- if .Values.controller.nginxStatus.enable }}
           - -nginx-status
           - -nginx-status-port={{ .Values.controller.nginxStatus.port }}
+          - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatus.allowCidrs }}
 {{- end }}
 {{- if .Values.controller.reportIngressStatus.enable }}
           - -report-ingress-status
           - -external-service={{ .Values.controller.reportIngressStatus.externalService }}
           - -enable-leader-election={{ .Values.controller.reportIngressStatus.enableLeaderElection }}
-          - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatus.allowCidrs }}
 {{- end }}
 {{- if and .Values.prometheus.create .Values.controller.nginxStatus.enable }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -66,6 +66,9 @@ spec:
           - -external-service={{ .Values.controller.reportIngressStatus.externalService }}
           - -enable-leader-election={{ .Values.controller.reportIngressStatus.enableLeaderElection }}
 {{- end }}
+{{- if .Values.controller.nginxStatusAllowCidrs }}
+          - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatusAllowCidrs }}
+{{- end }}
 {{- if and .Values.prometheus.create .Values.controller.nginxStatus.enable }}
       - image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
         name: nginx-prometheus-exporter

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -65,8 +65,6 @@ spec:
           - -report-ingress-status
           - -external-service={{ .Values.controller.reportIngressStatus.externalService }}
           - -enable-leader-election={{ .Values.controller.reportIngressStatus.enableLeaderElection }}
-{{- end }}
-{{- if .Values.controller.nginxStatus.allowCidrs }}
           - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatus.allowCidrs }}
 {{- end }}
 {{- if and .Values.prometheus.create .Values.controller.nginxStatus.enable }}

--- a/deployments/helm-chart/templates/controller-service.yaml
+++ b/deployments/helm-chart/templates/controller-service.yaml
@@ -33,4 +33,8 @@ spec:
     name: https
   selector:
     app: {{ .Values.controller.name | trunc 63 }}
+  {{- if .Values.controller.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.controller.service.externalIPs | indent 4 }}
+  {{- end }}
 {{- end }}

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -31,11 +31,13 @@ controller:
     externalTrafficPolicy: Local
     annotations: {}
     loadBalancerIP: ""
+    externalIPs: []
   serviceAccountName: nginx-ingress
   reportIngressStatus:
     enable: true
     externalService: nginx-ingress
     enableLeaderElection: true
+  nginxStatusAllowCidrs: "127.0.0.1"
 rbac:
   create: true
 prometheus:

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -25,6 +25,7 @@ controller:
   nginxStatus:
     enable: true
     port: 8080
+    allowCidrs: "127.0.0.1"
   service:
     create: true
     type: LoadBalancer
@@ -37,7 +38,6 @@ controller:
     enable: true
     externalService: nginx-ingress
     enableLeaderElection: true
-  nginxStatusAllowCidrs: "127.0.0.1"
 rbac:
   create: true
 prometheus:


### PR DESCRIPTION
### Proposed changes
* Add `nginx-status-allow-cidrs` cli argument support to helm chart. Implemented in: https://github.com/nginxinc/kubernetes-ingress/pull/387
* Add [service externalIPs](https://kubernetes.io/docs/concepts/services-networking/service/#external-ips) support to the service template of the helm chart.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
