### PR TITLE
Init Ingress labeled metrics on start

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -187,6 +187,8 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 		lbc.addLeaderHandler(createLeaderHandler(lbc))
 	}
 
+	lbc.updateIngressMetrics()
+
 	return lbc
 }
 


### PR DESCRIPTION
### Proposed changes
Labeled Ingress Resources metrics are shown (and set to 0) even if there are no ingress resources in the cluster when the IC runs for the first time.

