### PR TITLE
Change prometheus port annotation to string

### DIFF
--- a/deployments/daemon-set/nginx-ingress.yaml
+++ b/deployments/daemon-set/nginx-ingress.yaml
@@ -13,7 +13,7 @@ spec:
         app: nginx-ingress
      #annotations:
        #prometheus.io/scrape: "true"
-       #prometheus.io/port: 9113
+       #prometheus.io/port: "9113"
     spec:
       serviceAccountName: nginx-ingress
       containers:

--- a/deployments/daemon-set/nginx-plus-ingress.yaml
+++ b/deployments/daemon-set/nginx-plus-ingress.yaml
@@ -13,7 +13,7 @@ spec:
         app: nginx-ingress
      #annotations:
        #prometheus.io/scrape: "true"
-       #prometheus.io/port: 9113
+       #prometheus.io/port: "9113"
     spec:
       serviceAccountName: nginx-ingress
       containers:

--- a/deployments/deployment/nginx-ingress.yaml
+++ b/deployments/deployment/nginx-ingress.yaml
@@ -14,7 +14,7 @@ spec:
         app: nginx-ingress
      #annotations:
        #prometheus.io/scrape: "true"
-       #prometheus.io/port: 9113
+       #prometheus.io/port: "9113"
     spec:
       serviceAccountName: nginx-ingress
       containers:

--- a/deployments/deployment/nginx-plus-ingress.yaml
+++ b/deployments/deployment/nginx-plus-ingress.yaml
@@ -14,7 +14,7 @@ spec:
         app: nginx-ingress
      #annotations:
        #prometheus.io/scrape: "true"
-       #prometheus.io/port: 9113
+       #prometheus.io/port: "9113"
     spec:
       serviceAccountName: nginx-ingress
       containers:


### PR DESCRIPTION
### Proposed changes
Fixed a bug on daemon-set/deployment manifests when using the `prometheus.io/port` annotation for NGINX and NGINX Plus. Port needs to be a `string` and it was incorrectly set as an `int`. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
