### PR TITLE
Fix hsts support when not using SSL

### DIFF
--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -53,9 +53,7 @@ server {
 	proxy_pass_header {{$proxyPassHeader}};{{end}}
 	{{end}}
 
-	{{if $server.SSL}}
-	{{if not $server.GRPCOnly}}
-	{{- if $server.HSTS}}
+	{{- if and $server.HSTS (or $server.SSL $server.HSTSBehindProxy)}}
 	set $hsts_header_val "";
 	proxy_hide_header Strict-Transport-Security;
 	{{- if $server.HSTSBehindProxy}}
@@ -69,6 +67,8 @@ server {
 	add_header Strict-Transport-Security "$hsts_header_val" always;
 	{{end}}
 
+	{{if $server.SSL}}
+	{{if not $server.GRPCOnly}}
 	{{- if $server.SSLRedirect}}
 	if ($scheme = http) {
 		return 301 https://$host:{{index $server.SSLPorts 0}}$request_uri;

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -39,9 +39,7 @@ server {
 	{{range $proxyPassHeader := $server.ProxyPassHeaders}}
 	proxy_pass_header {{$proxyPassHeader}};{{end}}
 
-	{{if $server.SSL}}
-	{{if not $server.GRPCOnly}}
-	{{- if $server.HSTS}}
+	{{- if and $server.HSTS (or $server.SSL $server.HSTSBehindProxy)}}
 	set $hsts_header_val "";
 	proxy_hide_header Strict-Transport-Security;
 	{{- if $server.HSTSBehindProxy}}
@@ -55,6 +53,8 @@ server {
 	add_header Strict-Transport-Security "$hsts_header_val" always;
 	{{end}}
 
+	{{if $server.SSL}}
+	{{if not $server.GRPCOnly}}
 	{{- if $server.SSLRedirect}}
 	if ($scheme = http) {
 		return 301 https://$host:{{index $server.SSLPorts 0}}$request_uri;


### PR DESCRIPTION
Closes #627

### Proposed changes
This change will fix the HSTS support when not handling SSL at the ingress layer. Previously, the templating code would only render the HSTS related directives if the `SSL` was true which is never the case when a load balancer that sits in front of the ingress handle the TLS.  

Fixes the following issue: https://github.com/nginxinc/kubernetes-ingress/issues/627

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
