### PR TITLE
Add type ExternalName service support for NGINX Plus

### DIFF
--- a/docs/configmap-and-annotations.md
+++ b/docs/configmap-and-annotations.md
@@ -101,6 +101,11 @@ spec:
 | N/A | `worker-shutdown-timeout` | Sets the value of the [worker_shutdown_timeout](http://nginx.org/en/docs/ngx_core_module.html#worker_shutdown_timeout) directive. | N/A | |
 | N/A | `server-names-hash-bucket-size` | Sets the value of the [server_names_hash_bucket_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size) directive. | Depends on the size of the processor’s cache line. | |
 | N/A | `server-names-hash-max-size` | Sets the value of the [server_names_hash_max_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size) directive. | `512` | |
+| N/A | `resolver-addresses` | Sets the value of the [resolver](http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver) addresses. Note: If you use a DNS name (ex., `kube-dns.kube-system.svc.cluster.local`) as a resolver address, NGINX Plus will resolve it using the system resolver during the start and on every configuration reload. As a consequence, If the name cannot be resolved or the DNS server doesn't respond, NGINX Plus will fail to start or reload. To avoid this, consider using only IP addresses as resolver addresses. Supported in NGINX Plus only. | N/A | [Support for Type ExternalName Services](../examples/externalname-services). |
+| N/A | `resolver-ipv6` | Enables IPv6 resolution in the resolver. Supported in NGINX Plus only. | `True` | [Support for Type ExternalName Services](../examples/externalname-services). |
+| N/A | `resolver-valid` | Sets the time NGINX caches the resolved DNS records. Supported in NGINX Plus only. | TTL value of a DNS record | [Support for Type ExternalName Services](../examples/externalname-services). |
+| N/A | `resolver-timeout` | Sets the [resolver_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver_timeout) for name resolution. Supported in NGINX Plus only.  | `30s` | [Support for Type ExternalName Services](../examples/externalname-services). |
+
 
 ### Logging 
 

--- a/examples/externalname-services/README.md
+++ b/examples/externalname-services/README.md
@@ -1,0 +1,61 @@
+# Support for Type ExternalName Services
+The Ingress Controller supports routing requests to services of the type [ExternalName](https://kubernetes.io/docs/concepts/services-networking/service/#externalname).
+ 
+An ExternalName service is defined by an external DNS name that is resolved into the IP addresses, typically external to the cluster. This enables to use the Ingress Controller to route requests to the destinations outside of the cluster. 
+
+**Note:** This feature is only available in NGINX Plus.
+
+
+## Prerequisites
+To use ExternalName services, first you need to configure one or more resolvers using the ConfigMap. NGINX Plus will use those resolvers to resolve DNS names of the services.
+
+For example, the following ConfigMap configures one resolver:
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-config
+  namespace: nginx-ingress
+data:
+  resolver-addresses: "10.0.0.10"
+```
+
+Additional resolver parameters, including the caching of DNS records, are available. Check the corresponding [ConfigMap and Annotations](../../docs/configmap-and-annotations.md) section.
+
+
+## Example
+In the following yaml file we define an ExternalName service with the name my-service:
+
+```yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  type: ExternalName
+  externalName: my.service.example.com
+```
+
+In the following Ingress resource we use my-service:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: example-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: my-service
+          servicePort: 80
+
+```
+
+As a result, NGINX Plus will route requests for “example.com” to the IP addresses behind the DNS name my.service.example.com.

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/nginxinc/kubernetes-ingress/internal/nginx"
 	"github.com/nginxinc/kubernetes-ingress/internal/nginx/plus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"

--- a/internal/nginx/config.go
+++ b/internal/nginx/config.go
@@ -49,6 +49,10 @@ type Config struct {
 	HealthCheckMandatory          bool
 	HealthCheckMandatoryQueue     int64
 	SlowStart                     string
+	ResolverAddresses             []string
+	ResolverIPV6                  bool
+	ResolverValid                 string
+	ResolverTimeout               string
 
 	// http://nginx.org/en/docs/http/ngx_http_realip_module.html
 	RealIPHeader    string
@@ -93,6 +97,7 @@ func NewDefaultConfig() *Config {
 		FailTimeout:                "10s",
 		LBMethod:                   "random two least_conn",
 		MainErrorLogLevel:          "notice",
+		ResolverIPV6:               true,
 	}
 }
 
@@ -361,5 +366,46 @@ func ParseConfigMap(cfgm *api_v1.ConfigMap, nginxPlus bool) *Config {
 			cfg.MainStreamSnippets = mainStreamSnippets
 		}
 	}
+
+	if resolverAddresses, exists, err := GetMapKeyAsStringSlice(cfgm.Data, "resolver-addresses", cfgm, ","); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			if nginxPlus {
+				cfg.ResolverAddresses = resolverAddresses
+			} else {
+				glog.Warning("ConfigMap key 'resolver-addresses' requires NGINX Plus")
+			}
+		}
+	}
+
+	if resolverIpv6, exists, err := GetMapKeyAsBool(cfgm.Data, "resolver-ipv6", cfgm); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			if nginxPlus {
+				cfg.ResolverIPV6 = resolverIpv6
+			} else {
+				glog.Warning("ConfigMap key 'resolver-ipv6' requires NGINX Plus")
+			}
+		}
+	}
+
+	if resolverValid, exists := cfgm.Data["resolver-valid"]; exists {
+		if nginxPlus {
+			cfg.ResolverValid = resolverValid
+		} else {
+			glog.Warning("ConfigMap key 'resolver-valid' requires NGINX Plus")
+		}
+	}
+
+	if resolverTimeout, exists := cfgm.Data["resolver-timeout"]; exists {
+		if nginxPlus {
+			cfg.ResolverTimeout = resolverTimeout
+		} else {
+			glog.Warning("ConfigMap key 'resolver-timeout' requires NGINX Plus")
+		}
+	}
+
 	return cfg
 }

--- a/internal/nginx/configurator.go
+++ b/internal/nginx/configurator.go
@@ -821,6 +821,13 @@ func (cnf *Configurator) createUpstream(ingEx *IngressEx, name string, backend *
 	endps, exists := ingEx.Endpoints[backend.ServiceName+backend.ServicePort.String()]
 	if exists {
 		var upsServers []UpstreamServer
+		// Always false for NGINX OSS
+		_, isExternalNameSvc := ingEx.ExternalNameSvcs[backend.ServiceName]
+		if isExternalNameSvc && !cnf.IsResolverConfigured() {
+			glog.Warningf("A resolver must be configured for Type ExternalName service %s, no upstream servers will be created", backend.ServiceName)
+			endps = []string{}
+		}
+
 		for _, endp := range endps {
 			addressport := strings.Split(endp, ":")
 			upsServers = append(upsServers, UpstreamServer{
@@ -829,6 +836,7 @@ func (cnf *Configurator) createUpstream(ingEx *IngressEx, name string, backend *
 				MaxFails:    cfg.MaxFails,
 				FailTimeout: cfg.FailTimeout,
 				SlowStart:   cfg.SlowStart,
+				Resolve:     isExternalNameSvc,
 			})
 		}
 		if len(upsServers) > 0 {
@@ -1078,9 +1086,13 @@ func (cnf *Configurator) updatePlusEndpoints(ingEx *IngressEx) error {
 		name := getNameForUpstream(ingEx.Ingress, emptyHost, ingEx.Ingress.Spec.Backend)
 		endps, exists := ingEx.Endpoints[ingEx.Ingress.Spec.Backend.ServiceName+ingEx.Ingress.Spec.Backend.ServicePort.String()]
 		if exists {
-			err := cnf.nginxAPI.UpdateServers(name, endps, cfg, cnf.nginx.configVersion)
-			if err != nil {
-				return fmt.Errorf("Couldn't update the endpoints for %v: %v", name, err)
+			if _, isExternalName := ingEx.ExternalNameSvcs[ingEx.Ingress.Spec.Backend.ServiceName]; isExternalName {
+				glog.V(3).Infof("Service %s is Type ExternalName, skipping NGINX Plus endpoints update via API", ingEx.Ingress.Spec.Backend.ServiceName)
+			} else {
+				err := cnf.nginxAPI.UpdateServers(name, endps, cfg, cnf.nginx.configVersion)
+				if err != nil {
+					return fmt.Errorf("Couldn't update the endpoints for %v: %v", name, err)
+				}
 			}
 		}
 	}
@@ -1092,6 +1104,10 @@ func (cnf *Configurator) updatePlusEndpoints(ingEx *IngressEx) error {
 			name := getNameForUpstream(ingEx.Ingress, rule.Host, &path.Backend)
 			endps, exists := ingEx.Endpoints[path.Backend.ServiceName+path.Backend.ServicePort.String()]
 			if exists {
+				if _, isExternalName := ingEx.ExternalNameSvcs[path.Backend.ServiceName]; isExternalName {
+					glog.V(3).Infof("Service %s is Type ExternalName, skipping NGINX Plus endpoints update via API", path.Backend.ServiceName)
+					continue
+				}
 				err := cnf.nginxAPI.UpdateServers(name, endps, cfg, cnf.nginx.configVersion)
 				if err != nil {
 					return fmt.Errorf("Couldn't update the endpoints for %v: %v", name, err)
@@ -1162,6 +1178,10 @@ func GenerateNginxMainConfig(config *Config) *MainConfig {
 		WorkerShutdownTimeout:     config.MainWorkerShutdownTimeout,
 		WorkerConnections:         config.MainWorkerConnections,
 		WorkerRlimitNofile:        config.MainWorkerRlimitNofile,
+		ResolverAddresses:         config.ResolverAddresses,
+		ResolverIPV6:              config.ResolverIPV6,
+		ResolverValid:             config.ResolverValid,
+		ResolverTimeout:           config.ResolverTimeout,
 	}
 	return nginxCfg
 }
@@ -1242,4 +1262,9 @@ func (cnf *Configurator) HasMinion(master *extensions.Ingress, minion *extension
 		return false
 	}
 	return cnf.minions[masterName][objectMetaToFileName(&minion.ObjectMeta)]
+}
+
+// IsResolverConfigured checks if a DNS resolver is present in NGINX configuration
+func (cnf *Configurator) IsResolverConfigured() bool {
+	return len(cnf.config.ResolverAddresses) != 0
 }

--- a/internal/nginx/configurator_test.go
+++ b/internal/nginx/configurator_test.go
@@ -226,6 +226,7 @@ func createCafeIngressEx() IngressEx {
 			"coffee-svc80": {"10.0.0.1:80"},
 			"tea-svc80":    {"10.0.0.2:80"},
 		},
+		ExternalNameSvcs: map[string]bool{},
 	}
 	return cafeIngressEx
 }

--- a/internal/nginx/ingress.go
+++ b/internal/nginx/ingress.go
@@ -10,11 +10,12 @@ import (
 // IngressEx holds an Ingress along with Secrets and Endpoints of the services
 // that are referenced in this Ingress
 type IngressEx struct {
-	Ingress      *extensions.Ingress
-	TLSSecrets   map[string]*api_v1.Secret
-	JWTKey       JWTKey
-	Endpoints    map[string][]string
-	HealthChecks map[string]*api_v1.Probe
+	Ingress          *extensions.Ingress
+	TLSSecrets       map[string]*api_v1.Secret
+	JWTKey           JWTKey
+	Endpoints        map[string][]string
+	HealthChecks     map[string]*api_v1.Probe
+	ExternalNameSvcs map[string]bool
 }
 
 // MergeableIngresses is a mergeable ingress of a master and minions

--- a/internal/nginx/nginx.go
+++ b/internal/nginx/nginx.go
@@ -61,6 +61,7 @@ type UpstreamServer struct {
 	MaxFails    int
 	FailTimeout string
 	SlowStart   string
+	Resolve     bool
 }
 
 // HealthCheck describes an active HTTP health check
@@ -174,6 +175,10 @@ type MainConfig struct {
 	WorkerShutdownTimeout  string
 	WorkerConnections      string
 	WorkerRlimitNofile     string
+	ResolverAddresses      []string
+	ResolverIPV6           bool
+	ResolverValid          string
+	ResolverTimeout        string
 }
 
 // NewUpstreamWithDefaultServer creates an upstream with the default server.

--- a/internal/nginx/templates/nginx-plus.ingress.tmpl
+++ b/internal/nginx/templates/nginx-plus.ingress.tmpl
@@ -5,7 +5,7 @@ upstream {{$upstream.Name}} {
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}}
-	    {{- if $server.SlowStart}} slow_start={{$server.SlowStart}}{{end}};{{end}}
+	    {{- if $server.SlowStart}} slow_start={{$server.SlowStart}}{{end}}{{if $server.Resolve}} resolve{{end}};{{end}}
 	{{if $upstream.StickyCookie}}
 	sticky cookie {{$upstream.StickyCookie}};
 	{{end}}

--- a/internal/nginx/templates/nginx-plus.tmpl
+++ b/internal/nginx/templates/nginx-plus.tmpl
@@ -60,6 +60,11 @@ http {
     {{if .SSLPreferServerCiphers}}ssl_prefer_server_ciphers on;{{end}}
     {{if .SSLDHParam}}ssl_dhparam {{.SSLDHParam}};{{end}}
 
+    {{if .ResolverAddresses}}
+    resolver {{range $resolver := .ResolverAddresses}}{{$resolver}}{{end}}{{if .ResolverValid}} valid={{.ResolverValid}}{{end}}{{if not .ResolverIPV6}} ipv6=off{{end}};
+    {{if .ResolverTimeout}}resolver_timeout {{.ResolverTimeout}};{{end}}
+    {{end}}
+
     server {
         listen 80 default_server{{if .ProxyProtocol}} proxy_protocol{{end}};
         listen 443 ssl default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};

--- a/internal/nginx/templates/templates_test.go
+++ b/internal/nginx/templates/templates_test.go
@@ -99,6 +99,10 @@ var mainCfg = nginx.MainConfig{
 	WorkerRlimitNofile:     "65536",
 	StreamSnippets:         []string{"# comment"},
 	StreamLogFormat:        "$remote_addr",
+	ResolverAddresses:      []string{"example.com", "127.0.0.1"},
+	ResolverIPV6:           false,
+	ResolverValid:          "10s",
+	ResolverTimeout:        "15s",
 }
 
 func TestIngressForNGINXPlus(t *testing.T) {


### PR DESCRIPTION
### Proposed changes
Closes #262
Closes #446

This PR adds support for type [ExternalName](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) services for NGINX Plus only.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
