### PR TITLE
Fix 502 server unix-domain socket path

### DIFF
--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -14,7 +14,7 @@ import (
 	conf_v1alpha1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1alpha1"
 )
 
-const nginx502Server = "unix:/var/lib/nginx-502-server.sock"
+const nginx502Server = "unix:/var/lib/nginx/nginx-502-server.sock"
 
 var incompatibleLBMethodsForSlowStart = map[string]bool{
 	"random":                          true,


### PR DESCRIPTION
### Proposed changes
Fix unix-domain socket path for 502 server.

#### Before change
```
[crit] 56#56: *18 connect() to unix:/var/lib/nginx-502-server.sock failed (2: No such file or directory) while connecting to upstream, client: 192.168.99.1, server: cafe.example.com, request: "GET /coffee HTTP/1.1", upstream: "http://unix:/var/lib/nginx-502-server.sock:/coffee", host: "cafe.example.com"
```

#### After change
```
192.168.99.1 - - [01/Nov/2019:17:34:59 +0000] "GET /coffee HTTP/1.1" 502 157 "-" "curl/7.54.0" "-"
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
