### PR TITLE
Fix: Allow TLSRedirect.basedOn to be unset

### DIFF
--- a/pkg/apis/configuration/validation/validation.go
+++ b/pkg/apis/configuration/validation/validation.go
@@ -76,7 +76,7 @@ func validateTLSRedirect(redirect *v1alpha1.TLSRedirect, fieldPath *field.Path) 
 	}
 
 	if redirect.BasedOn != "" && redirect.BasedOn != "scheme" && redirect.BasedOn != "x-forwarded-proto" {
-		allErrs = append(allErrs, field.Invalid(fieldPath.Child("basedOn"), redirect.BasedOn, "accepted values are '', 'scheme', 'x-forwarded-proto'"))
+		allErrs = append(allErrs, field.Invalid(fieldPath.Child("basedOn"), redirect.BasedOn, "accepted values are 'scheme', 'x-forwarded-proto'"))
 	}
 
 	return allErrs

--- a/pkg/apis/configuration/validation/validation.go
+++ b/pkg/apis/configuration/validation/validation.go
@@ -75,8 +75,8 @@ func validateTLSRedirect(redirect *v1alpha1.TLSRedirect, fieldPath *field.Path) 
 		allErrs = append(allErrs, validateTLSRedirectStatusCode(*redirect.Code, fieldPath.Child("code"))...)
 	}
 
-	if redirect.BasedOn != "scheme" && redirect.BasedOn != "x-forwarded-proto" {
-		allErrs = append(allErrs, field.Invalid(fieldPath.Child("basedOn"), redirect.BasedOn, "accepted values are 'scheme' or 'x-forwarded-proto'"))
+	if redirect.BasedOn != "" && redirect.BasedOn != "scheme" && redirect.BasedOn != "x-forwarded-proto" {
+		allErrs = append(allErrs, field.Invalid(fieldPath.Child("basedOn"), redirect.BasedOn, "accepted values are '', 'scheme', 'x-forwarded-proto'"))
 	}
 
 	return allErrs

--- a/pkg/apis/configuration/validation/validation_test.go
+++ b/pkg/apis/configuration/validation/validation_test.go
@@ -103,6 +103,13 @@ func TestValidateTLS(t *testing.T) {
 				BasedOn: "scheme",
 			},
 		},
+		{
+			Secret: "my-secret",
+			Redirect: &v1alpha1.TLSRedirect{
+				Enable: true,
+				Code:   createPointerFromInt(307),
+			},
+		},
 	}
 
 	for _, tls := range validTLSes {

--- a/pkg/apis/configuration/validation/validation_test.go
+++ b/pkg/apis/configuration/validation/validation_test.go
@@ -96,6 +96,16 @@ func TestValidateTLS(t *testing.T) {
 			Secret: "my-secret",
 		},
 		{
+			Secret:   "my-secret",
+			Redirect: &v1alpha1.TLSRedirect{},
+		},
+		{
+			Secret: "my-secret",
+			Redirect: &v1alpha1.TLSRedirect{
+				Enable: true,
+			},
+		},
+		{
 			Secret: "my-secret",
 			Redirect: &v1alpha1.TLSRedirect{
 				Enable:  true,


### PR DESCRIPTION
### Proposed changes
Given the following config
```yaml
redirect:
  enable: true
  code: 301
```

The VS resource would be rejected:
```
Warning  Rejected 44s nginx-ingress-controller  VirtualServer test-namespace-1572877439202/virtual-server-tls is invalid and was rejected: spec.tls.redirect.basedOn: Invalid value: “”: accepted values are ‘scheme’ or ‘x-forwarded-proto’
```

This PR now accepts `""` (unset) as a valid input for TLSRedirect so the VS resource is accepted. The default `$scheme` value is then generated for basedOn.

New behaviour:
```
Event(v1.ObjectReference{Kind:"VirtualServer", Namespace:"default", Name:"cafe", UID:"0d840dbe-61e1-4a8c-a9ee-2b397e906a59", APIVersion:"k8s.nginx.org/v1alpha1", ResourceVersion:"354233", FieldPath:""}): type: 'Normal' reason: 'AddedOrUpdated' Configuration for default/cafe was added or updated
```
### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
