### PR TITLE
Add support for Kubernetes ExternalName service

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1072,9 +1072,17 @@ func compareContainerPortAndServicePort(containerPort api_v1.ContainerPort, svcP
 
 func (lbc *LoadBalancerController) getEndpointsForIngressBackend(backend *extensions.IngressBackend, namespace string) ([]string, error) {
 	svc, err := lbc.getServiceForIngressBackend(backend, namespace)
+
 	if err != nil {
 		glog.V(3).Infof("Error getting service %v: %v", backend.ServiceName, err)
 		return nil, err
+	}
+
+	if svc.Spec.Type == api_v1.ServiceTypeExternalName {
+		var endpoints []string
+		endpoint := fmt.Sprintf("%s:%d", backend.ServiceName, int32(backend.ServicePort.IntValue()) )
+		endpoints = append(endpoints, endpoint)
+		return endpoints, nil
 	}
 
 	endps, err := lbc.endpointLister.GetServiceEndpoints(svc)


### PR DESCRIPTION
### Proposed changes

I've tried to use ExternalName service with this ingress-controller but doesn't work, so I perform some changes to the `controller.go` to use `backend.ServiceName:backend.ServicePort` as a default endpoint instead of look for them in kubernetes objects.

These changes are based in the issue [#262](https://github.com/nginxinc/kubernetes-ingress/issues/262) and this comment [ExternalName](https://github.com/nginxinc/kubernetes-ingress/issues/262#issuecomment-376918311)

I've just modify `getEndpointsForIngressBackend` method to add these lines:

```go
	if svc.Spec.Type == api_v1.ServiceTypeExternalName {
		var endpoints []string
		endpoint := fmt.Sprintf("%s:%d", backend.ServiceName, int32(backend.ServicePort.IntValue()) )
		endpoints = append(endpoints, endpoint)
		return endpoints, nil
	}
```

Hope this help :smiley: 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
