### PR TITLE
Add upstream object to the generation methods

### DIFF
--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -92,7 +92,7 @@ func generateVirtualServerConfig(virtualServerEx *VirtualServerEx, tlsPemFileNam
 	for _, u := range virtualServerEx.VirtualServer.Spec.Upstreams {
 		upstreamName := virtualServerUpstreamNamer.GetNameForUpstream(u.Name)
 		endpointsKey := GenerateEndpointsKey(virtualServerEx.VirtualServer.Namespace, u.Service, u.Port)
-		ups := generateUpstream(upstreamName, u.LBMethod, virtualServerEx.Endpoints[endpointsKey], isPlus, baseCfgParams)
+		ups := generateUpstream(upstreamName, u, virtualServerEx.Endpoints[endpointsKey], isPlus, baseCfgParams)
 		upstreams = append(upstreams, ups)
 	}
 	// generate upstreams for each VirtualServerRoute
@@ -101,7 +101,7 @@ func generateVirtualServerConfig(virtualServerEx *VirtualServerEx, tlsPemFileNam
 		for _, u := range vsr.Spec.Upstreams {
 			upstreamName := upstreamNamer.GetNameForUpstream(u.Name)
 			endpointsKey := GenerateEndpointsKey(vsr.Namespace, u.Service, u.Port)
-			ups := generateUpstream(upstreamName, u.LBMethod, virtualServerEx.Endpoints[endpointsKey], isPlus, baseCfgParams)
+			ups := generateUpstream(upstreamName, u, virtualServerEx.Endpoints[endpointsKey], isPlus, baseCfgParams)
 			upstreams = append(upstreams, ups)
 		}
 	}
@@ -195,7 +195,7 @@ func generateVirtualServerConfig(virtualServerEx *VirtualServerEx, tlsPemFileNam
 	}
 }
 
-func generateUpstream(upstreamName string, lBMethod string, endpoints []string, isPlus bool, cfgParams *ConfigParams) version2.Upstream {
+func generateUpstream(upstreamName string, upstream conf_v1alpha1.Upstream, endpoints []string, isPlus bool, cfgParams *ConfigParams) version2.Upstream {
 	var upsServers []version2.UpstreamServer
 
 	for _, e := range endpoints {
@@ -219,7 +219,7 @@ func generateUpstream(upstreamName string, lBMethod string, endpoints []string, 
 	ups := version2.Upstream{
 		Name:     upstreamName,
 		Servers:  upsServers,
-		LBMethod: generateLBMethod(lBMethod, cfgParams.LBMethod),
+		LBMethod: generateLBMethod(upstream.LBMethod, cfgParams.LBMethod),
 	}
 
 	return ups

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -732,6 +732,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithRules(t *testing.T) {
 
 func TestGenerateUpstream(t *testing.T) {
 	name := "test-upstream"
+	upstream := conf_v1alpha1.Upstream{}
 	endpoints := []string{
 		"192.168.10.10:8080",
 	}
@@ -754,7 +755,7 @@ func TestGenerateUpstream(t *testing.T) {
 		LBMethod: "random",
 	}
 
-	result := generateUpstream(name, "", endpoints, isPlus, &cfgParams)
+	result := generateUpstream(name, upstream, endpoints, isPlus, &cfgParams)
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("generateUpstream() returned %v but expected %v", result, expected)
 	}
@@ -762,6 +763,7 @@ func TestGenerateUpstream(t *testing.T) {
 
 func TestGenerateUpstreamForZeroEndpoints(t *testing.T) {
 	name := "test-upstream"
+	upstream := conf_v1alpha1.Upstream{}
 	var endpoints []string // nil
 	cfgParams := ConfigParams{
 		MaxFails:    1,
@@ -780,7 +782,7 @@ func TestGenerateUpstreamForZeroEndpoints(t *testing.T) {
 		},
 	}
 
-	result := generateUpstream(name, "", endpoints, isPlus, &cfgParams)
+	result := generateUpstream(name, upstream, endpoints, isPlus, &cfgParams)
 	if !reflect.DeepEqual(result, expectedForNGINX) {
 		t.Errorf("generateUpstream(isPlus=%v) returned %v but expected %v", isPlus, result, expectedForNGINX)
 	}
@@ -791,7 +793,7 @@ func TestGenerateUpstreamForZeroEndpoints(t *testing.T) {
 		Servers: nil,
 	}
 
-	result = generateUpstream(name, "", endpoints, isPlus, &cfgParams)
+	result = generateUpstream(name, upstream, endpoints, isPlus, &cfgParams)
 	if !reflect.DeepEqual(result, expectedForNGINXPlus) {
 		t.Errorf("generateUpstream(isPlus=%v) returned %v but expected %v", isPlus, result, expectedForNGINXPlus)
 	}


### PR DESCRIPTION
### Proposed changes
Refactor the generation of Upstreams for Virtual Server and Virtual Server Routes in preparation for all the new features we will add soon.

Instead of passing all the parameters one by one, it is better to pass the whole Upstream, and work from there.

