### PR TITLE
Add `max-conns` checks to the tests.

### DIFF
--- a/tests/data/annotations/mergeable/minion-annotations-differ.yaml
+++ b/tests/data/annotations/mergeable/minion-annotations-differ.yaml
@@ -6,6 +6,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.org/mergeable-ingress-type: "master"
     nginx.org/proxy-send-timeout: "10s"
+    nginx.org/max-conns: "108"
 spec:
   rules:
   - host: annotations.example.com
@@ -18,6 +19,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.org/mergeable-ingress-type: "minion"
     nginx.org/proxy-send-timeout: "25s"
+    nginx.org/max-conns: "1048"
 spec:
   rules:
   - host: annotations.example.com
@@ -36,6 +38,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.org/mergeable-ingress-type: "minion"
     nginx.org/proxy-send-timeout: "33s"
+    nginx.org/max-conns: "1024"
 spec:
   rules:
   - host: annotations.example.com

--- a/tests/data/virtual-server-route-upstream-options/configmap-with-keys.yaml
+++ b/tests/data/virtual-server-route-upstream-options/configmap-with-keys.yaml
@@ -11,3 +11,4 @@ data:
   proxy-read-timeout: "22s"
   proxy-send-timeout: "55s"
   keepalive: "1024"
+  max-conns: "1000" # there is no support for this key

--- a/tests/data/virtual-server-route-upstream-options/route-multiple-invalid-keys.yaml
+++ b/tests/data/virtual-server-route-upstream-options/route-multiple-invalid-keys.yaml
@@ -15,6 +15,7 @@ spec:
     read-timeout: "-16s"
     send-timeout: "s"
     keepalive: -10
+    max-conns: -23
   - name: backend3
     service: backend3-svc
     port: 80
@@ -25,6 +26,7 @@ spec:
     read-timeout: "1.2"
     send-timeout: "ten"
     keepalive: -24
+    max-conns: -1000
   subroutes:
   - path: "/backends/backend1"
     upstream: backend1

--- a/tests/data/virtual-server-route-upstream-options/route-single-invalid-keys.yaml
+++ b/tests/data/virtual-server-route-upstream-options/route-single-invalid-keys.yaml
@@ -15,6 +15,7 @@ spec:
     read-timeout: "-16s"
     send-timeout: "-0s"
     keepalive: -10
+    max-conns: -23
   subroutes:
   - path: "/backend2"
     upstream: backend2

--- a/tests/data/virtual-server-upstream-options/configmap-with-keys.yaml
+++ b/tests/data/virtual-server-upstream-options/configmap-with-keys.yaml
@@ -11,3 +11,4 @@ data:
   proxy-read-timeout: "22s"
   proxy-send-timeout: "55s"
   keepalive: "1024"
+  max-conns: "1000" # there is no support for this key

--- a/tests/data/virtual-server-upstream-options/virtual-server-with-invalid-keys.yaml
+++ b/tests/data/virtual-server-upstream-options/virtual-server-with-invalid-keys.yaml
@@ -15,6 +15,7 @@ spec:
     read-timeout: "-16s"
     send-timeout: "s"
     keepalive: -12
+    max-conns: -23
   - name: backend1
     service: backend1-svc
     port: 80
@@ -25,6 +26,7 @@ spec:
     read-timeout: "1.2"
     send-timeout: "."
     keepalive: -19
+    max-conns: -24
   routes:
   - path: "/backend1"
     upstream: backend1

--- a/tests/suite/test_v_s_route_upstream_options.py
+++ b/tests/suite/test_v_s_route_upstream_options.py
@@ -75,10 +75,10 @@ class TestVSRouteUpstreamOptions:
     @pytest.mark.parametrize('options, expected_strings', [
         ({"lb-method": "least_conn", "max-fails": 8,
           "fail-timeout": "13s", "connect-timeout": "55s", "read-timeout": "1s", "send-timeout": "1h",
-          "keepalive": 54},
+          "keepalive": 54, "max-conns": 1024},
          ["least_conn;", "max_fails=8 ",
-          "fail_timeout=13s ", "max_conns=0;", "proxy_connect_timeout 55s;", "proxy_read_timeout 1s;", "proxy_send_timeout 1h;",
-          "keepalive 54;", 'proxy_set_header Connection "";']),
+          "fail_timeout=13s ", "proxy_connect_timeout 55s;", "proxy_read_timeout 1s;",
+          "proxy_send_timeout 1h;", "keepalive 54;", 'proxy_set_header Connection "";', "max_conns=1024;"]),
         ({"lb-method": "ip_hash", "connect-timeout": "75", "read-timeout": "15", "send-timeout": "1h"},
          ["ip_hash;", "proxy_connect_timeout 75;", "proxy_read_timeout 15;", "proxy_send_timeout 1h;"]),
         ({"connect-timeout": "1m", "read-timeout": "1m", "send-timeout": "1s"},
@@ -135,7 +135,7 @@ class TestVSRouteUpstreamOptions:
           "proxy_connect_timeout 44s;", "proxy_read_timeout 22s;", "proxy_send_timeout 55s;",
           "keepalive 1024;", 'proxy_set_header Connection "";'],
          ["ip_hash;", "least_conn;", "random ", "hash", "least_time ",
-          "max_fails=1 ", "fail_timeout=10s ", "max_conns=1s;",
+          "max_fails=1 ", "fail_timeout=10s ", "max_conns=1000;",
           "proxy_connect_timeout 60s;", "proxy_read_timeout 60s;", "proxy_send_timeout 60s;"]),
     ])
     def test_when_option_in_config_map_only(self, kube_apis,
@@ -189,7 +189,7 @@ class TestVSRouteUpstreamOptions:
           "fail_timeout=1m ", "max_conns=0;", "proxy_connect_timeout 1m;", "proxy_read_timeout 77s;", "proxy_send_timeout 23s;",
           "keepalive 48;", 'proxy_set_header Connection "";'],
          ["ip_hash;", "random ", "hash", "least_time ", "max_fails=1 ",
-          "fail_timeout=10s ", "max_conns=1s;", "proxy_connect_timeout 44s;", "proxy_read_timeout 22s;", "proxy_send_timeout 55s;",
+          "fail_timeout=10s ", "proxy_connect_timeout 44s;", "proxy_read_timeout 22s;", "proxy_send_timeout 55s;",
           "keepalive 1024;"])
     ])
     def test_v_s_r_overrides_config_map(self, kube_apis,
@@ -253,15 +253,15 @@ class TestVSRouteUpstreamOptionsValidation:
         invalid_fields_s = ["upstreams[0].lb-method", "upstreams[0].fail-timeout",
                             "upstreams[0].max-fails", "upstreams[0].connect-timeout",
                             "upstreams[0].read-timeout", "upstreams[0].send-timeout",
-                            "upstreams[0].keepalive"]
+                            "upstreams[0].keepalive","upstreams[0].max-conns"]
         invalid_fields_m = ["upstreams[0].lb-method", "upstreams[0].fail-timeout",
                             "upstreams[0].max-fails", "upstreams[0].connect-timeout",
                             "upstreams[0].read-timeout", "upstreams[0].send-timeout",
-                            "upstreams[0].keepalive",
+                            "upstreams[0].keepalive", "upstreams[0].max-conns",
                             "upstreams[1].lb-method", "upstreams[1].fail-timeout",
                             "upstreams[1].max-fails", "upstreams[1].connect-timeout",
                             "upstreams[1].read-timeout", "upstreams[1].send-timeout",
-                            "upstreams[1].keepalive"]
+                            "upstreams[1].keepalive", "upstreams[1].max-conns"]
         text_s = f"{v_s_route_setup.route_s.namespace}/{v_s_route_setup.route_s.name}"
         text_m = f"{v_s_route_setup.route_m.namespace}/{v_s_route_setup.route_m.name}"
         vsr_s_event_text = f"VirtualServerRoute {text_s} is invalid and was rejected: "

--- a/tests/suite/test_virtual_server_upstream_options.py
+++ b/tests/suite/test_virtual_server_upstream_options.py
@@ -79,10 +79,10 @@ class TestVirtualServerUpstreamOptions:
     @pytest.mark.parametrize('options, expected_strings', [
         ({"lb-method": "least_conn", "max-fails": 8,
           "fail-timeout": "13s", "connect-timeout": "55s", "read-timeout": "1s", "send-timeout": "1h",
-          "keepalive": 54},
+          "keepalive": 54, "max-conns": 1048},
          ["least_conn;", "max_fails=8 ",
-          "fail_timeout=13s ", "max_conns=0;", "proxy_connect_timeout 55s;", "proxy_read_timeout 1s;", "proxy_send_timeout 1h;",
-          "keepalive 54;", 'proxy_set_header Connection "";']),
+          "fail_timeout=13s ", "proxy_connect_timeout 55s;", "proxy_read_timeout 1s;",
+          "proxy_send_timeout 1h;", "keepalive 54;", 'proxy_set_header Connection "";', "max_conns=1048;"]),
         ({"lb-method": "ip_hash", "connect-timeout": "75", "read-timeout": "15", "send-timeout": "1h"},
          ["ip_hash;", "proxy_connect_timeout 75;", "proxy_read_timeout 15;", "proxy_send_timeout 1h;"]),
         ({"connect-timeout": "1m", "read-timeout": "1m", "send-timeout": "1s"},
@@ -125,7 +125,7 @@ class TestVirtualServerUpstreamOptions:
           "proxy_connect_timeout 44s;", "proxy_read_timeout 22s;", "proxy_send_timeout 55s;",
           "keepalive 1024;", 'proxy_set_header Connection "";'],
          ["ip_hash;", "least_conn;", "random ", "hash", "least_time ",
-          "max_fails=1 ", "fail_timeout=10s ", "max_conns=1s;",
+          "max_fails=1 ", "fail_timeout=10s ", "max_conns=1000;",
           "proxy_connect_timeout 60s;", "proxy_read_timeout 60s;", "proxy_send_timeout 60s;"]),
     ])
     def test_when_option_in_config_map_only(self, kube_apis, ingress_controller_prerequisites,
@@ -166,11 +166,11 @@ class TestVirtualServerUpstreamOptions:
           "fail-timeout": "1m", "connect-timeout": "1m", "read-timeout": "77s", "send-timeout": "23s",
           "keepalive": 48},
          ["least_conn;", "max_fails=12 ",
-          "fail_timeout=1m ", "max_conns=0;", "proxy_connect_timeout 1m;", "proxy_read_timeout 77s;", "proxy_send_timeout 23s;",
-          "keepalive 48;", 'proxy_set_header Connection "";'],
+          "fail_timeout=1m ", "max_conns=0;", "proxy_connect_timeout 1m;", "proxy_read_timeout 77s;",
+          "proxy_send_timeout 23s;", "keepalive 48;", 'proxy_set_header Connection "";'],
          ["ip_hash;", "random ", "hash", "least_time ", "max_fails=1 ",
-          "fail_timeout=10s ", "max_conns=33s;", "proxy_connect_timeout 44s;", "proxy_read_timeout 22s;", "proxy_send_timeout 55s;",
-          "keepalive 1024;"])
+          "fail_timeout=10s ", "proxy_connect_timeout 44s;", "proxy_read_timeout 22s;",
+          "proxy_send_timeout 55s;", "keepalive 1024;"])
     ])
     def test_v_s_overrides_config_map(self, kube_apis, ingress_controller_prerequisites,
                                       crd_ingress_controller, virtual_server_setup,
@@ -220,7 +220,12 @@ class TestVirtualServerUpstreamOptionValidation:
         invalid_fields = ["upstreams[0].lb-method", "upstreams[0].fail-timeout",
                           "upstreams[0].max-fails", "upstreams[0].connect-timeout",
                           "upstreams[0].read-timeout", "upstreams[0].send-timeout",
-                          "upstreams[0].keepalive"]
+                          "upstreams[0].keepalive", "upstreams[0].max-conns",
+                          "upstreams[1].lb-method", "upstreams[1].fail-timeout",
+                          "upstreams[1].max-fails", "upstreams[1].connect-timeout",
+                          "upstreams[1].read-timeout", "upstreams[1].send-timeout",
+                          "upstreams[1].keepalive", "upstreams[1].max-conns"
+                          ]
         text = f"{virtual_server_setup.namespace}/{virtual_server_setup.vs_name}"
         vs_event_text = f"VirtualServer {text} is invalid and was rejected: "
         vs_file = f"{TEST_DATA}/virtual-server-upstream-options/virtual-server-with-invalid-keys.yaml"


### PR DESCRIPTION
Covers checks for Ingress annotation and VS/VSRs upstream options.