### PR TITLE
Set a strict version to `cffi`

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,6 +4,7 @@ forcediphttpsadapter==1.0.1
 kubernetes==8.0.1
 pytest==4.4.1
 ipaddress==1.0.22 # >= 1.0.17
+cffi==1.12.3
 pyopenssl==19.0.0
 certifi==2019.6.16
 urllib3==1.25.3


### PR DESCRIPTION
Tests need `pyopenssl` and it has a dependency named `cffi`. Set a strict version to `cffi` cause its lates update (1.13.0) broke the tests image.