### PR TITLE
Hide VS/VSR metrics when CRDs disabled

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -239,7 +239,7 @@ func main() {
 	if *enablePrometheusMetrics {
 		registry = prometheus.NewRegistry()
 		managerCollector = collectors.NewLocalManagerMetricsCollector()
-		controllerCollector = collectors.NewControllerMetricsCollector()
+		controllerCollector = collectors.NewControllerMetricsCollector(*enableCustomResources)
 
 		err = managerCollector.Register(registry)
 		if err != nil {

--- a/internal/metrics/collectors/controller.go
+++ b/internal/metrics/collectors/controller.go
@@ -21,7 +21,7 @@ type ControllerMetricsCollector struct {
 }
 
 // NewControllerMetricsCollector creates a new ControllerMetricsCollector
-func NewControllerMetricsCollector(areCrdsEnabled bool) *ControllerMetricsCollector {
+func NewControllerMetricsCollector(crdsEnabled bool) *ControllerMetricsCollector {
 	ingResTotal := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name:      "ingress_resources_total",
@@ -31,7 +31,7 @@ func NewControllerMetricsCollector(areCrdsEnabled bool) *ControllerMetricsCollec
 		labelNamesController,
 	)
 
-	if !areCrdsEnabled {
+	if !crdsEnabled {
 		return &ControllerMetricsCollector{ingressesTotal: ingResTotal}
 	}
 

--- a/internal/metrics/collectors/controller.go
+++ b/internal/metrics/collectors/controller.go
@@ -14,13 +14,14 @@ type ControllerCollector interface {
 
 // ControllerMetricsCollector implements the ControllerCollector interface and prometheus.Collector interface
 type ControllerMetricsCollector struct {
+	crdsEnabled              bool
 	ingressesTotal           *prometheus.GaugeVec
 	virtualServersTotal      prometheus.Gauge
 	virtualServerRoutesTotal prometheus.Gauge
 }
 
 // NewControllerMetricsCollector creates a new ControllerMetricsCollector
-func NewControllerMetricsCollector() *ControllerMetricsCollector {
+func NewControllerMetricsCollector(areCrdsEnabled bool) *ControllerMetricsCollector {
 	ingResTotal := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name:      "ingress_resources_total",
@@ -29,6 +30,10 @@ func NewControllerMetricsCollector() *ControllerMetricsCollector {
 		},
 		labelNamesController,
 	)
+
+	if !areCrdsEnabled {
+		return &ControllerMetricsCollector{ingressesTotal: ingResTotal}
+	}
 
 	vsResTotal := prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -47,6 +52,7 @@ func NewControllerMetricsCollector() *ControllerMetricsCollector {
 	)
 
 	return &ControllerMetricsCollector{
+		crdsEnabled:              true,
 		ingressesTotal:           ingResTotal,
 		virtualServersTotal:      vsResTotal,
 		virtualServerRoutesTotal: vsrResTotal,
@@ -71,15 +77,19 @@ func (cc *ControllerMetricsCollector) SetVirtualServerRoutes(count int) {
 // Describe implements prometheus.Collector interface Describe method
 func (cc *ControllerMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	cc.ingressesTotal.Describe(ch)
-	cc.virtualServersTotal.Describe(ch)
-	cc.virtualServerRoutesTotal.Describe(ch)
+	if cc.crdsEnabled {
+		cc.virtualServersTotal.Describe(ch)
+		cc.virtualServerRoutesTotal.Describe(ch)
+	}
 }
 
 // Collect implements the prometheus.Collector interface Collect method
 func (cc *ControllerMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	cc.ingressesTotal.Collect(ch)
-	cc.virtualServersTotal.Collect(ch)
-	cc.virtualServerRoutesTotal.Collect(ch)
+	if cc.crdsEnabled {
+		cc.virtualServersTotal.Collect(ch)
+		cc.virtualServerRoutesTotal.Collect(ch)
+	}
 }
 
 // Register registers all the metrics of the collector


### PR DESCRIPTION
### Proposed changes
Prometheus metrics were added in https://github.com/nginxinc/kubernetes-ingress/pull/724

However it doesn't make sense to report number of handled VS/VSR resources in the case that we know CRDs are disabled.

Ingress resource metrics remain exported unconditionally because they are always enabled and handled by the ingress controller.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
