### PR TITLE
Add checks for `slow-start` upstream option

### DIFF
--- a/tests/data/virtual-server-route-upstream-options/plus-route-m-invalid-keys.yaml
+++ b/tests/data/virtual-server-route-upstream-options/plus-route-m-invalid-keys.yaml
@@ -23,6 +23,7 @@ spec:
         - name: ""
           value: "$one"
       statusMatch: "invalid"
+    slow-start: "-3s"
   - name: backend3
     service: backend3-svc
     port: 80
@@ -41,6 +42,7 @@ spec:
         - name: "`=1^&*"
           value: "`=1.±!@£$%^&*()_+{}[]'^&*"
       statusMatch: "invalid"
+    slow-start: "1.5m"
   subroutes:
   - path: "/backends/backend1"
     upstream: backend1

--- a/tests/data/virtual-server-route-upstream-options/plus-route-s-invalid-keys.yaml
+++ b/tests/data/virtual-server-route-upstream-options/plus-route-s-invalid-keys.yaml
@@ -23,6 +23,7 @@ spec:
         - name: "`=1^&*"
           value: "$one"
       statusMatch: "invalid"
+    slow-start: " "
   subroutes:
   - path: "/backend2"
     upstream: backend2

--- a/tests/data/virtual-server-upstream-options/plus-virtual-server-with-invalid-keys.yaml
+++ b/tests/data/virtual-server-upstream-options/plus-virtual-server-with-invalid-keys.yaml
@@ -23,6 +23,7 @@ spec:
         - name: ""
           value: "$one"
       statusMatch: "invalid"
+    slow-start: "-3s"
   - name: backend1
     service: backend1-svc
     port: 80
@@ -41,6 +42,7 @@ spec:
         - name: "`=1^&*"
           value: "`=1.±!@£$%^&*()_+{}[]'^&*"
       statusMatch: "invalid"
+    slow-start: "1.5d"
   routes:
   - path: "/backend1"
     upstream: backend1


### PR DESCRIPTION
Cases are similar to any other upstream options. There are no checks for warnings in IC logs. 