### PR TITLE
Fix TestVerifyClient performance

### DIFF
--- a/internal/nginx/verify/client.go
+++ b/internal/nginx/verify/client.go
@@ -14,7 +14,8 @@ import (
 
 // Client is a client for verifying the config version.
 type Client struct {
-	client *http.Client
+	client     *http.Client
+	maxRetries int
 }
 
 // NewClient returns a new client pointed at the config version socket.
@@ -27,6 +28,7 @@ func NewClient() *Client {
 				},
 			},
 		},
+		maxRetries: 160,
 	}
 }
 
@@ -57,10 +59,8 @@ func (c *Client) GetConfigVersion() (int, error) {
 // WaitForCorrectVersion calls the config version endpoint until it gets the expectedVersion,
 // which ensures that a new worker process has been started for that config version.
 func (c *Client) WaitForCorrectVersion(expectedVersion int) error {
-	// This value needs tuning.
-	maxRetries := 160
 	sleep := 25 * time.Millisecond
-	for i := 1; i <= maxRetries; i++ {
+	for i := 1; i <= c.maxRetries; i++ {
 		time.Sleep(sleep)
 
 		version, err := c.GetConfigVersion()

--- a/internal/nginx/verify/client_test.go
+++ b/internal/nginx/verify/client_test.go
@@ -27,9 +27,9 @@ func getTestHTTPClient() *http.Client {
 }
 
 func TestVerifyClient(t *testing.T) {
-
 	c := Client{
-		client: getTestHTTPClient(),
+		client:     getTestHTTPClient(),
+		maxRetries: 1,
 	}
 
 	configVersion, err := c.GetConfigVersion()


### PR DESCRIPTION
### Proposed changes
When running a unit test VerifyClient only tries once to get the correct config version

This improves the speed of initial run of tests. Which is helpful in building images for private registries, and CI pipeline build times.


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
