### PR TITLE
Add reminder to delete nginx-ingress ClusterRole

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -193,3 +193,10 @@ Delete the `nginx-ingress` namespace to uninstall the Ingress controller along w
 $ kubectl delete namespace nginx-ingress
 ```
 
+**Note**: If RBAC is enabled on your cluster and you completed step 2, you will need to remove the ClusterRole and ClusterRoleBinding created in that step:
+
+```
+$ kubectl delete clusterrole nginx-ingress
+$ kubectl delete clusterrolebinding nginx-ingress
+```
+


### PR DESCRIPTION
### Proposed changes
When a user attempts to uninstall everything that is created in the nginx-ingress namespace, they may have not deleted the RBAC ClusterRole added in step 2. This note ensures they delete that role as well so that all resources are deleted when uninstalling nginx-ingress.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
