### PR TITLE
Improve secret handling

### DIFF
--- a/internal/handlers/secret.go
+++ b/internal/handlers/secret.go
@@ -17,11 +17,8 @@ func CreateSecretHandlers(lbc *controller.LoadBalancerController) cache.Resource
 			if err := lbc.ValidateSecret(secret); err != nil {
 				return
 			}
-			nsname := secret.Namespace + "/" + secret.Name
-			if nsname == lbc.GetDefaultServerSecret() {
-				glog.V(3).Infof("Adding default server Secret: %v", secret.Name)
-				lbc.AddSyncQueue(obj)
-			}
+			glog.V(3).Infof("Adding Secret: %v", secret.Name)
+			lbc.AddSyncQueue(obj)
 		},
 		DeleteFunc: func(obj interface{}) {
 			secret, isSecr := obj.(*api_v1.Secret)

--- a/internal/nginx/ingress.go
+++ b/internal/nginx/ingress.go
@@ -12,7 +12,7 @@ import (
 type IngressEx struct {
 	Ingress      *extensions.Ingress
 	TLSSecrets   map[string]*api_v1.Secret
-	JWTKey       *api_v1.Secret
+	JWTKey       JWTKey
 	Endpoints    map[string][]string
 	HealthChecks map[string]*api_v1.Probe
 }
@@ -21,6 +21,12 @@ type IngressEx struct {
 type MergeableIngresses struct {
 	Master  *IngressEx
 	Minions []*IngressEx
+}
+
+// JWTKey represents a secret that holds JSON Web Key
+type JWTKey struct {
+	Name   string
+	Secret *api_v1.Secret
 }
 
 var masterBlacklist = map[string]bool{

--- a/internal/nginx/nginx.go
+++ b/internal/nginx/nginx.go
@@ -84,6 +84,7 @@ type Server struct {
 	SSL                   bool
 	SSLCertificate        string
 	SSLCertificateKey     string
+	SSLCiphers            string
 	GRPCOnly              bool
 	StatusZone            string
 	HTTP2                 bool

--- a/internal/nginx/secret.go
+++ b/internal/nginx/secret.go
@@ -28,8 +28,8 @@ func ValidateTLSSecret(secret *api_v1.Secret) error {
 
 // ValidateJWKSecret validates the secret. If it is valid, the function returns nil.
 func ValidateJWKSecret(secret *api_v1.Secret) error {
-	if _, exists := secret.Data[JWTKey]; !exists {
-		return fmt.Errorf("Secret doesn't have %v", JWTKey)
+	if _, exists := secret.Data[JWTKeyKey]; !exists {
+		return fmt.Errorf("Secret doesn't have %v", JWTKeyKey)
 	}
 
 	return nil

--- a/internal/nginx/templates/nginx-plus.ingress.tmpl
+++ b/internal/nginx/templates/nginx-plus.ingress.tmpl
@@ -31,6 +31,9 @@ server {
 	{{- end}}
 	ssl_certificate {{$server.SSLCertificate}};
 	ssl_certificate_key {{$server.SSLCertificateKey}};
+	{{if $server.SSLCiphers}}
+	ssl_ciphers {{$server.SSLCiphers}};
+	{{end}}
 	{{end}}
 	{{range $setRealIPFrom := $server.SetRealIPFrom}}
 	set_real_ip_from {{$setRealIPFrom}};{{end}}

--- a/internal/nginx/templates/nginx.ingress.tmpl
+++ b/internal/nginx/templates/nginx.ingress.tmpl
@@ -20,6 +20,9 @@ server {
 	{{- end}}
 	ssl_certificate {{$server.SSLCertificate}};
 	ssl_certificate_key {{$server.SSLCertificateKey}};
+	{{if $server.SSLCiphers}}
+	ssl_ciphers {{$server.SSLCiphers}};
+	{{end}}
 	{{end}}
 	{{range $setRealIPFrom := $server.SetRealIPFrom}}
 	set_real_ip_from {{$setRealIPFrom}};{{end}}

--- a/internal/nginx/templates/templates_test.go
+++ b/internal/nginx/templates/templates_test.go
@@ -51,6 +51,7 @@ var ingCfg = nginx.IngressNginxConfig{
 			SSL:               true,
 			SSLCertificate:    "secret.pem",
 			SSLCertificateKey: "secret.pem",
+			SSLCiphers:        "NULL",
 			SSLPorts:          []int{443},
 			SSLRedirect:       true,
 			Locations: []nginx.Location{


### PR DESCRIPTION
### Proposed changes

- Simplify the secret handling logic.
- Change the secret handling logic. See below.

Changes:

1. An Ingress includes TLS termination, but the referenced
TLS Secret is missing in Kubernetes/invalid or goes missing/
becomes invalid. An Ingress can be a regular Ingress or a
mergeable Master.

Before: the Ingress resource was rejected.

Now: the Ingress resource is not rejected. Instead, the generated
config for that Ingress resource now includes the ssl_ciphers
directive set to "NULL", which makes NGINX break any attempt to
establish a TLS connection with the corresponding Ingress host.

2. An Ingress includes JWT auth, but the referenced JWK is
missing in Kubernetes/invalid or goes missing/becomes invalid.
An Ingress can be a regular Ingress, a mergeable Master or
a mergeable Minion.

Before: the Ingress resource was rejected.

Now. the Ingress resource is not rejected. However, the generated
config for that Ingress still references the JWK on the file system,
which does not exist. This makes NGINX Plus return a 500 response
for a request to the corresponding Ingress host (or the path of the
host for mergeable minions).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
