### PR TITLE
Fix lb-method validation

### DIFF
--- a/internal/nginx/extensions.go
+++ b/internal/nginx/extensions.go
@@ -25,16 +25,14 @@ func ParseLBMethod(method string) (string, error) {
 }
 
 var nginxLBValidInput = map[string]bool{
-	"least_conn":                      true,
-	"ip_hash":                         true,
-	"random":                          true,
-	"random two":                      true,
-	"random two least_conn":           true,
+	"least_conn":            true,
+	"ip_hash":               true,
+	"random":                true,
+	"random two":            true,
+	"random two least_conn": true,
 }
 
 var nginxPlusLBValidInput = map[string]bool{
-	"least_time":                      true,
-	"last_byte":                       true,
 	"least_conn":                      true,
 	"ip_hash":                         true,
 	"random":                          true,

--- a/internal/nginx/extensions_test.go
+++ b/internal/nginx/extensions_test.go
@@ -72,6 +72,8 @@ func TestParseLBMethodForPlus(t *testing.T) {
 		"",
 		"blabla",
 		"hash123",
+		"least_time",
+		"last_byte",
 		"least_time inflight header",
 		"random one",
 		"random two ip_hash",


### PR DESCRIPTION
### Bug description
`lb-method` and `nginx.org/lb-method` currently allow the following invalid values: `"least_time"` and `"last_byte"`.

### Proposed changes
* `"least_time"` and `"last_byte"` are no longer valid input
* Add the above as invalid input to unit test

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
