### PR TITLE
Add ServerStatusZones support in vs/vsr

### DIFF
--- a/internal/configs/version2/config.go
+++ b/internal/configs/version2/config.go
@@ -31,6 +31,7 @@ type UpstreamServer struct {
 // Server defines a server.
 type Server struct {
 	ServerName                            string
+	StatusZone                            string
 	ProxyProtocol                         bool
 	SSL                                   *SSL
 	RedirectToHTTPSBasedOnXForwarderProto bool

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -41,7 +41,7 @@ server {
     listen 80{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};
 
     server_name {{ $s.ServerName }};
-    status_zone {{ $s.ServerName }};
+    status_zone {{ $s.StatusZone }};
 
     {{ with $ssl := $s.SSL }}
     listen 443 ssl{{ if $ssl.HTTP2 }} http2{{ end }}{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -41,6 +41,7 @@ server {
     listen 80{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};
 
     server_name {{ $s.ServerName }};
+    status_zone {{ $s.ServerName }};
 
     {{ with $ssl := $s.SSL }}
     listen 443 ssl{{ if $ssl.HTTP2 }} http2{{ end }}{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};

--- a/internal/configs/version2/templates_test.go
+++ b/internal/configs/version2/templates_test.go
@@ -95,6 +95,7 @@ var virtualServerCfg = VirtualServerConfig{
 	},
 	Server: Server{
 		ServerName:    "example.com",
+		StatusZone:    "example.com",
 		ProxyProtocol: true,
 		SSL: &SSL{
 			HTTP2:           true,

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -326,6 +326,7 @@ func generateVirtualServerConfig(virtualServerEx *VirtualServerEx, tlsPemFileNam
 		StatusMatches: statusMatches,
 		Server: version2.Server{
 			ServerName:                            virtualServerEx.VirtualServer.Spec.Host,
+			StatusZone:                            virtualServerEx.VirtualServer.Spec.Host,
 			ProxyProtocol:                         baseCfgParams.ProxyProtocol,
 			SSL:                                   ssl,
 			RedirectToHTTPSBasedOnXForwarderProto: baseCfgParams.RedirectToHTTPS,

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -255,6 +255,7 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 		},
 		Server: version2.Server{
 			ServerName:                            "cafe.example.com",
+			StatusZone:                            "cafe.example.com",
 			ProxyProtocol:                         true,
 			RedirectToHTTPSBasedOnXForwarderProto: true,
 			ServerTokens:                          "off",
@@ -456,6 +457,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 		},
 		Server: version2.Server{
 			ServerName: "cafe.example.com",
+			StatusZone: "cafe.example.com",
 			InternalRedirectLocations: []version2.InternalRedirectLocation{
 				{
 					Path:        "/tea",
@@ -713,6 +715,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithRules(t *testing.T) {
 		},
 		Server: version2.Server{
 			ServerName: "cafe.example.com",
+			StatusZone: "cafe.example.com",
 			InternalRedirectLocations: []version2.InternalRedirectLocation{
 				{
 					Path:        "/tea",


### PR DESCRIPTION
### Proposed changes
VirtualServer now sets a [status_zone](http://nginx.org/en/docs/http/ngx_http_api_module.html#status_zone) in the server block. Which allows metrics to be collected.

Metrics can be viewed at: `/api/5/http/server_zones/`

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
