### PR TITLE
Update helm-chart rbac to have minimum required privileges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,4 @@ before_install:
 - if [[ "${TRAVIS_PULL_REQUEST_SLUG}" == "nginxinc/kubernetes-ingress" || "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
   wget https://${fossalocation}/${fossafile} && tar xzf ${fossafile}
   && ./fossa init
-  && ./fossa analyze -t kubernetes-ingress -b ${TRAVIS_BRANCH}; fi
-env:
-  global:
-    secure: V55h8keIrz7C4KiiyTGRUFY51coVcQSf1W/jPt0G9x8SQIY4s0jJ5jbNx5M1Sllic1wrdZJrSK+q9dxqJBHn/1JsOSgx6CAx8NCsBECJuWz2N841uTVlXSNuW+FpJT3sBtNauwcdxVXJ+FmuL74rPJm1n+utWuXVtaGcj3y39r7gldqBbNiGKTIseMfrHreA+i5U8Yy/6FYk5Pm9TG2jtP+e5lHF7jD6/E1EnhLGOl9u0GAHu1VHHRNU0GNXFZR/mObfsDhBw5QkaZNFavW8/1xU7//ueYM+ZlQUbb/mPC4G4F1A7oouflYnEjmuqAxwxGL30F6xNKCVUV3rW2V7yaBFcLCM+0F3Qw1NHe67hmxRVloHdWl1of5SNHsWgJ8pVA4k6mcOETOwUJS2WN38txphsQKt9SEtu2oB50KVpXt/REg+2OY2Ln880lyzDPGjvV/UT6voa1LhnAx7JQnoQqwOEFk1zwcVxIGxePvCL2PYVkC3iKuj8ESixyZk5r/k0/hVl1n3T1l2KlzmxQgMg7Ew7T0Uv3EyCPc7i39sUMv86XV6BHaooTgDGSSquxiVABZUpaEYHBGq57gmYahVRbKeonOQ4wDFzXWTWSVP6tzy5iBoF5ecD6xB2IpFXwPhKYDPKOnU0eJpahfzUwJMXee/RjVtzswIjRU4BAV8xZY=
+  && FOSSA_API_KEY=${fossapush} ./fossa analyze -t kubernetes-ingress -b ${TRAVIS_BRANCH}; fi

--- a/deployments/helm-chart/templates/rbac.yaml
+++ b/deployments/helm-chart/templates/rbac.yaml
@@ -31,8 +31,10 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.controller.reportIngressStatus.enableLeaderElection }}
   - update
   - create
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/deployments/helm-chart/templates/rbac.yaml
+++ b/deployments/helm-chart/templates/rbac.yaml
@@ -58,7 +58,7 @@ rules:
   - watch
 {{- if .Values.controller.reportIngressStatus.enable }}
 - apiGroups:
-  - "extensions"
+  - extensions
   resources:
   - ingresses/status
   verbs:


### PR DESCRIPTION
### Proposed changes
The leader election used in the status reporting feature requires the IC to create/update a Configmap. Thus, RBAC must allow that. However, when the feature is disabled, the RBAC must now allow create/update on the Configmap.

When the `controller.reportIngressStatus.enableLeaderElection` is false, the RBAC must not allow the IC to create/update the ConfigMaps.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
