### PR TITLE
Update Go version to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 services:
 - docker
 go:
-- "1.12"
+- "1.13"
 script:
 - echo "Building ingress controller commit:${TRAVIS_COMMIT}"
 - make BUILD_IN_CONTAINER=0 container;

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PREFIX = nginx/nginx-ingress
 
 DOCKER_TEST_RUN = docker run --rm -v $(shell pwd):/go/src/github.com/nginxinc/kubernetes-ingress -w /go/src/github.com/nginxinc/kubernetes-ingress
 DOCKER_BUILD_RUN = docker run --rm -v $(shell pwd):/go/src/github.com/nginxinc/kubernetes-ingress -w /go/src/github.com/nginxinc/kubernetes-ingress/cmd/nginx-ingress/
-GOLANG_CONTAINER = golang:1.12
+GOLANG_CONTAINER = golang:1.13
 DOCKERFILEPATH = build
 DOCKERFILE = Dockerfile # note, this can be overwritten e.g. can be DOCKERFILE=DockerFileForPlus
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginxinc/kubernetes-ingress
 
-go 1.12
+go 1.13
 
 require (
 	github.com/evanphx/json-patch v4.2.0+incompatible // indirect


### PR DESCRIPTION
### Proposed changes
Go 1.13 was released recently.
We need to update our projects to use Go 1.13
Make sure both travis files (if present) and Makefiles are updated.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
