### PR TITLE
Validate healthcheck fields unconditionally. Fix sessionCookie error msg

### DIFF
--- a/pkg/apis/configuration/validation/validation.go
+++ b/pkg/apis/configuration/validation/validation.go
@@ -237,7 +237,7 @@ func validateSessionCookie(sc *v1alpha1.SessionCookie, fieldPath *field.Path) fi
 		// A Domain prefix of "." is allowed.
 		domain := strings.TrimPrefix(sc.Domain, ".")
 		for _, msg := range validation.IsDNS1123Subdomain(domain) {
-			allErrs = append(allErrs, field.Invalid(fieldPath, sc.Domain, msg))
+			allErrs = append(allErrs, field.Invalid(fieldPath.Child("domain"), sc.Domain, msg))
 		}
 	}
 

--- a/pkg/apis/configuration/validation/validation.go
+++ b/pkg/apis/configuration/validation/validation.go
@@ -179,7 +179,7 @@ func validateUpstreamLBMethod(lBMethod string, fieldPath *field.Path, isPlus boo
 func validateUpstreamHealthCheck(hc *v1alpha1.HealthCheck, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if hc == nil || !hc.Enable {
+	if hc == nil {
 		return allErrs
 	}
 

--- a/pkg/apis/configuration/validation/validation_test.go
+++ b/pkg/apis/configuration/validation/validation_test.go
@@ -1825,15 +1825,29 @@ func TestValidateUpstreamHealthCheck(t *testing.T) {
 }
 
 func TestValidateUpstreamHealthCheckFails(t *testing.T) {
-	hc := &v1alpha1.HealthCheck{
-		Enable: true,
-		Path:   "/healthz//;",
+	tests := []struct {
+		hc *v1alpha1.HealthCheck
+	}{
+		{
+			hc: &v1alpha1.HealthCheck{
+				Enable: true,
+				Path:   "/healthz//;",
+			},
+		},
+		{
+			hc: &v1alpha1.HealthCheck{
+				Enable: false,
+				Path:   "/healthz//;",
+			},
+		},
 	}
 
-	allErrs := validateUpstreamHealthCheck(hc, field.NewPath("healthCheck"))
+	for _, test := range tests {
+		allErrs := validateUpstreamHealthCheck(test.hc, field.NewPath("healthCheck"))
 
-	if len(allErrs) == 0 {
-		t.Errorf("validateUpstreamHealthCheck() returned no errors for invalid input %v", hc)
+		if len(allErrs) == 0 {
+			t.Errorf("validateUpstreamHealthCheck() returned no errors for invalid input %v", test.hc)
+		}
 	}
 }
 


### PR DESCRIPTION
### Proposed changes

#### Validate upstreamHealthchecks unconditionally
* All healthcheck fields are now validated regardless of whether healthchecks are enabled or not.

#### Fix sessionCookie error message
* In the case of invalid input for sessionCookie domain. The error would not include the valid context

##### Before
`spec.upstreams[0].sessionCookie: Invalid value: “$request_uri”:`
##### After
`spec.upstreams[0].sessionCookie.domain: Invalid value: “$request_uri”:`

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
