### PR TITLE
Fix Helm Chart disable nginxStatus bug

### DIFF
--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -72,8 +72,8 @@ spec:
 {{- end }}
           - -health-status={{ .Values.controller.healthStatus }}
           - -nginx-debug={{ .Values.controller.nginxDebug }}
+          - -nginx-status={{ .Values.controller.nginxStatus.enable }}
 {{- if .Values.controller.nginxStatus.enable }}
-          - -nginx-status
           - -nginx-status-port={{ .Values.controller.nginxStatus.port }}
           - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatus.allowCidrs }}
 {{- end }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -58,8 +58,8 @@ spec:
 {{- end }}
           - -health-status={{ .Values.controller.healthStatus }}
           - -nginx-debug={{ .Values.controller.nginxDebug }}
+          - -nginx-status={{ .Values.controller.nginxStatus.enable }}
 {{- if .Values.controller.nginxStatus.enable }}
-          - -nginx-status
           - -nginx-status-port={{ .Values.controller.nginxStatus.port }}
           - -nginx-status-allow-cidrs={{ .Values.controller.nginxStatus.allowCidrs }}
 {{- end }}


### PR DESCRIPTION
### Bug description:
It is not possible to disable NGINX Status through the helm chart.

Expected behaviour: 
`helm install --name test --set controller.nginxStatus.enable=false .` disables NGINX Status

Actual:
`helm install --name test --set controller.nginxStatus.enable=false .` does not disable NGINX Status

The bug arises because the template assumes nginxStatus has a default value of `false` but it defaults to `true`

Bug introduced in: https://github.com/nginxinc/kubernetes-ingress/commit/ebb2a512c096da94a5cdcc2a9101f1f28a2af5a0

### Proposed changes
* nginxStatus cli argument is now set to false if nginxStatus.enable set to `false` in `values.yaml`

`helm install --name test --set controller.nginxStatus.enable=false .` now disables NGINX Status

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
