### PR TITLE
Fix panic with health checks

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1043,7 +1043,7 @@ func findProbeForPods(pods []api_v1.Pod, svcPort *api_v1.ServicePort) *api_v1.Pr
 			for _, port := range container.Ports {
 				if compareContainerPortAndServicePort(port, *svcPort) {
 					// only http ReadinessProbes are useful for us
-					if container.ReadinessProbe.Handler.HTTPGet != nil && container.ReadinessProbe.PeriodSeconds > 0 {
+					if container.ReadinessProbe != nil && container.ReadinessProbe.Handler.HTTPGet != nil && container.ReadinessProbe.PeriodSeconds > 0 {
 						return container.ReadinessProbe
 					}
 				}


### PR DESCRIPTION
### Proposed changes

If health checking was enabled, but no readiness probe was defined
in the pod templates, the Ingress Controller would crash. This
commit fixes that.

Fixes https://github.com/nginxinc/kubernetes-ingress/issues/417

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
