### PR TITLE
Add support for health status uri customisation

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -532,11 +532,11 @@ const locationErrMsg = "must start with / and must not include any whitespace ch
 var locationRegexp = regexp.MustCompile("^" + locationFmt + "$")
 
 func validateLocation(location string) error {
-	if location == "" {
-		return fmt.Errorf("invalid location: an empty string is an invalid location")
+	if location == "" || location == "/" {
+		return fmt.Errorf("invalid location format: '%v' is an invalid location", location)
 	}
 	if !locationRegexp.MatchString(location) {
-		msg := validation.RegexError(locationErrMsg, locationFmt, "/", "/path", "/path/subpath-123")
+		msg := validation.RegexError(locationErrMsg, locationFmt, "/path", "/path/subpath-123")
 		return fmt.Errorf("invalid location format: %v", msg)
 	}
 	return nil

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -40,8 +40,11 @@ var (
 	gitCommit string
 
 	healthStatus = flag.Bool("health-status", false,
-		`Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request.
+		`Add a location based on the value of health-status-uri to the default server. The location responds with the 200 status code for any request.
 	Useful for external health-checking of the Ingress controller`)
+
+	healthStatusURI = flag.String("health-status-uri", "/nginx-health",
+		`Sets the location of health status uri in the default server. Requires -health-status`)
 
 	proxyURL = flag.String("proxy", "",
 		`Use a proxy server to connect to Kubernetes API started by "kubectl proxy" command. For testing purposes only.
@@ -320,6 +323,7 @@ func main() {
 
 	staticCfgParams := &configs.StaticConfigParams{
 		HealthStatus:                   *healthStatus,
+		HealthStatusURI:                *healthStatusURI,
 		NginxStatus:                    *nginxStatus,
 		NginxStatusAllowCIDRs:          allowedCIDRs,
 		NginxStatusPort:                *nginxStatusPort,

--- a/cmd/nginx-ingress/main_test.go
+++ b/cmd/nginx-ingress/main_test.go
@@ -98,3 +98,29 @@ func TestValidateCIDRorIP(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateLocation(t *testing.T) {
+	badLocations := []string{
+		"",
+		"/",
+		" /test",
+		"/bad;",
+	}
+	for _, badLocation := range badLocations {
+		err := validateLocation(badLocation)
+		if err == nil {
+			t.Errorf("validateLocation(%v) returned no error when it should have returned an error", badLocation)
+		}
+	}
+
+	goodLocations := []string{
+		"/test",
+		"/test/subtest",
+	}
+	for _, goodLocation := range goodLocations {
+		err := validateLocation(goodLocation)
+		if err != nil {
+			t.Errorf("validateLocation(%v) returned an error when it should have returned no error: %v", goodLocation, err)
+		}
+	}
+}

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -86,6 +86,7 @@ Parameter | Description | Default
 `controller.watchNamespace` | Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces. | ""
 `controller.enableCustomResources` | Enable the custom resources. | false
 `controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress controller. | false
+`controller.healthStatusURI` | Sets the URI of health status location in the default server. Requires `contoller.healthStatus`. | "/nginx-health"
 `controller.nginxStatus.enable` | Enable the NGINX stub_status, or the NGINX Plus API. | true
 `controller.nginxStatus.port` | Set the port where the NGINX stub_status or the NGINX Plus API is exposed. | 8080
 `controller.nginxStatus.allowCidrs` | Whitelist IPv4 IP/CIDR blocks to allow access to NGINX stub_status or the NGINX Plus API. Separate multiple IP/CIDR by commas. | 127.0.0.1

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -91,6 +91,7 @@ spec:
           - -watch-namespace={{ .Values.controller.watchNamespace }}
 {{- end }}
           - -health-status={{ .Values.controller.healthStatus }}
+          - -health-status-uri={{ .Values.controller.healthStatusURI }}
           - -nginx-debug={{ .Values.controller.nginxDebug }}
           - -v={{ .Values.controller.logLevel }}
           - -nginx-status={{ .Values.controller.nginxStatus.enable }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -89,6 +89,7 @@ spec:
           - -watch-namespace={{ .Values.controller.watchNamespace }}
 {{- end }}
           - -health-status={{ .Values.controller.healthStatus }}
+          - -health-status-uri={{ .Values.controller.healthStatusURI }}
           - -nginx-debug={{ .Values.controller.nginxDebug }}
           - -v={{ .Values.controller.logLevel }}
           - -nginx-status={{ .Values.controller.nginxStatus.enable }}

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -110,7 +110,7 @@ controller:
   ## Useful for external health-checking of the Ingress controller.
   healthStatus: false
 
-  ## Sets the URI of health status location in the default server. Requires -health-status (default "/nginx-health").
+  ## Sets the URI of health status location in the default server. Requires contoller.healthStatus.
   healthStatusURI: "/nginx-health"
 
   nginxStatus:

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -106,9 +106,12 @@ controller:
   ## Enable the custom resources.
   enableCustomResources: false
 
-  ## Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request.
+  ## Add a location based on the value of health-status-uri to the default server. The location responds with the 200 status code for any request.
   ## Useful for external health-checking of the Ingress controller.
   healthStatus: false
+
+  ## Set the name of the location for healthStatus. Requires -health-status.
+  healthStatusURI: "/nginx-health"
 
   nginxStatus:
     ## Enable the NGINX stub_status, or the NGINX Plus API.

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -110,7 +110,7 @@ controller:
   ## Useful for external health-checking of the Ingress controller.
   healthStatus: false
 
-  ## Set the name of the location for healthStatus. Requires -health-status.
+  ## Sets the URI of health status location in the default server. Requires -health-status (default "/nginx-health").
   healthStatusURI: "/nginx-health"
 
   nginxStatus:

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -11,7 +11,7 @@ Usage of ./nginx-ingress:
 	the file "/etc/nginx/secrets/default" does not exist, the Ingress controller will fail to start
   -wildcard-tls-secret string
     	A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified.
-    	Format: <namespace>/<name>. If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection. 
+       Format: <namespace>/<name>. If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection.
     	If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress controller will fail to start.
   -enable-custom-resources
     	Enable custom resources
@@ -21,8 +21,10 @@ Usage of ./nginx-ingress:
     	Specifies the name of the service with the type LoadBalancer through which the Ingress controller pods are exposed externally.
     	The external address of the service is used when reporting the status of Ingress resources. Requires -report-ingress-status.
   -health-status
-    	Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request.
-	Useful for external health-checking of the Ingress controller
+        Add a location based on the value of health-status-uri to the default server. The location responds with the 200 status code for any request.
+    	Useful for external health-checking of the Ingress controller
+  -health-status-uri string
+    	Sets the location of health status uri in the default server. Requires -health-status (default "/nginx-health")
   -ingress-class string
     	A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its class
 	- i.e. have the annotation "kubernetes.io/ingress.class" equal to the class. Additionally,

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -24,7 +24,7 @@ Usage of ./nginx-ingress:
         Add a location based on the value of health-status-uri to the default server. The location responds with the 200 status code for any request.
     	Useful for external health-checking of the Ingress controller
   -health-status-uri string
-    	Sets the location of health status uri in the default server. Requires -health-status (default "/nginx-health")
+       Sets the URI of health status location in the default server. Requires -health-status (default "/nginx-health")
   -ingress-class string
     	A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its class
 	- i.e. have the annotation "kubernetes.io/ingress.class" equal to the class. Additionally,

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -86,6 +86,7 @@ type ConfigParams struct {
 // StaticConfigParams holds immutable NGINX configuration parameters that affect the main NGINX config.
 type StaticConfigParams struct {
 	HealthStatus                   bool
+	HealthStatusURI                string
 	NginxStatus                    bool
 	NginxStatusAllowCIDRs          []string
 	NginxStatusPort                int

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -430,6 +430,7 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool) *ConfigParams {
 func GenerateNginxMainConfig(staticCfgParams *StaticConfigParams, config *ConfigParams) *version1.MainConfig {
 	nginxCfg := &version1.MainConfig{
 		HealthStatus:                   staticCfgParams.HealthStatus,
+		HealthStatusURI:                staticCfgParams.HealthStatusURI,
 		NginxStatus:                    staticCfgParams.NginxStatus,
 		NginxStatusAllowCIDRs:          staticCfgParams.NginxStatusAllowCIDRs,
 		NginxStatusPort:                staticCfgParams.NginxStatusPort,

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -13,6 +13,7 @@ import (
 func createTestStaticConfigParams() *StaticConfigParams {
 	return &StaticConfigParams{
 		HealthStatus:                   true,
+		HealthStatusURI:                "/nginx-health",
 		NginxStatus:                    true,
 		NginxStatusAllowCIDRs:          []string{"127.0.0.1"},
 		NginxStatusPort:                8080,

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -131,6 +131,7 @@ type MainConfig struct {
 	ErrorLogLevel                  string
 	StreamLogFormat                string
 	HealthStatus                   bool
+	HealthStatusURI                string
 	NginxStatus                    bool
 	NginxStatusAllowCIDRs          []string
 	NginxStatusPort                int

--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -106,7 +106,7 @@ http {
         {{end}}
 
         {{if .HealthStatus}}
-        location /nginx-health {
+        location {{.HealthStatusURI}} {
             default_type text/plain;
             return 200 "healthy\n";
         }

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -100,7 +100,7 @@ http {
         {{end}}
 
         {{if .HealthStatus}}
-        location /nginx-health {
+        location {{.HealthStatusURI}} {
             default_type text/plain;
             return 200 "healthy\n";
         }


### PR DESCRIPTION
### Proposed changes
Fixes: https://github.com/nginxinc/kubernetes-ingress/issues/721

Allow customisation of health check uri via cli arg.
* Add `-health-check-uri` cli argument.
* Add `controller.healthCheckURI` field to helm chart.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
