### PR TITLE
Fix daemonset template for helm

### DIFF
--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -52,7 +52,7 @@ spec:
           containerPort: 443
           hostPort: 443
 {{ if .Values.controller.customPorts }}
-{{ toYaml .Values.controller.customPorts | indent 4 }}
+{{ toYaml .Values.controller.customPorts | indent 8 }}
 {{ end }}
 {{- if .Values.prometheus.create }}
         - name: prometheus


### PR DESCRIPTION
### Proposed changes
Bug introduced in: #581 

DaemonSet helm template has a bug in the `customPorts` YAML indentation. It is 4 and it should be 8. This PR Fixes it.
