### PR TITLE
Makefile builds w/o go installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,18 @@ else
 endif
 
 verify-codegen: 
+ifeq ($(BUILD_IN_CONTAINER), 1)
+	$(DOCKER_RUN) $(GOLANG_CONTAINER) ./hack/verify-codegen.sh
+else 
 	./hack/verify-codegen.sh
+endif
 
 update-codegen: 
+ifeq ($(BUILD_IN_CONTAINER), 1)
+	$(DOCKER_RUN) $(GOLANG_CONTAINER) ./hack/update-codegen.sh
+else 
 	./hack/update-codegen.sh
+endif
 
 certificate-and-key:
 ifeq ($(GENERATE_DEFAULT_CERT_AND_KEY),1)

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,7 @@ else
 endif
 
 verify-codegen: 
-ifeq ($(BUILD_IN_CONTAINER), 1)
-	$(DOCKER_RUN) $(GOLANG_CONTAINER) ./hack/verify-codegen.sh
-else 
+ifneq ($(BUILD_IN_CONTAINER), 1)
 	./hack/verify-codegen.sh
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,7 @@ else
 endif
 
 update-codegen: 
-ifeq ($(BUILD_IN_CONTAINER), 1)
-	$(DOCKER_RUN) $(GOLANG_CONTAINER) ./hack/update-codegen.sh
-else 
 	./hack/update-codegen.sh
-endif
 
 certificate-and-key:
 ifeq ($(GENERATE_DEFAULT_CERT_AND_KEY),1)


### PR DESCRIPTION
### Proposed changes
verify-codegen.sh doesn't run if IC is being built in a container 


- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
