### PR TITLE
Add checks on hash-variables in ConfigMap for VS

### DIFF
--- a/tests/data/virtual-server-configmap-keys/configmap-global-variables.yaml
+++ b/tests/data/virtual-server-configmap-keys/configmap-global-variables.yaml
@@ -1,0 +1,8 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-config
+  namespace: nginx-ingress
+data:
+  variables-hash-bucket-size: "124"
+  variables-hash-max-size: "0"

--- a/tests/data/virtual-server-configmap-keys/configmap-validation-keys-invalid.yaml
+++ b/tests/data/virtual-server-configmap-keys/configmap-validation-keys-invalid.yaml
@@ -12,3 +12,5 @@ data:
   keepalive: "invalid"
   proxy-protocol: "invalid proxy"
   redirect-to-https: "invalid"
+  variables-hash-bucket-size: "0"
+  variables-hash-max-size: "-1024"

--- a/tests/data/virtual-server-configmap-keys/configmap-validation-keys.yaml
+++ b/tests/data/virtual-server-configmap-keys/configmap-validation-keys.yaml
@@ -13,3 +13,5 @@ data:
   proxy-protocol: "true"
   redirect-to-https: "true"
   upstream-zone-size: "0" # special value
+  variables-hash-bucket-size: "512"
+  variables-hash-max-size: "2048"


### PR DESCRIPTION
Test cases are similar to any other CM keys.