### PR TITLE
Add custom NodePort to helm controller-service.

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -81,6 +81,8 @@ Parameter | Description | Default
 `controller.service.loadBalancerIP` | The static IP address for the load balancer. Requires `controller.service.type` set to `LoadBalancer`. The cloud provider must support this feature.  | None
 `controller.service.loadBalancerSourceRanges` | The IP ranges (CIDR) that are allowed to access the load balancer. Requires `controller.service.type` set to `LoadBalancer`. The cloud provider must support this feature. | []
 `controller.service.externalIPs` | The list of external IPs for the Ingress controller service. | []
+`controller.service.NodePort.Http` | Custom NodePort number for http. Requires `controller.service.type` set to `NodePort`. | None
+`controller.service.NodePort.Https` | Custom NodePort number for https. Requires `controller.service.type` set to `NodePort`. | None
 `controller.serviceAccount.name` | The name of the service account of the Ingress controller pods. Used for RBAC. | nginx-ingress
 `controller.serviceAccount.imagePullSecrets` | The names of the secrets containing docker registry credentials. | []
 `controller.ingressClass` | A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its class - i.e. have the annotation `"kubernetes.io/ingress.class"` equal to the class. Additionally, the Ingress controller processes Ingress resources that do not have that annotation which can be disabled by setting the "-use-ingress-class-only" flag. | nginx

--- a/deployments/helm-chart/templates/controller-service.yaml
+++ b/deployments/helm-chart/templates/controller-service.yaml
@@ -33,10 +33,20 @@ spec:
     targetPort: 80
     protocol: TCP
     name: http
+  {{- if (eq .Values.controller.service.type "NodePort") }}
+    {{- if .Values.controller.service.NodePort.Http }}
+    nodePort: {{ .Values.controller.service.NodePort.Http }}
+    {{- end}}
+  {{- end}}
   - port: 443
     targetPort: 443
     protocol: TCP
     name: https
+  {{- if (eq .Values.controller.service.type "NodePort") }}
+    {{- if .Values.controller.service.NodePort.Https }}
+    nodePort: {{ .Values.controller.service.NodePort.Https }}
+    {{- end}}
+  {{- end}}
   selector:
     app: {{ .Values.controller.name | trunc 63 }}
   {{- if .Values.controller.service.externalIPs }}


### PR DESCRIPTION
### Proposed changes
Add two configuration parameters to helm chart controller service, in order to use custom ports number when using NodePort.

These are the new parameters:
`controller.service.NodePort.Http`
`controller.service.NodePort.Https`

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] I have checked that all unit tests pass after adding my changes
- [ X] I have updated necessary documentation
- [ X] I have rebased my branch onto master
- [ X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
