### PR TITLE
Organize tests into Smoke and non-Smoke suite

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,9 +9,10 @@ TAG = latest
 PREFIX = test-runner
 KUBE_CONFIG_FOLDER = $${HOME}/.kube
 SHOW_IC_LOGS = no
+PYTEST_ARGS =
 
 build:
 	docker build -t $(PREFIX):$(TAG) -f docker/Dockerfile ..
 
 run-tests:
-	docker run --rm -v $(KUBE_CONFIG_FOLDER):/root/.kube $(PREFIX):$(TAG) --context=$(CONTEXT) --image=$(BUILD_IMAGE) --image-pull-policy=$(PULL_POLICY) --deployment-type=$(DEPLOYMENT_TYPE) --ic-type=$(IC_TYPE) --service=$(SERVICE) --node-ip=$(NODE_IP) --show-ic-logs=$(SHOW_IC_LOGS)
+	docker run --rm -v $(KUBE_CONFIG_FOLDER):/root/.kube $(PREFIX):$(TAG) --context=$(CONTEXT) --image=$(BUILD_IMAGE) --image-pull-policy=$(PULL_POLICY) --deployment-type=$(DEPLOYMENT_TYPE) --ic-type=$(IC_TYPE) --service=$(SERVICE) --node-ip=$(NODE_IP) --show-ic-logs=$(SHOW_IC_LOGS) $(PYTEST_ARGS)

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,5 +53,6 @@ The table below shows various configuration options for the tests. If you use Py
 | `--kubeconfig` | `N/A` | An absolute path to a kubeconfig file. | `~/.kube/config` or the value of the `KUBECONFIG` env variable |
 | `N/A` | `KUBE_CONFIG_FOLDER` | A path to a folder with a kubeconfig file. | `~/.kube/` |
 | `--show-ic-logs` | `SHOW_IC_LOGS` | A flag to control accumulating IC logs in stdout. | `no` |
+| `N/A` | `PYTEST_ARGS` | Any additional pytest command-line arguments (i.e `-m "smoke"`) | `""` |
 
 If you would like to use an IDE (such as PyCharm) to run the tests, use the [pytest.ini](pytest.ini) file to set the command-line arguments.

--- a/tests/suite/test_v_s_route.py
+++ b/tests/suite/test_v_s_route.py
@@ -45,6 +45,7 @@ def assert_event_and_get_count(event_text, events_list) -> int:
     pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize('crd_ingress_controller, v_s_route_setup',
                          [({"type": "complete", "extra_args": [f"-enable-custom-resources"]},
                            {"example": "virtual-server-route"})],

--- a/tests/suite/test_virtual_server.py
+++ b/tests/suite/test_virtual_server.py
@@ -9,6 +9,7 @@ from suite.resources_utils import patch_rbac, replace_service, read_service, \
 from suite.yaml_utils import get_paths_from_vs_yaml, get_first_vs_host_from_yaml, get_names_from_yaml
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize('crd_ingress_controller, virtual_server_setup',
                          [({"type": "complete", "extra_args": [f"-enable-custom-resources"]},
                            {"example": "virtual-server", "app_type": "simple"})],

--- a/tests/suite/test_virtual_server_advanced_routing.py
+++ b/tests/suite/test_virtual_server_advanced_routing.py
@@ -16,6 +16,7 @@ def execute_assertions(resp_1, resp_2, resp_3):
     assert "Server name: backend4-" in resp_3.text
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize('crd_ingress_controller, virtual_server_setup',
                          [({"type": "complete", "extra_args": [f"-enable-custom-resources"]},
                            {"example": "virtual-server-advanced-routing", "app_type": "advanced-routing"})],

--- a/tests/suite/test_virtual_server_split_traffic.py
+++ b/tests/suite/test_virtual_server_split_traffic.py
@@ -38,6 +38,7 @@ def get_upstreams_of_splitting(file) -> []:
     return upstreams
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize('crd_ingress_controller, virtual_server_setup',
                          [({"type": "complete", "extra_args": [f"-enable-custom-resources"]},
                            {"example": "virtual-server-split-traffic", "app_type": "split"})],

--- a/tests/suite/test_virtual_server_tls.py
+++ b/tests/suite/test_virtual_server_tls.py
@@ -59,6 +59,7 @@ def assert_gb_subject(virtual_server_setup):
     assert subject_dict[b'CN'] == b'cafe.example.com'
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize('crd_ingress_controller, virtual_server_setup',
                          [({"type": "complete", "extra_args": [f"-enable-custom-resources"]},
                            {"example": "virtual-server-tls", "app_type": "simple"})],

--- a/tests/suite/test_wildcard_tls_secret.py
+++ b/tests/suite/test_wildcard_tls_secret.py
@@ -92,6 +92,7 @@ def wildcard_tls_secret_ingress_controller(cli_arguments, kube_apis, ingress_con
     return IngressControllerWithSecret(secret_name)
 
 
+@pytest.mark.smoke
 class TestTLSWildcardSecrets:
     @pytest.mark.parametrize("path", paths)
     def test_response_code_200(self, wildcard_tls_secret_ingress_controller, wildcard_tls_secret_setup, path):


### PR DESCRIPTION
Check if this helps to make CI/CD stable. To run tests from the "smoke" suite add `-m "smoke"` argument to pytest command.