### PR TITLE
Add checks for Warning event

### DIFF
--- a/tests/suite/test_v_s_route_externalname.py
+++ b/tests/suite/test_v_s_route_externalname.py
@@ -7,7 +7,7 @@ from suite.custom_resources_utils import create_virtual_server_from_yaml, \
 from suite.fixtures import VirtualServerRoute, PublicEndpoint
 from suite.resources_utils import get_first_pod_name, get_events, \
     wait_before_test, replace_configmap_from_yaml, create_service_from_yaml, \
-    delete_namespace, create_namespace_with_name_from_yaml, read_service, replace_service
+    delete_namespace, create_namespace_with_name_from_yaml, read_service, replace_service, replace_configmap
 from suite.yaml_utils import get_paths_from_vsr_yaml, get_route_namespace_from_vs_yaml, get_first_vs_host_from_yaml, \
     get_external_host_from_service_yaml
 
@@ -144,9 +144,11 @@ class TestVSRWithExternalNameService:
         text_vs = f"{vsr_externalname_setup.namespace}/{vsr_externalname_setup.vs_name}"
         vsr_event_text = f"Configuration for {text_vsr} was added or updated"
         vs_event_text = f"Configuration for {text_vs} was added or updated"
+        vs_event_update_text = f"Configuration for {text_vs} was updated"
         initial_events = get_events(kube_apis.v1, vsr_externalname_setup.route.namespace)
         initial_count_vsr = assert_event_and_get_count(vsr_event_text, initial_events)
         initial_count_vs = assert_event_and_get_count(vs_event_text, initial_events)
+        initial_count_vs_up = assert_event_and_get_count(vs_event_update_text, initial_events)
 
         print("Step 1: Update external host in externalName service")
         external_svc = read_service(kube_apis.v1, vsr_externalname_setup.external_svc, vsr_externalname_setup.namespace)
@@ -155,6 +157,19 @@ class TestVSRWithExternalNameService:
                         vsr_externalname_setup.external_svc, vsr_externalname_setup.namespace, external_svc)
         wait_before_test(1)
 
-        new_events = get_events(kube_apis.v1, vsr_externalname_setup.route.namespace)
-        assert_event_and_count(vsr_event_text, initial_count_vsr + 1, new_events)
-        assert_event_and_count(vs_event_text, initial_count_vs + 1, new_events)
+        events_step_1 = get_events(kube_apis.v1, vsr_externalname_setup.route.namespace)
+        assert_event_and_count(vsr_event_text, initial_count_vsr + 1, events_step_1)
+        assert_event_and_count(vs_event_text, initial_count_vs + 1, events_step_1)
+        assert_event_and_count(vs_event_update_text, initial_count_vs_up, events_step_1)
+
+        print("Step 2: Remove resolver from ConfigMap to trigger an error")
+        vsr_event_warning_text = f"Configuration for {text_vsr} was updated with warning(s):"
+        config_map_name = ingress_controller_prerequisites.config_map["metadata"]["name"]
+        replace_configmap(kube_apis.v1, config_map_name,
+                          ingress_controller_prerequisites.namespace,
+                          ingress_controller_prerequisites.config_map)
+        wait_before_test(1)
+
+        events_step_2 = get_events(kube_apis.v1, vsr_externalname_setup.route.namespace)
+        assert_event_and_count(vsr_event_warning_text, 1, events_step_2)
+        assert_event_and_count(vs_event_update_text, initial_count_vs_up + 1, events_step_2)


### PR DESCRIPTION
Extend existing tests on ExternalName Service and Upstream Options Support in VS/VSRs. Add a new fixture `restore_configmap`, it ensures the changes from previous tests don't interfere with following ones. There is test_virtual_server_configmap_keys.py with similar fixture, I'll refactor it in a separate PR.