### PR TITLE
Use Controller name value for app selectors In Release 1.5

### DIFF
--- a/deployments/helm-chart/templates/_helpers.tpl
+++ b/deployments/helm-chart/templates/_helpers.tpl
@@ -62,3 +62,10 @@ Expand wildcard TLS name.
 {{- define "nginx-ingress.wildcardTLSName" -}}
 {{- printf "%s-%s" (include "nginx-ingress.name" .) "wildcard-tls-secret" -}}
 {{- end -}}
+
+{{/*
+Expand app name.
+*/}}
+{{- define "nginx-ingress.appName" -}}
+{{- default (include "nginx-ingress.name" .) .Values.controller.name -}}
+{{- end -}}

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -9,11 +9,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ include "nginx-ingress.name" . }}
+      app: {{ include "nginx-ingress.appName" . }}
   template:
     metadata:
       labels:
-        app: {{ include "nginx-ingress.name" . }}
+        app: {{ include "nginx-ingress.appName" . }}
 {{- if or (.Values.prometheus.create) (.Values.controller.pod.annotations) }}
       annotations:
 {{- if .Values.prometheus.create }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -10,11 +10,11 @@ spec:
   replicas: {{ .Values.controller.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "nginx-ingress.name" . }}
+      app: {{ include "nginx-ingress.appName" . }}
   template:
     metadata:
       labels:
-        app: {{ include "nginx-ingress.name" . }}
+        app: {{ include "nginx-ingress.appName" . }}
 {{- if or (.Values.prometheus.create) (.Values.controller.pod.annotations) }}
       annotations:
 {{- if .Values.prometheus.create }}

--- a/deployments/helm-chart/templates/controller-service.yaml
+++ b/deployments/helm-chart/templates/controller-service.yaml
@@ -46,7 +46,7 @@ spec:
   {{- end }}
 {{- end }}
   selector:
-    app: {{ include "nginx-ingress.name" . }}
+    app:  {{ include "nginx-ingress.appName" . }}
   {{- if .Values.controller.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.controller.service.externalIPs | indent 4 }}


### PR DESCRIPTION
### Proposed changes
Use Controller name value for app selectors In Release 1.5

