### PR TITLE
Add ports customisation options for ingress controller service.

### DIFF
--- a/deployments/helm-chart/Chart.yaml
+++ b/deployments/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.3.1
+version: 0.3.2
 appVersion: edge
 description: NGINX Ingress Controller
 sources:

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -81,6 +81,12 @@ Parameter | Description | Default
 `controller.service.loadBalancerIP` | The static IP address for the load balancer. Requires `controller.service.type` set to `LoadBalancer`. The cloud provider must support this feature.  | None
 `controller.service.loadBalancerSourceRanges` | The IP ranges (CIDR) that are allowed to access the load balancer. Requires `controller.service.type` set to `LoadBalancer`. The cloud provider must support this feature. | []
 `controller.service.externalIPs` | The list of external IPs for the Ingress controller service. | []
+`controller.service.httpPort.enable` | Enables the HTTP port for the Ingress controller service. | true
+`controller.service.httpPort.port` | The HTTP port of the Ingress controller service. | 80
+`controller.service.httpPort.nodePort` | The custom NodePort for the HTTP port. Requires `controller.service.type` set to `NodePort`. | ""
+`controller.service.httpsPort.enable` | Enables the HTTPS port for the Ingress controller service. | true
+`controller.service.httpsPort.port` | The HTTPS port of the Ingress controller service. | 443
+`controller.service.httpsPort.nodePort` | The custom NodePort for the HTTPS port. Requires `controller.service.type` set to `NodePort`.  | ""
 `controller.serviceAccount.name` | The name of the service account of the Ingress controller pods. Used for RBAC. | nginx-ingress
 `controller.serviceAccount.imagePullSecrets` | The names of the secrets containing docker registry credentials. | []
 `controller.ingressClass` | A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its class - i.e. have the annotation `"kubernetes.io/ingress.class"` equal to the class. Additionally, the Ingress controller processes Ingress resources that do not have that annotation which can be disabled by setting the "-use-ingress-class-only" flag. | nginx

--- a/deployments/helm-chart/templates/controller-service.yaml
+++ b/deployments/helm-chart/templates/controller-service.yaml
@@ -29,14 +29,24 @@ spec:
 {{- end }}
   type: {{ .Values.controller.service.type }}
   ports:
-  - port: 80
+{{- if .Values.controller.service.httpPort.enable }}
+  - port: {{ .Values.controller.service.httpPort.port }}
     targetPort: 80
     protocol: TCP
     name: http
-  - port: 443
+  {{- if eq .Values.controller.service.type "NodePort" }}
+    nodePort: {{ .Values.controller.service.httpPort.nodePort }}
+  {{- end }}
+{{- end }}
+{{- if .Values.controller.service.httpsPort.enable }}
+  - port: {{ .Values.controller.service.httpsPort.port }}
     targetPort: 443
     protocol: TCP
     name: https
+  {{- if eq .Values.controller.service.type "NodePort" }}
+    nodePort: {{ .Values.controller.service.httpsPort.nodePort }}
+  {{- end }}
+{{- end }}
   selector:
     app: {{ .Values.controller.name | trunc 63 }}
   {{- if .Values.controller.service.externalIPs }}

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -36,6 +36,14 @@ controller:
     loadBalancerIP: ""
     externalIPs: []
     loadBalancerSourceRanges: []
+    httpPort:
+      enable: true
+      port: 80
+      nodePort: ""
+    httpsPort:
+      enable: true
+      port: 443
+      nodePort: ""
   serviceAccount:
     name: nginx-ingress
     imagePullSecrets: []


### PR DESCRIPTION
### Proposed changes

Add needed parameters to helm chart in orders to use custom options for the follow features:
* Use custom NodePort numbers in the k8s service.
* Enable/Disable options for http/https port service.
* Set custom ports number for http/https port service.

#### Notes
```
    httpPort:
      enable: true
      port: 80
      nodePort: ""
    httpsPort:
      enable: true
      port: 443
      nodePort: ""
```
Take into account the `port` spec in `httpPort|httpsPort` within `values.yaml` must match the container ports in the deployment|daemonset; another option would be add parametrized `targetPort` to the `values.yaml` and modify subsequents yaml files like `controller-deployment.yaml` and `controller-daemonset.yaml`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
