### PR TITLE
Feature - Add nodeSelector, affinity and tolerations to daemonset and deployment templates

### DIFF
--- a/deployments/helm-chart/Chart.yaml
+++ b/deployments/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.2.0
+version: 0.3.0
 appVersion: edge
 description: NGINX Ingress Controller
 sources:

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -71,7 +71,8 @@ Parameter | Description | Default
 `controller.defaultTLS.secret` | The secret with a TLS certificate and key for the default HTTPS server. The value must follow the following format: `<namespace>/<name>`. Used as an alternative to specifiying a certifcate and key using `controller.defaultTLS.cert` and `controller.defaultTLS.key` parameters. | None
 `controller.nodeSelector` | The node selector for pod assignment for the Ingress controller pods. | { }
 `controller.terminationGracePeriodSeconds` | The termination grace period of the Ingress controller pod. | 30
-`controller.tolerations` | The tolerations required for the IBM Cloud Private installation. | None
+`controller.tolerations` | The taints to tolerate for the Ingress controller pods. | []
+`controller.affinity` | The affinities of the ingress controller pods. | { }
 `controller.replicaCount` | The number of replicas of the Ingress controller deployment. | 1
 `controller.service.create` | Creates a service to expose the Ingress controller pods. | true
 `controller.service.type` | The type of service to create for the Ingress controller. | LoadBalancer

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -71,8 +71,8 @@ Parameter | Description | Default
 `controller.defaultTLS.secret` | The secret with a TLS certificate and key for the default HTTPS server. The value must follow the following format: `<namespace>/<name>`. Used as an alternative to specifiying a certifcate and key using `controller.defaultTLS.cert` and `controller.defaultTLS.key` parameters. | None
 `controller.nodeSelector` | The node selector for pod assignment for the Ingress controller pods. | { }
 `controller.terminationGracePeriodSeconds` | The termination grace period of the Ingress controller pod. | 30
-`controller.tolerations` | The taints to tolerate for the Ingress controller pods. | []
-`controller.affinity` | The affinities of the ingress controller pods. | { }
+`controller.tolerations` | The tolerations of the Ingress controller pods. | []
+`controller.affinity` | The affinity of the Ingress controller pods. | { }
 `controller.replicaCount` | The number of replicas of the Ingress controller deployment. | 1
 `controller.service.create` | Creates a service to expose the Ingress controller pods. | true
 `controller.service.type` | The type of service to create for the Ingress controller. | LoadBalancer

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -26,15 +26,15 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
 {{- if .Values.controller.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.controller.nodeSelector | trimSuffix "\n" | indent 8 }}
+{{ toYaml .Values.controller.nodeSelector | indent 8 }}
 {{- end }}
 {{- if .Values.controller.tolerations }}
       tolerations:
-{{ toYaml .Values.controller.tolerations | trimSuffix "\n" | indent 6 }}
+{{ toYaml .Values.controller.tolerations | indent 6 }}
 {{- end }}
 {{- if .Values.controller.affinity }}
       affinity:
-{{ toYaml .Values.controller.affinity | trimSuffix "\n" | indent 8 }}
+{{ toYaml .Values.controller.affinity | indent 8 }}
 {{- end }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
       containers:

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -26,15 +26,15 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
 {{- if .Values.controller.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.controller.nodeSelector | indent 8 }}
+{{ toYaml .Values.controller.nodeSelector | trimSuffix "\n" | indent 8 }}
 {{- end }}
-{{- if eq .Values.controller.tolerations "icp" }}
+{{- if .Values.controller.tolerations }}
       tolerations:
-      - key: "dedicated"
-        operator: "Exists"
-        effect: "NoSchedule"
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
+{{ toYaml .Values.controller.tolerations | trimSuffix "\n" | indent 6 }}
+{{- end }}
+{{- if .Values.controller.affinity }}
+      affinity:
+{{ toYaml .Values.controller.affinity | trimSuffix "\n" | indent 8 }}
 {{- end }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
       containers:

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -25,15 +25,15 @@ spec:
     spec:
 {{- if .Values.controller.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.controller.nodeSelector | trimSuffix "\n" | indent 8 }}
+{{ toYaml .Values.controller.nodeSelector | indent 8 }}
 {{- end }}
 {{- if .Values.controller.tolerations }}
       tolerations:
-{{ toYaml .Values.controller.tolerations | trimSuffix "\n" | indent 6 }}
+{{ toYaml .Values.controller.tolerations | indent 6 }}
 {{- end }}
 {{- if .Values.controller.affinity }}
       affinity:
-{{ toYaml .Values.controller.affinity | trimSuffix "\n" | indent 8 }}
+{{ toYaml .Values.controller.affinity | indent 8 }}
 {{- end }}
       serviceAccountName: {{ .Values.controller.serviceAccount.name }}
       hostNetwork: {{ .Values.controller.hostNetwork }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -23,6 +23,18 @@ spec:
         prometheus.io/port: "{{ .Values.prometheus.port }}"
 {{- end }}
     spec:
+{{- if .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.controller.nodeSelector | trimSuffix "\n" | indent 8 }}
+{{- end }}
+{{- if .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml .Values.controller.tolerations | trimSuffix "\n" | indent 6 }}
+{{- end }}
+{{- if .Values.controller.affinity }}
+      affinity:
+{{ toYaml .Values.controller.affinity | trimSuffix "\n" | indent 8 }}
+{{- end }}
       serviceAccountName: {{ .Values.controller.serviceAccount.name }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
       containers:

--- a/deployments/helm-chart/values-icp.yaml
+++ b/deployments/helm-chart/values-icp.yaml
@@ -7,4 +7,9 @@ controller:
   nodeSelector: { beta.kubernetes.io/arch: "amd64",
                    proxy: "true" }
   terminationGracePeriodSeconds: 60
-  tolerations: "icp"
+  tolerations:
+    - key: "dedicated"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"

--- a/deployments/helm-chart/values-icp.yaml
+++ b/deployments/helm-chart/values-icp.yaml
@@ -4,8 +4,9 @@ controller:
   image:
     repository: mycluster.icp:8500/kube-system/nginx-plus-ingress
     tag: "edge"
-  nodeSelector: { beta.kubernetes.io/arch: "amd64",
-                   proxy: "true" }
+  nodeSelector:
+    beta.kubernetes.io/arch: "amd64"
+    proxy: true
   terminationGracePeriodSeconds: 60
   tolerations:
     - key: "dedicated"

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -17,7 +17,8 @@ controller:
     # secret: <namespace>/<secret_name>
   nodeSelector: {}
   terminationGracePeriodSeconds: 30
-  tolerations: ""
+  tolerations: []
+  affinity: {}
   replicaCount: 1
   ingressClass: nginx
   useIngressClassOnly: false


### PR DESCRIPTION
Fixes: https://github.com/nginxinc/kubernetes-ingress/issues/444

### Proposed changes
* Add nodeSelector support to deployment template
* Add affinity support to daemonset and deployment templates
* Tolerations changed to be more flexible. Can now be used in deployments and daemonsets that are not deployed to ICP
* Improved formatting of `values-icp.yaml`
### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
