### PR TITLE
Add checks for gen code for CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,18 @@ else
 	go test ./...
 endif
 
+verify: 
+	./hack/verify-codegen.sh
+
+regen: 
+	./hack/update-codegen.sh
+
 certificate-and-key:
 ifeq ($(GENERATE_DEFAULT_CERT_AND_KEY),1)
 	./build/generate_default_cert_and_key.sh
 endif
 
-container: test nginx-ingress certificate-and-key
+container: test verify nginx-ingress certificate-and-key
 	cp $(DOCKERFILEPATH)/$(DOCKERFILE) ./Dockerfile
 	docker build $(DOCKER_BUILD_OPTIONS) --build-arg IC_VERSION=$(VERSION)-$(GIT_COMMIT) -f Dockerfile -t $(PREFIX):$(TAG) .
 

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ else
 	go test ./...
 endif
 
-verify: 
+verify-codegen: 
 	./hack/verify-codegen.sh
 
-regen: 
+update-codegen: 
 	./hack/update-codegen.sh
 
 certificate-and-key:
@@ -45,7 +45,7 @@ ifeq ($(GENERATE_DEFAULT_CERT_AND_KEY),1)
 	./build/generate_default_cert_and_key.sh
 endif
 
-container: test verify nginx-ingress certificate-and-key
+container: test verify-codegen nginx-ingress certificate-and-key
 	cp $(DOCKERFILEPATH)/$(DOCKERFILE) ./Dockerfile
 	docker build $(DOCKER_BUILD_OPTIONS) --build-arg IC_VERSION=$(VERSION)-$(GIT_COMMIT) -f Dockerfile -t $(PREFIX):$(TAG) .
 

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -43,6 +43,6 @@ if [[ $ret -eq 0 ]]
 then
   echo "${DIFFROOT} up to date."
 else
-  echo "${DIFFROOT} is out of date. Please run hack/update-codegen.sh"
+  echo "${DIFFROOT} is out of date. Please regenerate code"
   exit 1
 fi


### PR DESCRIPTION
### Proposed changes
Added a target in makefile that checks if generated code for CRDs needs regenerating. 

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork