### PR TITLE
Add release namespace to all helm charts

### DIFF
--- a/deployments/helm-chart/Chart.yaml
+++ b/deployments/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.5.0
+version: 0.6.0
 appVersion: edge
 description: NGINX Ingress Controller
 icon: https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/master/deployments/helm-chart/chart-icon.png

--- a/deployments/helm-chart/templates/controller-configmap.yaml
+++ b/deployments/helm-chart/templates/controller-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "nginx-ingress.configName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-ingress.labels" . | nindent 4 }}
 data:

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: {{ default (include "nginx-ingress.name" .) .Values.controller.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-ingress.labels" . | nindent 4 }}
 spec:

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ default (include "nginx-ingress.name" .) .Values.controller.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-ingress.labels" . | nindent 4 }}
 spec:

--- a/deployments/helm-chart/templates/controller-secret.yaml
+++ b/deployments/helm-chart/templates/controller-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "nginx-ingress.defaultTLSName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-ingress.labels" . | nindent 4 }}
 type: Opaque

--- a/deployments/helm-chart/templates/controller-service.yaml
+++ b/deployments/helm-chart/templates/controller-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "nginx-ingress.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-ingress.labels" . | nindent 4 }}
 {{- if .Values.controller.service.annotations }}

--- a/deployments/helm-chart/templates/controller-serviceaccount.yaml
+++ b/deployments/helm-chart/templates/controller-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "nginx-ingress.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-ingress.labels" . | nindent 4 }}
 {{- if .Values.controller.serviceAccount.imagePullSecrets }}

--- a/deployments/helm-chart/templates/controller-wildcard-secret.yaml
+++ b/deployments/helm-chart/templates/controller-wildcard-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "nginx-ingress.wildcardTLSName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-ingress.labels" . | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
### Proposed changes

This request came from another Pull Request https://github.com/nginxinc/kubernetes-ingress/pull/546#issuecomment-486234510

Add the Release.Namespace as the metadata.namespace in all of the Helm charts. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
