### PR TITLE
Update nginx-ingress-with-prometheus.yaml

### DIFF
--- a/deployments/deployment/nginx-ingress-with-prometheus.yaml
+++ b/deployments/deployment/nginx-ingress-with-prometheus.yaml
@@ -49,5 +49,5 @@ spec:
         args:
           - -web.listen-address
           - :9113
-          - nginx.scrape-uri
+          - -nginx.scrape-uri
           - http://127.0.0.1:8080/stub_status


### PR DESCRIPTION
Add missing `-` to use nginx.scrape-uri

### Proposed changes
The example yaml missed `-` to set nginx.scrape-uri correctly

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
