### PR TITLE
Add checks for `health check` upstream options

### DIFF
--- a/tests/data/virtual-server-route-upstream-options/plus-route-m-invalid-keys.yaml
+++ b/tests/data/virtual-server-route-upstream-options/plus-route-m-invalid-keys.yaml
@@ -1,0 +1,48 @@
+apiVersion: k8s.nginx.org/v1alpha1
+kind: VirtualServerRoute
+metadata:
+  name: backends
+spec:
+  host: virtual-server-route.example.com
+  upstreams:
+  - name: backend1
+    service: backend1-svc
+    port: 80
+    healthCheck:
+      enable: True
+      path: "invalid"
+      interval: 1.5d
+      jitter: invalid
+      fails: -5
+      passes: -1
+      port: -1
+      connect-timeout: invalid
+      read-timeout: m
+      send-timeout: d
+      headers:
+        - name: ""
+          value: "$one"
+      statusMatch: "invalid"
+  - name: backend3
+    service: backend3-svc
+    port: 80
+    healthCheck:
+      enable: True
+      path: "invalid"
+      interval: 1.5d
+      jitter: invalid
+      fails: -5
+      passes: -1
+      port: -1
+      connect-timeout: invalid
+      read-timeout: m
+      send-timeout: d
+      headers:
+        - name: "`=1^&*"
+          value: "`=1.±!@£$%^&*()_+{}[]'^&*"
+      statusMatch: "invalid"
+  subroutes:
+  - path: "/backends/backend1"
+    upstream: backend1
+  - path: "/backends/backend3"
+    upstream: backend3

--- a/tests/data/virtual-server-route-upstream-options/plus-route-s-invalid-keys.yaml
+++ b/tests/data/virtual-server-route-upstream-options/plus-route-s-invalid-keys.yaml
@@ -1,0 +1,28 @@
+apiVersion: k8s.nginx.org/v1alpha1
+kind: VirtualServerRoute
+metadata:
+  name: backend2
+spec:
+  host: virtual-server-route.example.com
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+    healthCheck:
+      enable: True
+      path: "invalid"
+      interval: 1.5d
+      jitter: invalid
+      fails: -5
+      passes: -1
+      port: -1
+      connect-timeout: invalid
+      read-timeout: m
+      send-timeout: d
+      headers:
+        - name: "`=1^&*"
+          value: "$one"
+      statusMatch: "invalid"
+  subroutes:
+  - path: "/backend2"
+    upstream: backend2

--- a/tests/data/virtual-server-upstream-options/plus-virtual-server-with-invalid-keys.yaml
+++ b/tests/data/virtual-server-upstream-options/plus-virtual-server-with-invalid-keys.yaml
@@ -1,0 +1,48 @@
+apiVersion: k8s.nginx.org/v1alpha1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+    healthCheck:
+      enable: True
+      path: "invalid"
+      interval: 1.5d
+      jitter: invalid
+      fails: -5
+      passes: -1
+      port: -1
+      connect-timeout: invalid
+      read-timeout: m
+      send-timeout: d
+      headers:
+        - name: ""
+          value: "$one"
+      statusMatch: "invalid"
+  - name: backend1
+    service: backend1-svc
+    port: 80
+    healthCheck:
+      enable: True
+      path: "invalid"
+      interval: 1.5d
+      jitter: invalid
+      fails: -5
+      passes: -1
+      port: -1
+      connect-timeout: invalid
+      read-timeout: m
+      send-timeout: d
+      headers:
+        - name: "`=1^&*"
+          value: "`=1.±!@£$%^&*()_+{}[]'^&*"
+      statusMatch: "invalid"
+  routes:
+  - path: "/backend1"
+    upstream: backend1
+  - path: "/backend2"
+    upstream: backend2


### PR DESCRIPTION
The cases are similar to the other upstream options but only run for Nginx Plus. 