### PR TITLE
Improve NGINX start

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -229,7 +229,6 @@ func main() {
 
 	var nginxAPI *plus.NginxAPIController
 	if *nginxPlus {
-		time.Sleep(500 * time.Millisecond)
 		httpClient := getSocketClient()
 		nginxAPI, err = plus.NewNginxAPIController(&httpClient, "http://nginx-plus-api/api", local)
 		if err != nil {

--- a/internal/nginx/verify/client.go
+++ b/internal/nginx/verify/client.go
@@ -60,16 +60,18 @@ func (c *Client) WaitForCorrectVersion(expectedVersion int) error {
 	// This value needs tuning.
 	maxRetries := 160
 	sleep := 25 * time.Millisecond
-	for i := 0; i < maxRetries; i++ {
+	for i := 1; i <= maxRetries; i++ {
+		time.Sleep(sleep)
+
 		version, err := c.GetConfigVersion()
 		if err != nil {
-			return fmt.Errorf("unable to fetch version: %v", err)
+			glog.V(3).Infof("Unable to fetch version: %v", err)
+			continue
 		}
 		if version == expectedVersion {
 			glog.V(3).Infof("success, version %v ensured. iterations: %v. took: %v", expectedVersion, i, time.Duration(i)*sleep)
 			return nil
 		}
-		time.Sleep(sleep)
 	}
 	return fmt.Errorf("could not get expected version: %v", expectedVersion)
 }


### PR DESCRIPTION
### Proposed changes

Improve how the IC starts NGINX

For NGINX and NGINX Plus:
- After the IC starts NGINX, check that NGINX is running by
querying the config version via the unix socket -- the same check
that is performed after each configuration reload.
- Modify the check to always sleep before the first check.

For NGINX Plus:
- Remove no longer required 0.5s timeout during the IC start.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
