### PR TITLE
Add OpenTracing module version to Dockerfile for Plus

### DIFF
--- a/build/DockerfileWithOpentracingForPlus
+++ b/build/DockerfileWithOpentracingForPlus
@@ -12,6 +12,8 @@ FROM debian:stretch-slim
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_PLUS_VERSION 19-1~stretch
+ENV NGINX_OPENTRACING_MODULE_VERSION 19+0.8.0-1~stretch
+
 ARG IC_VERSION
 
 # Download certificate and key from the customer portal (https://cs.nginx.com)
@@ -48,7 +50,7 @@ RUN set -x \
     && apt-get update && apt-get install -y \
     nginx-plus=${NGINX_PLUS_VERSION} \
     # Install OpenTracing module
-    nginx-plus-module-opentracing \ 
+    nginx-plus-module-opentracing=${NGINX_OPENTRACING_MODULE_VERSION} \
     && apt-get remove --purge --auto-remove -y gnupg1 \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /etc/ssl/nginx \


### PR DESCRIPTION
### Proposed changes
OpenTracing module for Plus needs to be parametrised in the Dockerfile as well. Right now, because a new version of NGINX Plus is released, the build fails because it tries to get the module for the last NGINX Plus version.


Note: if https://github.com/nginxinc/kubernetes-ingress/pull/677 is merged before, update Version here.