### PR TITLE
Add configmap keys for Hash Related variables

### DIFF
--- a/docs/configmap-and-annotations.md
+++ b/docs/configmap-and-annotations.md
@@ -107,7 +107,8 @@ spec:
 | N/A | `resolver-timeout` | Sets the [resolver_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver_timeout) for name resolution. Supported in NGINX Plus only.  | `30s` | [Support for Type ExternalName Services](../examples/externalname-services). |
 | N/A | `keepalive-timeout` | Sets the value of the [keepalive_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout) directive. | `65s` | |
 | N/A | `keepalive-requests` | Sets the value of the [keepalive_requests](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests) directive. | `100` | |
-
+| N/A | `variables-hash-bucket-size` | Sets the value of the [variables_hash_bucket_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#variables_hash_bucket_size) directive. | `256` | |
+| N/A | `variables-hash-max-size` | Sets the value of the [variables-hash-max-size](http://nginx.org/en/docs/http/ngx_http_core_module.html#variables_hash_max_size) directive. | `1024` | |
 
 ### Logging
 

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -51,6 +51,8 @@ type ConfigParams struct {
 	ResolverTimeout               string
 	MainKeepaliveTimeout          string
 	MainKeepaliveRequests         int64
+	VariablesHashBucketSize       uint64
+	VariablesHashMaxSize          uint64
 
 	RealIPHeader    string
 	SetRealIPFrom   []string
@@ -105,5 +107,7 @@ func NewDefaultConfigParams() *ConfigParams {
 		ResolverIPV6:               true,
 		MainKeepaliveTimeout:       "65s",
 		MainKeepaliveRequests:      100,
+		VariablesHashBucketSize:    256,
+		VariablesHashMaxSize:       1024,
 	}
 }

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/nginxinc/kubernetes-ingress/internal/configs/version1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // ParseConfigMap parses ConfigMap into ConfigParams.
@@ -375,6 +375,22 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool) *ConfigParams {
 		}
 	}
 
+	if varHashBucketSize, exists, err := GetMapKeyAsUint64(cfgm.Data, "variables-hash-bucket-size", cfgm, true); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfgParams.VariablesHashBucketSize = varHashBucketSize
+		}
+	}
+
+	if varHashMaxSize, exists, err := GetMapKeyAsUint64(cfgm.Data, "variables-hash-max-size", cfgm, false); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfgParams.VariablesHashMaxSize = varHashMaxSize
+		}
+	}
+
 	return cfgParams
 }
 
@@ -413,6 +429,8 @@ func GenerateNginxMainConfig(staticCfgParams *StaticConfigParams, config *Config
 		ResolverTimeout:                config.ResolverTimeout,
 		KeepaliveTimeout:               config.MainKeepaliveTimeout,
 		KeepaliveRequests:              config.MainKeepaliveRequests,
+		VariablesHashBucketSize:        config.VariablesHashBucketSize,
+		VariablesHashMaxSize:           config.VariablesHashMaxSize,
 	}
 	return nginxCfg
 }

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +50,24 @@ func GetMapKeyAsInt64(m map[string]string, key string, context apiObject) (int64
 		i, err := strconv.ParseInt(str, 10, 64)
 		if err != nil {
 			return 0, exists, fmt.Errorf("%s %v/%v '%s' contains invalid integer: %v, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key, err)
+		}
+
+		return i, exists, nil
+	}
+
+	return 0, false, nil
+}
+
+// GetMapKeyAsUint64 tries to find and parse a key in a map as uint64.
+func GetMapKeyAsUint64(m map[string]string, key string, context apiObject, nonZero bool) (uint64, bool, error) {
+	if str, exists := m[key]; exists {
+		i, err := strconv.ParseUint(str, 10, 64)
+		if err != nil {
+			return 0, exists, fmt.Errorf("%s %v/%v '%s' contains invalid uint64: %v, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key, err)
+		}
+
+		if nonZero && i == 0 {
+			return 0, exists, fmt.Errorf("%s %v/%v '%s' must be greater than 0, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key)
 		}
 
 		return i, exists, nil

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -153,6 +153,8 @@ type MainConfig struct {
 	ResolverTimeout                string
 	KeepaliveTimeout               string
 	KeepaliveRequests              int64
+	VariablesHashBucketSize        uint64
+	VariablesHashMaxSize           uint64
 }
 
 // NewUpstreamWithDefaultServer creates an upstream with the default server.

--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -56,7 +56,8 @@ http {
     server_names_hash_max_size {{.ServerNamesHashMaxSize}};
     {{if .ServerNamesHashBucketSize}}server_names_hash_bucket_size {{.ServerNamesHashBucketSize}};{{end}}
 
-    variables_hash_bucket_size 256;
+    variables_hash_bucket_size {{.VariablesHashBucketSize}};
+    variables_hash_max_size {{.VariablesHashMaxSize}};
 
     map $http_upgrade $connection_upgrade {
         default upgrade;

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -55,7 +55,8 @@ http {
     server_names_hash_max_size {{.ServerNamesHashMaxSize}};
     {{if .ServerNamesHashBucketSize}}server_names_hash_bucket_size {{.ServerNamesHashBucketSize}};{{end}}
 
-    variables_hash_bucket_size 256;
+    variables_hash_bucket_size {{.VariablesHashBucketSize}};
+    variables_hash_max_size {{.VariablesHashMaxSize}};
 
     map $http_upgrade $connection_upgrade {
         default upgrade;

--- a/internal/configs/version1/templates_test.go
+++ b/internal/configs/version1/templates_test.go
@@ -88,21 +88,23 @@ var ingCfg = IngressNginxConfig{
 }
 
 var mainCfg = MainConfig{
-	ServerNamesHashMaxSize: "512",
-	ServerTokens:           "off",
-	WorkerProcesses:        "auto",
-	WorkerCPUAffinity:      "auto",
-	WorkerShutdownTimeout:  "1m",
-	WorkerConnections:      "1024",
-	WorkerRlimitNofile:     "65536",
-	StreamSnippets:         []string{"# comment"},
-	StreamLogFormat:        "$remote_addr",
-	ResolverAddresses:      []string{"example.com", "127.0.0.1"},
-	ResolverIPV6:           false,
-	ResolverValid:          "10s",
-	ResolverTimeout:        "15s",
-	KeepaliveTimeout:       "65s",
-	KeepaliveRequests:      100,
+	ServerNamesHashMaxSize:  "512",
+	ServerTokens:            "off",
+	WorkerProcesses:         "auto",
+	WorkerCPUAffinity:       "auto",
+	WorkerShutdownTimeout:   "1m",
+	WorkerConnections:       "1024",
+	WorkerRlimitNofile:      "65536",
+	StreamSnippets:          []string{"# comment"},
+	StreamLogFormat:         "$remote_addr",
+	ResolverAddresses:       []string{"example.com", "127.0.0.1"},
+	ResolverIPV6:            false,
+	ResolverValid:           "10s",
+	ResolverTimeout:         "15s",
+	KeepaliveTimeout:        "65s",
+	KeepaliveRequests:       100,
+	VariablesHashBucketSize: 256,
+	VariablesHashMaxSize:    1024,
 }
 
 func TestIngressForNGINXPlus(t *testing.T) {


### PR DESCRIPTION
### Proposed changes

`variables_hash_bucket_size` and `variables_hash_max_size` directives are now configurable in ConfigMaps.
