### PR TITLE
Added upstream zone directive annotation 

### DIFF
--- a/docs/configmap-and-annotations.md
+++ b/docs/configmap-and-annotations.md
@@ -166,7 +166,7 @@ spec:
 | `nginx.org/websocket-services` | N/A | Enables WebSocket for services. | N/A | [WebSocket support](../examples/websocket). |
 | `nginx.org/max-fails` | `max-fails` | Sets the value of the [max_fails](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_fails) parameter of the `server` directive. | `1` | |
 | `nginx.org/max-conns` | N\A | Sets the value of the [max_conns](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns) parameter of the `server` directive. | `0` | |
-| `nginx.org/upstream-zone-size` | N\A | Sets the size of the shared memory [zone](https://nginx.org/en/docs/http/ngx_http_upstream_module.html?#zone). If this annotation is not present then the zone directive will not be set. | `N\A` | |
+| `nginx.org/upstream-zone-size` | `upstream-zone-size` | Sets the size of the shared memory [zone](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#zone) for upstreams. For NGINX, the special value `0` disables the shared memory zones. | `256K` | |
 | `nginx.org/fail-timeout` | `fail-timeout` | Sets the value of the [fail_timeout](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#fail_timeout) parameter of the `server` directive. | `10s` | |
 | `nginx.com/sticky-cookie-services` | N/A | Configures session persistence. | N/A | [Session Persistence](../examples/session-persistence). |
 | `nginx.org/keepalive` | `keepalive` | Sets the value of the [keepalive](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive) directive. Note that `proxy_set_header Connection "";` is added to the generated configuration when the value > 0. | `0` | |

--- a/docs/configmap-and-annotations.md
+++ b/docs/configmap-and-annotations.md
@@ -166,6 +166,7 @@ spec:
 | `nginx.org/websocket-services` | N/A | Enables WebSocket for services. | N/A | [WebSocket support](../examples/websocket). |
 | `nginx.org/max-fails` | `max-fails` | Sets the value of the [max_fails](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_fails) parameter of the `server` directive. | `1` | |
 | `nginx.org/max-conns` | N\A | Sets the value of the [max_conns](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns) parameter of the `server` directive. | `0` | |
+| `nginx.org/upstream-zone-size` | N\A | Sets the size of the shared memory [zone](https://nginx.org/en/docs/http/ngx_http_upstream_module.html?#zone). If this annotation is not present then the zone directive will not be set. | `N\A` | |
 | `nginx.org/fail-timeout` | `fail-timeout` | Sets the value of the [fail_timeout](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#fail_timeout) parameter of the `server` directive. | `10s` | |
 | `nginx.com/sticky-cookie-services` | N/A | Configures session persistence. | N/A | [Session Persistence](../examples/session-persistence). |
 | `nginx.org/keepalive` | `keepalive` | Sets the value of the [keepalive](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive) directive. Note that `proxy_set_header Connection "";` is added to the generated configuration when the value > 0. | `0` | |

--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -45,6 +45,7 @@ var minionInheritanceList = map[string]bool{
 	"nginx.org/proxy-buffers":            true,
 	"nginx.org/proxy-buffer-size":        true,
 	"nginx.org/proxy-max-temp-file-size": true,
+	"nginx.org/upstream-zone-size":       true,
 	"nginx.org/location-snippets":        true,
 	"nginx.org/lb-method":                true,
 	"nginx.org/keepalive":                true,
@@ -245,6 +246,10 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 
 	if proxyBufferSize, exists := ingEx.Ingress.Annotations["nginx.org/proxy-buffer-size"]; exists {
 		cfgParams.ProxyBufferSize = proxyBufferSize
+	}
+
+	if upstreamZoneSize, exists := ingEx.Ingress.Annotations["nginx.org/upstream-zone-size"]; exists {
+		cfgParams.UpstreamZoneSize = upstreamZoneSize
 	}
 
 	if proxyMaxTempFileSize, exists := ingEx.Ingress.Annotations["nginx.org/proxy-max-temp-file-size"]; exists {

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -110,7 +110,7 @@ func NewDefaultConfigParams() *ConfigParams {
 		SSLPorts:                   []int{443},
 		MaxFails:                   1,
 		MaxConns:                   0,
-		UpstreamZoneSize: 			"256k",
+		UpstreamZoneSize: 		    "256k",
 		FailTimeout:                "10s",
 		LBMethod:                   "random two least_conn",
 		MainErrorLogLevel:          "notice",

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -29,6 +29,7 @@ type ConfigParams struct {
 	ProxyProtocol                 bool
 	ProxyHideHeaders              []string
 	ProxyPassHeaders              []string
+	UpstreamZoneSize              string
 	HSTS                          bool
 	HSTSBehindProxy               bool
 	HSTSMaxAge                    int64

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -110,7 +110,7 @@ func NewDefaultConfigParams() *ConfigParams {
 		SSLPorts:                   []int{443},
 		MaxFails:                   1,
 		MaxConns:                   0,
-		UpstreamZoneSize: 		    "256k",
+		UpstreamZoneSize:           "256k",
 		FailTimeout:                "10s",
 		LBMethod:                   "random two least_conn",
 		MainErrorLogLevel:          "notice",

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -110,6 +110,7 @@ func NewDefaultConfigParams() *ConfigParams {
 		SSLPorts:                   []int{443},
 		MaxFails:                   1,
 		MaxConns:                   0,
+		UpstreamZoneSize: 			"256k",
 		FailTimeout:                "10s",
 		LBMethod:                   "random two least_conn",
 		MainErrorLogLevel:          "notice",

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -307,6 +307,10 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool) *ConfigParams {
 		}
 	}
 
+	if upstreamZoneSize, exists := cfgm.Data["upstream-zone-size"]; exists {
+		cfgParams.UpstreamZoneSize = upstreamZoneSize
+	}
+
 	if failTimeout, exists := cfgm.Data["fail-timeout"]; exists {
 		cfgParams.FailTimeout = failTimeout
 	}

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -301,6 +301,7 @@ func createUpstream(ingEx *IngressEx, name string, backend *extensions.IngressBa
 	}
 
 	ups.LBMethod = cfg.LBMethod
+	ups.UpstreamZoneSize = cfg.UpstreamZoneSize
 	return ups
 }
 

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -125,6 +125,7 @@ func createExpectedConfigForCafeIngressEx() version1.IngressNginxConfig {
 	coffeeUpstream := version1.Upstream{
 		Name:     "default-cafe-ingress-cafe.example.com-coffee-svc-80",
 		LBMethod: "random two least_conn",
+		UpstreamZoneSize: "256k",
 		UpstreamServers: []version1.UpstreamServer{
 			{
 				Address:     "10.0.0.1",
@@ -137,6 +138,7 @@ func createExpectedConfigForCafeIngressEx() version1.IngressNginxConfig {
 	teaUpstream := version1.Upstream{
 		Name:     "default-cafe-ingress-cafe.example.com-tea-svc-80",
 		LBMethod: "random two least_conn",
+		UpstreamZoneSize: "256k",
 		UpstreamServers: []version1.UpstreamServer{
 			{
 				Address:     "10.0.0.2",
@@ -476,6 +478,7 @@ func createExpectedConfigForMergeableCafeIngress() version1.IngressNginxConfig {
 	coffeeUpstream := version1.Upstream{
 		Name:     "default-cafe-ingress-coffee-minion-cafe.example.com-coffee-svc-80",
 		LBMethod: "random two least_conn",
+		UpstreamZoneSize: "256k",
 		UpstreamServers: []version1.UpstreamServer{
 			{
 				Address:     "10.0.0.1",
@@ -488,6 +491,7 @@ func createExpectedConfigForMergeableCafeIngress() version1.IngressNginxConfig {
 	teaUpstream := version1.Upstream{
 		Name:     "default-cafe-ingress-tea-minion-cafe.example.com-tea-svc-80",
 		LBMethod: "random two least_conn",
+		UpstreamZoneSize: "256k",
 		UpstreamServers: []version1.UpstreamServer{
 			{
 				Address:     "10.0.0.2",

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -23,6 +23,7 @@ type Upstream struct {
 	LBMethod        string
 	Queue           int64
 	QueueTimeout    int64
+	UpstreamZoneSize string
 }
 
 // UpstreamServer describes a server in an NGINX upstream.

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -170,6 +170,7 @@ type MainConfig struct {
 func NewUpstreamWithDefaultServer(name string) Upstream {
 	return Upstream{
 		Name: name,
+		UpstreamZoneSize: "256k",
 		UpstreamServers: []UpstreamServer{
 			{
 				Address:     "127.0.0.1",

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -2,7 +2,7 @@
 
 {{range $upstream := .Upstreams}}
 upstream {{$upstream.Name}} {
-	{{if $upstream.UpstreamZoneSize }}{{zone {{$upstream.Name}} $upstream.UpstreamZoneSize}};{{end}}
+	{{if $upstream.UpstreamZoneSize }}zone {{$upstream.Name}} {{$upstream.UpstreamZoneSize}};{{end}}
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}};{{end}}

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -2,6 +2,7 @@
 
 {{range $upstream := .Upstreams}}
 upstream {{$upstream.Name}} {
+	{{if $upstream.UpstreamZoneSize }}{{zone {{$upstream.Name}} $upstream.UpstreamZoneSize}};{{end}}
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}};{{end}}

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -2,7 +2,7 @@
 
 {{range $upstream := .Upstreams}}
 upstream {{$upstream.Name}} {
-	{{if $upstream.UpstreamZoneSize }}zone {{$upstream.Name}} {{$upstream.UpstreamZoneSize}};{{end}}
+	{{if ne $upstream.UpstreamZoneSize "0" }}zone {{$upstream.Name}} {{$upstream.UpstreamZoneSize}};{{end}}
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}};{{end}}

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -2,7 +2,7 @@
 
 {{range $upstream := .Upstreams}}
 upstream {{$upstream.Name}} {
-	{{if ne $upstream.UpstreamZoneSize "0" }}zone {{$upstream.Name}} {{$upstream.UpstreamZoneSize}};{{end}}
+	{{if ne $upstream.UpstreamZoneSize "0"}}zone {{$upstream.Name}} {{$upstream.UpstreamZoneSize}};{{end}}
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}};{{end}}

--- a/internal/configs/version1/templates_test.go
+++ b/internal/configs/version1/templates_test.go
@@ -13,6 +13,7 @@ const nginxPlusMainTmpl = "nginx-plus.tmpl"
 
 var testUps = Upstream{
 	Name: "test",
+	UpstreamZoneSize: "256k",
 	UpstreamServers: []UpstreamServer{
 		{
 			Address:     "127.0.0.1",


### PR DESCRIPTION
### Proposed changes
These changes enable the zone directive on upstream block with upstream name equal to zone name and zone size equals to the annotation value. This follow the same convention as nginx-plus ingress config. For instance, `nginx.org/upstream-zone-size: "32k"` in your ingress.yaml will generate a config such as
```
upstream myService-ingress-prod-myService.production.ingress.net-myService-prod-80 {
   zone myService-ingress-prod-myService.production.ingress.net-myService-prod-80 32k;
   server 125.255.255.255:8888 max_fails=3 fail_timeout=10 max_conns=6;
}
```
If the annotation is not present then the zone directive will not be present on the config. 

[Nginx Documentation for upstream zone](https://nginx.org/en/docs/http/ngx_http_upstream_module.html?#zone)

| | |
-- | --
Syntax: | zone **name** [size]; 
Default: | N/A 
Context: | upstream 

## Motivation
In multi worker nginx setup([worker_processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes) > 1), the zone directive fixes the least_conn lb method as well as max_fails, max_conns parameters. From the nginx document on [load balancing](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#zone-size):
>For example, if the configuration of a group is not shared, each worker process maintains its own counter for failed attempts to pass a request to a server (set by the max_fails parameter). In this case, each request gets to only one worker process. When the worker process that is selected to process a request fails to transmit the request to a server, other worker processes don’t know anything about it. While some worker process can consider a server unavailable, others might still send requests to this server. For a server to be definitively considered unavailable, the number of failed attempts during the timeframe set by the fail_timeout parameter must equal max_fails multiplied by the number of worker processes. On the other hand, the zone directive guarantees the expected behavior.
Similarly, the Least Connections load‑balancing method might not work as expected without the zone directive, at least under low load.

## Use case
A properly working least_conn load balancer is very useful in balancing long lived connections and limiting load on the destination servers; particularly when upstream servers are streaming web apps. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
