### PR TITLE
Add checks for 'queue' support in VS/VSR upstreams

### DIFF
--- a/tests/data/virtual-server-route-upstream-options/plus-route-m-invalid-keys.yaml
+++ b/tests/data/virtual-server-route-upstream-options/plus-route-m-invalid-keys.yaml
@@ -24,6 +24,9 @@ spec:
           value: "$one"
       statusMatch: "invalid"
     slow-start: "-3s"
+    queue:
+      size: -100
+      timeout: ":"
   - name: backend3
     service: backend3-svc
     port: 80
@@ -43,6 +46,8 @@ spec:
           value: "`=1.±!@£$%^&*()_+{}[]'^&*"
       statusMatch: "invalid"
     slow-start: "1.5m"
+    queue:
+      timeout: "hour"
   subroutes:
   - path: "/backends/backend1"
     upstream: backend1

--- a/tests/data/virtual-server-route-upstream-options/plus-route-s-invalid-keys.yaml
+++ b/tests/data/virtual-server-route-upstream-options/plus-route-s-invalid-keys.yaml
@@ -24,6 +24,9 @@ spec:
           value: "$one"
       statusMatch: "invalid"
     slow-start: " "
+    queue:
+      size: 0
+      timeout: "hour"
   subroutes:
   - path: "/backend2"
     upstream: backend2

--- a/tests/data/virtual-server-upstream-options/plus-virtual-server-with-invalid-keys.yaml
+++ b/tests/data/virtual-server-upstream-options/plus-virtual-server-with-invalid-keys.yaml
@@ -24,6 +24,9 @@ spec:
           value: "$one"
       statusMatch: "invalid"
     slow-start: "-3s"
+    queue:
+      size: -100
+      timeout: "one"
   - name: backend1
     service: backend1-svc
     port: 80
@@ -43,6 +46,9 @@ spec:
           value: "`=1.±!@£$%^&*()_+{}[]'^&*"
       statusMatch: "invalid"
     slow-start: "1.5d"
+    queue:
+      size: 0
+      timeout: "hour"
   routes:
   - path: "/backend1"
     upstream: backend1

--- a/tests/suite/test_virtual_server_upstream_options.py
+++ b/tests/suite/test_virtual_server_upstream_options.py
@@ -1,7 +1,7 @@
 import requests
 import pytest
 
-from settings import TEST_DATA
+from settings import TEST_DATA, DEPLOYMENTS
 from suite.custom_resources_utils import get_vs_nginx_template_conf, patch_virtual_server_from_yaml, \
     patch_virtual_server, generate_item_with_upstream_options
 from suite.resources_utils import get_first_pod_name, wait_before_test, replace_configmap_from_yaml, get_events
@@ -292,21 +292,23 @@ class TestVirtualServerUpstreamOptionValidation:
                          indirect=True)
 class TestOptionsSpecificForPlus:
     @pytest.mark.parametrize('options, expected_strings', [
-        ({"healthCheck": {"enable": True}, "slow-start": "3h"},
+        ({"lb-method": "least_conn", "healthCheck": {"enable": True}, "slow-start": "3h", "queue": {"size": 100}},
          ["health_check uri=/ port=80 interval=5s jitter=0s", "fails=1 passes=1;",
-          "slow_start=3h"]),
-        ({"healthCheck": {"enable": True, "path": "/health",
+          "slow_start=3h", "queue 100 timeout=60s;"]),
+        ({"lb-method": "least_conn",
+          "healthCheck": {"enable": True, "path": "/health",
                           "interval": "15s", "jitter": "3",
                           "fails": 2, "passes": 2, "port": 8080,
                           "tls": {"enable": True}, "statusMatch": "200",
                           "connect-timeout": "35s", "read-timeout": "45s", "send-timeout": "55s",
                           "headers": [{"name": "Host", "value": "virtual-server.example.com"}]},
+          "queue": {"size": 1000, "timeout": "66s"},
           "slow-start": "0s"},
          ["health_check uri=/health port=8080 interval=15s jitter=3", "fails=2 passes=2 match=",
           "proxy_pass https://vs", "status 200;",
           "proxy_connect_timeout 35s;", "proxy_read_timeout 45s;", "proxy_send_timeout 55s;",
           'proxy_set_header Host "virtual-server.example.com";',
-          "slow_start=0s"])
+          "slow_start=0s", "queue 1000 timeout=66s;"])
 
     ])
     def test_config_and_events(self, kube_apis, ingress_controller_prerequisites,
@@ -354,13 +356,15 @@ class TestOptionsSpecificForPlus:
             "upstreams[0].healthCheck.headers[0].name", "upstreams[0].healthCheck.headers[0].value",
             "upstreams[0].healthCheck.statusMatch",
             "upstreams[0].slow-start",
+            "upstreams[0].queue.size", "upstreams[0].queue.timeout",
             "upstreams[1].healthCheck.path", "upstreams[1].healthCheck.interval", "upstreams[1].healthCheck.jitter",
             "upstreams[1].healthCheck.fails", "upstreams[1].healthCheck.passes",
             "upstreams[1].healthCheck.connect-timeout",
             "upstreams[1].healthCheck.read-timeout", "upstreams[1].healthCheck.send-timeout",
             "upstreams[1].healthCheck.headers[0].name", "upstreams[1].healthCheck.headers[0].value",
             "upstreams[1].healthCheck.statusMatch",
-            "upstreams[1].slow-start"
+            "upstreams[1].slow-start",
+            "upstreams[1].queue.size", "upstreams[1].queue.timeout"
         ]
         text = f"{virtual_server_setup.namespace}/{virtual_server_setup.vs_name}"
         vs_event_text = f"VirtualServer {text} is invalid and was rejected: "


### PR DESCRIPTION
Test cases are the same as for any other upstream option. 