### PR TITLE
Fix trailing leader election cm when using helm

### DIFF
--- a/deployments/helm-chart/templates/controller-leader-election-configmap.yaml
+++ b/deployments/helm-chart/templates/controller-leader-election-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nginx-ingress.leaderElectionName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nginx-ingress.labels" . | nindent 4 }}
+data:

--- a/deployments/helm-chart/templates/controller-leader-election-configmap.yaml
+++ b/deployments/helm-chart/templates/controller-leader-election-configmap.yaml
@@ -5,4 +5,3 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-ingress.labels" . | nindent 4 }}
-data:


### PR DESCRIPTION
### Proposed changes
When removing an ingress controller deployment managed by helm.
A leader election configmap was left behind because it was created by
the IC and not managed by Tiller/Helm.

This PR pre-allocates the configmap so it is now managed by Helm.
The created configmap is blank, but once the Ingress Controller starts it updates the configmap with necessary Annotations required for leader election.

### Edge cases
If the configmap somehow already exists. The helm deployment fails cleanly at the client level.
```
$ kubectl create cm dev-nginx-ingress-leader-election
configmap/dev-nginx-ingress-leader-election created
$ helm install --name dev deployments/helm-chart -f deployments/helm-chart/values.yaml
Error: release dev failed: configmaps "dev-nginx-ingress-leader-election" already exists
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
