### PR TITLE
Add flag to control accumulating IC logs in stdout

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,9 +8,10 @@ NODE_IP =
 TAG = latest
 PREFIX = test-runner
 KUBE_CONFIG_FOLDER = $${HOME}/.kube
+SHOW_IC_LOGS = no
 
 build:
 	docker build -t $(PREFIX):$(TAG) -f docker/Dockerfile ..
 
 run-tests:
-	docker run --rm -v $(KUBE_CONFIG_FOLDER):/root/.kube $(PREFIX):$(TAG) --context=$(CONTEXT) --image=$(BUILD_IMAGE) --image-pull-policy=$(PULL_POLICY) --deployment-type=$(DEPLOYMENT_TYPE) --ic-type=$(IC_TYPE) --service=$(SERVICE) --node-ip=$(NODE_IP)
+	docker run --rm -v $(KUBE_CONFIG_FOLDER):/root/.kube $(PREFIX):$(TAG) --context=$(CONTEXT) --image=$(BUILD_IMAGE) --image-pull-policy=$(PULL_POLICY) --deployment-type=$(DEPLOYMENT_TYPE) --ic-type=$(IC_TYPE) --service=$(SERVICE) --node-ip=$(NODE_IP) --show-ic-logs=$(SHOW_IC_LOGS)

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,5 +52,6 @@ The table below shows various configuration options for the tests. If you use Py
 | `--node-ip` | `NODE_IP` | The public IP of a cluster node. Not required if you use the loadbalancer service (see --service argument). | `""` |
 | `--kubeconfig` | `N/A` | An absolute path to a kubeconfig file. | `~/.kube/config` or the value of the `KUBECONFIG` env variable |
 | `N/A` | `KUBE_CONFIG_FOLDER` | A path to a folder with a kubeconfig file. | `~/.kube/` |
+| `--show-ic-logs` | `SHOW_IC_LOGS` | A flag to control accumulating IC logs in stdout. | `no` |
 
 If you would like to use an IDE (such as PyCharm) to run the tests, use the [pytest.ini](pytest.ini) file to set the command-line arguments.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def pytest_addoption(parser) -> None:
                      action="store",
                      default=os.path.expanduser(KUBE_CONFIG_DEFAULT_LOCATION),
                      help="An absolute path to a kubeconfig file.")
+    parser.addoption("--show-ic-logs", action="store", default="no", help="Show IC logs in stdout on test failure")
 
 
 # import fixtures into pytest global namespace
@@ -67,7 +68,8 @@ def pytest_runtest_makereport(item) -> None:
     """
     Print out IC Pod logs on test failure.
 
-    Only look at actual failing test calls, not setup/teardown
+    Only look at actual failing test calls, not setup/teardown.
+    Only show the logs if commandline argument `--show-ic-logs` is set to 'yes'
 
     :param item:
     :return:
@@ -77,7 +79,7 @@ def pytest_runtest_makereport(item) -> None:
     rep = outcome.get_result()
 
     # we only look at actual failing test calls, not setup/teardown
-    if rep.when == "call" and rep.failed:
+    if rep.when == "call" and rep.failed and pytest.config.getoption("--show-ic-logs") == "yes":
         pod_namespace = item.funcargs['ingress_controller_prerequisites'].namespace
         pod_name = get_first_pod_name(item.funcargs['kube_apis'].v1, pod_namespace)
         print("\n===================== IC Logs Start =====================")


### PR DESCRIPTION
Add flag `--show-ic-logs`, default is 'no' (do Not show the logs)