### PR TITLE
Added max-conns annotation

### DIFF
--- a/docs/configmap-and-annotations.md
+++ b/docs/configmap-and-annotations.md
@@ -164,7 +164,7 @@ spec:
 | `nginx.org/grpc-services` | N/A | Enables gRPC for services. Note: requires HTTP/2 (see `http2` ConfigMap key); only works for Ingresses with TLS termination enabled. | N/A | [GRPC Services Support](../examples/grpc-services).|
 | `nginx.org/websocket-services` | N/A | Enables WebSocket for services. | N/A | [WebSocket support](../examples/websocket). |
 | `nginx.org/max-fails` | `max-fails` | Sets the value of the [max_fails](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_fails) parameter of the `server` directive. | `1` | |
-| `nginx.org/max-conns` | `max-conns` | Sets the value of the [max_conns](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns) parameter of the `server` directive. | `0` | |
+| `nginx.org/max-conns` | N\A | Sets the value of the [max_conns](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns) parameter of the `server` directive. | `0` | |
 | `nginx.org/fail-timeout` | `fail-timeout` | Sets the value of the [fail_timeout](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#fail_timeout) parameter of the `server` directive. | `10s` | |
 | `nginx.com/sticky-cookie-services` | N/A | Configures session persistence. | N/A | [Session Persistence](../examples/session-persistence). |
 | `nginx.org/keepalive` | `keepalive` | Sets the value of the [keepalive](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive) directive. Note that `proxy_set_header Connection "";` is added to the generated configuration when the value > 0. | `0` | |

--- a/docs/configmap-and-annotations.md
+++ b/docs/configmap-and-annotations.md
@@ -164,6 +164,7 @@ spec:
 | `nginx.org/grpc-services` | N/A | Enables gRPC for services. Note: requires HTTP/2 (see `http2` ConfigMap key); only works for Ingresses with TLS termination enabled. | N/A | [GRPC Services Support](../examples/grpc-services).|
 | `nginx.org/websocket-services` | N/A | Enables WebSocket for services. | N/A | [WebSocket support](../examples/websocket). |
 | `nginx.org/max-fails` | `max-fails` | Sets the value of the [max_fails](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_fails) parameter of the `server` directive. | `1` | |
+| `nginx.org/max-conns` | `max-conns` | Sets the value of the [max_conns](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns) parameter of the `server` directive. | `0` | |
 | `nginx.org/fail-timeout` | `fail-timeout` | Sets the value of the [fail_timeout](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#fail_timeout) parameter of the `server` directive. | `10s` | |
 | `nginx.com/sticky-cookie-services` | N/A | Configures session persistence. | N/A | [Session Persistence](../examples/session-persistence). |
 | `nginx.org/keepalive` | `keepalive` | Sets the value of the [keepalive](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive) directive. Note that `proxy_set_header Connection "";` is added to the generated configuration when the value > 0. | `0` | |

--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -48,6 +48,7 @@ var minionInheritanceList = map[string]bool{
 	"nginx.org/lb-method":                true,
 	"nginx.org/keepalive":                true,
 	"nginx.org/max-fails":                true,
+	"nginx.org/max-conns":                true,
 	"nginx.org/fail-timeout":             true,
 }
 
@@ -282,6 +283,14 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 			glog.Error(err)
 		} else {
 			cfgParams.MaxFails = maxFails
+		}
+	}
+
+	if maxConns, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/max-fails", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfgParams.MaxConns = maxConns
 		}
 	}
 

--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -286,7 +286,7 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 		}
 	}
 
-	if maxConns, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/max-fails", ingEx.Ingress); exists {
+	if maxConns, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/max-conns", ingEx.Ingress); exists {
 		if err != nil {
 			glog.Error(err)
 		} else {

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -40,6 +40,7 @@ type ConfigParams struct {
 	MainWorkerRlimitNofile        string
 	Keepalive                     int64
 	MaxFails                      int
+	MaxConns                      int
 	FailTimeout                   string
 	HealthCheckEnabled            bool
 	HealthCheckMandatory          bool
@@ -101,6 +102,7 @@ func NewDefaultConfigParams() *ConfigParams {
 		Ports:                      []int{80},
 		SSLPorts:                   []int{443},
 		MaxFails:                   1,
+		MaxConns:                   0,
 		FailTimeout:                "10s",
 		LBMethod:                   "random two least_conn",
 		MainErrorLogLevel:          "notice",

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -289,6 +289,7 @@ func createUpstream(ingEx *IngressEx, name string, backend *extensions.IngressBa
 				Address:     addressport[0],
 				Port:        addressport[1],
 				MaxFails:    cfg.MaxFails,
+				MaxConns:    cfg.MaxConns,
 				FailTimeout: cfg.FailTimeout,
 				SlowStart:   cfg.SlowStart,
 				Resolve:     isExternalNameSvc,

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -30,6 +30,7 @@ type UpstreamServer struct {
 	Address     string
 	Port        string
 	MaxFails    int
+	MaxConns    int
 	FailTimeout string
 	SlowStart   string
 	Resolve     bool
@@ -168,6 +169,7 @@ func NewUpstreamWithDefaultServer(name string) Upstream {
 				Address:     "127.0.0.1",
 				Port:        "8181",
 				MaxFails:    1,
+				MaxConns:    0,
 				FailTimeout: "10s",
 			},
 		},

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -3,7 +3,7 @@
 upstream {{$upstream.Name}} {
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
-	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}};{{end}}
+	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}};{{end}}
 	{{if $.Keepalive}}keepalive {{$.Keepalive}};{{end}}
 }{{end}}
 

--- a/internal/configs/version1/templates_test.go
+++ b/internal/configs/version1/templates_test.go
@@ -18,6 +18,7 @@ var testUps = Upstream{
 			Address:     "127.0.0.1",
 			Port:        "8181",
 			MaxFails:    0,
+			MaxConns:    0,
 			FailTimeout: "1s",
 			SlowStart:   "5s",
 		},


### PR DESCRIPTION
### Proposed changes
These changes enable the annotation max-conns which set the parameter max_conns on upstream server in nginx config. For instance, 
`nginx.org/max-conns: 6` on ingress.yaml should add to ngnix config
```
upstream myService-ingress-prod-myService.production.ingress.net-myService-prod-80 {
   server 125.255.255.255:8888 max_fails=3 fail_timeout=10 max_conns=6;
}
```
Here it's the documentation for max_conn https://nginx.org/en/docs/http/ngx_http_upstream_module.html

> max_conns=number
> limits the maximum number of simultaneous active connections to the proxied server (1.11.5). Default value is zero, meaning there is no limit. If the server group does not reside in the shared memory, the limitation works per each worker process.

## Use case
This parameter is very useful on load balancing long lived connections and limiting load on the destination servers. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
