### PR TITLE
Refactor tests code.

### DIFF
--- a/tests/data/externalname-services/externalname-svc.yaml
+++ b/tests/data/externalname-services/externalname-svc.yaml
@@ -4,4 +4,4 @@ metadata:
   name: externalname-service
 spec:
   type: ExternalName
-  externalName: nginx.com
+  externalName: external-backend-svc.external-ns.svc.cluster.local

--- a/tests/data/externalname-services/nginx-config.yaml
+++ b/tests/data/externalname-services/nginx-config.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 metadata:
   name: nginx-config
 data:
-  resolver-addresses: "8.8.8.8"
+  resolver-addresses: "kube-dns.kube-system.svc.cluster.local"

--- a/tests/data/virtual-server-externalname/externalname-svc.yaml
+++ b/tests/data/virtual-server-externalname/externalname-svc.yaml
@@ -4,4 +4,4 @@ metadata:
   name: externalname-service
 spec:
   type: ExternalName
-  externalName: nginx.com
+  externalName: external-backend-svc.external-ns.svc.cluster.local

--- a/tests/data/virtual-server-externalname/nginx-config.yaml
+++ b/tests/data/virtual-server-externalname/nginx-config.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 metadata:
   name: nginx-config
 data:
-  resolver-addresses: "8.8.8.8"
+  resolver-addresses: "kube-dns.kube-system.svc.cluster.local"

--- a/tests/data/virtual-server-route-externalname/externalname-svc.yaml
+++ b/tests/data/virtual-server-route-externalname/externalname-svc.yaml
@@ -4,4 +4,4 @@ metadata:
   name: externalname-service
 spec:
   type: ExternalName
-  externalName: nginx.com
+  externalName: external-backend-svc.external-ns.svc.cluster.local

--- a/tests/data/virtual-server-route-externalname/nginx-config.yaml
+++ b/tests/data/virtual-server-route-externalname/nginx-config.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 metadata:
   name: nginx-config
 data:
-  resolver-addresses: "8.8.8.8"
+  resolver-addresses: "kube-dns.kube-system.svc.cluster.local"

--- a/tests/data/virtual-server-route-externalname/route-single.yaml
+++ b/tests/data/virtual-server-route-externalname/route-single.yaml
@@ -1,7 +1,7 @@
 apiVersion: k8s.nginx.org/v1alpha1
 kind: VirtualServerRoute
 metadata:
-  name: ext-backend
+  name: externalname-route
 spec:
   host: virtual-server-route.example.com
   upstreams:

--- a/tests/data/virtual-server-route-externalname/standard/virtual-server.yaml
+++ b/tests/data/virtual-server-route-externalname/standard/virtual-server.yaml
@@ -6,4 +6,4 @@ spec:
   host: virtual-server-route.example.com
   routes:
   - path: "/external-backend"
-    route: external-backend-namespace/ext-backend
+    route: route-namespace/externalname-route

--- a/tests/suite/custom_assertions.py
+++ b/tests/suite/custom_assertions.py
@@ -5,7 +5,7 @@ from suite.custom_resources_utils import get_vs_nginx_template_conf
 
 
 def assert_no_new_events(old_list, new_list):
-    assert len(old_list) == len(new_list), "expected: lists are the same"
+    assert len(old_list) == len(new_list), "Expected: lists are of the same size"
     for i in range(len(new_list) - 1, -1, -1):
         if old_list[i].count != new_list[i].count:
             pytest.fail(f"Expected: no new events. There is a new event found:\"{new_list[i].message}\". Exiting...")

--- a/tests/suite/custom_assertions.py
+++ b/tests/suite/custom_assertions.py
@@ -1,0 +1,120 @@
+"""Describe the custom assertion methods"""
+import pytest
+
+from suite.custom_resources_utils import get_vs_nginx_template_conf
+
+
+def assert_no_new_events(old_list, new_list):
+    assert len(old_list) == len(new_list), "expected: lists are the same"
+    for i in range(len(new_list) - 1, -1, -1):
+        if old_list[i].count != new_list[i].count:
+            pytest.fail(f"Expected: no new events. There is a new event found:\"{new_list[i].message}\". Exiting...")
+
+
+def assert_event_count_increased(event_text, count, events_list) -> None:
+    """
+    Search for the event in the list and verify its counter is more than the expected value.
+
+    :param event_text: event text
+    :param count: expected value
+    :param events_list: list of events
+    :return:
+    """
+    for i in range(len(events_list) - 1, -1, -1):
+        if event_text in events_list[i].message:
+            assert events_list[i].count > count
+            return
+    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
+
+
+def assert_event_and_count(event_text, count, events_list) -> None:
+    """
+    Search for the event in the list and compare its counter with an expected value.
+
+    :param event_text: event text
+    :param count: expected value
+    :param events_list: list of events
+    :return:
+    """
+    for i in range(len(events_list) - 1, -1, -1):
+        if event_text in events_list[i].message:
+            assert events_list[i].count == count
+            return
+    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
+
+
+def assert_event_and_get_count(event_text, events_list) -> int:
+    """
+    Search for the event in the list and return its counter.
+
+    :param event_text: event text
+    :param events_list: list of events
+    :return: event.count
+    """
+    for i in range(len(events_list) - 1, -1, -1):
+        if event_text in events_list[i].message:
+            return events_list[i].count
+    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
+
+
+def assert_response_codes(resp_1, resp_2, code_1=200, code_2=200) -> None:
+    """
+    Assert responses status codes.
+
+    :param resp_1: Response
+    :param resp_2: Response
+    :param code_1: expected status code
+    :param code_2: expected status code
+    :return:
+    """
+    assert resp_1.status_code == code_1
+    assert resp_2.status_code == code_2
+
+
+def assert_event(event_text, events_list) -> None:
+    """
+    Search for the event in the list.
+
+    :param event_text: event text
+    :param events_list: list of events
+    :return:
+    """
+    for i in range(len(events_list) - 1, -1, -1):
+        if event_text in events_list[i].message:
+            return
+    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
+
+
+def assert_event_starts_with_text_and_contains_errors(event_text, events_list, fields_list) -> None:
+    """
+    Search for the event starting with the expected text in the list and check its message.
+
+    :param event_text: event text
+    :param events_list: list of events
+    :param fields_list: expected message contents
+    :return:
+    """
+    for i in range(len(events_list) - 1, -1, -1):
+        if str(events_list[i].message).startswith(event_text):
+            for field_error in fields_list:
+                assert field_error in events_list[i].message
+            return
+    pytest.fail(f"Failed to find the event starting with \"{event_text}\" in the list. Exiting...")
+
+
+def assert_vs_conf_not_exists(kube_apis, ic_pod_name, ic_namespace, virtual_server_setup):
+    new_response = get_vs_nginx_template_conf(kube_apis.v1,
+                                              virtual_server_setup.namespace,
+                                              virtual_server_setup.vs_name,
+                                              ic_pod_name,
+                                              ic_namespace)
+    assert "No such file or directory" in new_response
+
+
+def assert_vs_conf_exists(kube_apis, ic_pod_name, ic_namespace, virtual_server_setup):
+    new_response = get_vs_nginx_template_conf(kube_apis.v1,
+                                              virtual_server_setup.namespace,
+                                              virtual_server_setup.vs_name,
+                                              ic_pod_name,
+                                              ic_namespace)
+    assert "No such file or directory" not in new_response

--- a/tests/suite/resources_utils.py
+++ b/tests/suite/resources_utils.py
@@ -981,10 +981,10 @@ def ensure_response_from_backend(req_url, host) -> None:
     :param host:
     :return:
     """
-    for _ in range(10):
+    for _ in range(30):
         resp = requests.get(req_url, headers={"host": host}, verify=False)
         if resp.status_code != 502:
             print(f"At last after {_ * 2} seconds got 200. Continue...")
             return
         time.sleep(2)
-    pytest.fail(f"Keep getting 502 from {req_url} after 20 seconds. Exiting...")
+    pytest.fail(f"Keep getting 502 from {req_url} after 60 seconds. Exiting...")

--- a/tests/suite/resources_utils.py
+++ b/tests/suite/resources_utils.py
@@ -150,7 +150,7 @@ def scale_deployment(apps_v1_api: AppsV1Api, name, namespace, value) -> None:
     :return:
     """
     print(f"Scale a deployment '{name}'")
-    body = apps_v1_api.read_namespaced_deployment(name, namespace)
+    body = apps_v1_api.read_namespaced_deployment_scale(name, namespace)
     body.spec.replicas = value
     apps_v1_api.patch_namespaced_deployment_scale(name, namespace, body)
     print(f"Scale a deployment '{name}': complete")

--- a/tests/suite/test_annotations.py
+++ b/tests/suite/test_annotations.py
@@ -2,6 +2,7 @@ import pytest
 import yaml
 from kubernetes.client import ExtensionsV1beta1Api
 
+from suite.custom_assertions import assert_event_count_increased
 from suite.fixtures import PublicEndpoint
 from suite.resources_utils import ensure_connection_to_public_endpoint, \
     get_ingress_nginx_template_conf, \
@@ -18,14 +19,6 @@ def get_event_count(event_text, events_list) -> int:
         if event_text in events_list[i].message:
             return events_list[i].count
     return 0
-
-
-def assert_event_count_increased(event_text, count, events_list):
-    for i in range(len(events_list) - 1, -1, -1):
-        if event_text in events_list[i].message:
-            assert events_list[i].count > count
-            return
-    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
 
 
 def replace_ingresses_from_yaml(extensions_v1_beta1: ExtensionsV1beta1Api, namespace, yaml_manifest) -> None:

--- a/tests/suite/test_v_s_route.py
+++ b/tests/suite/test_v_s_route.py
@@ -2,6 +2,7 @@ import requests
 import pytest
 
 from settings import TEST_DATA
+from suite.custom_assertions import assert_event_and_count, assert_event_and_get_count
 from suite.custom_resources_utils import create_virtual_server_from_yaml, \
     delete_virtual_server, create_v_s_route_from_yaml, delete_v_s_route, get_vs_nginx_template_conf, \
     patch_v_s_route_from_yaml
@@ -30,22 +31,6 @@ def assert_locations_not_in_config(config, paths):
         assert f"location {path}" not in config
 
 
-def assert_event_and_count(event_text, count, events_list):
-    for i in range(len(events_list) - 1, -1, -1):
-        if event_text in events_list[i].message:
-            assert events_list[i].count == count
-            return
-    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
-
-
-def assert_event_and_get_count(event_text, events_list) -> int:
-    for i in range(len(events_list) - 1, -1, -1):
-        if event_text in events_list[i].message:
-            return events_list[i].count
-    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
-
-
-@pytest.mark.vsr
 @pytest.mark.smoke
 @pytest.mark.parametrize('crd_ingress_controller, v_s_route_setup',
                          [({"type": "complete", "extra_args": [f"-enable-custom-resources"]},

--- a/tests/suite/test_v_s_route_api.py
+++ b/tests/suite/test_v_s_route_api.py
@@ -43,8 +43,8 @@ class TestVSRNginxPlusApi:
         new_reloads_count = get_nginx_generation_value(req_url)
         assert new_reloads_count == initial_reloads_count, "Expected: no new reloads"
         for resp in [resp_s, resp_m]:
-            assert resp[0]['max_conns'] is 32
-            assert resp[0]['max_fails'] is 25
+            assert resp[0]['max_conns'] == 32
+            assert resp[0]['max_fails'] == 25
             assert resp[0]['fail_timeout'] == '15s'
             assert resp[0]['slow_start'] == '10s'
 

--- a/tests/suite/test_v_s_route_externalname.py
+++ b/tests/suite/test_v_s_route_externalname.py
@@ -9,7 +9,7 @@ from suite.fixtures import VirtualServerRoute, PublicEndpoint
 from suite.resources_utils import get_first_pod_name, get_events, \
     wait_before_test, replace_configmap_from_yaml, create_service_from_yaml, \
     delete_namespace, create_namespace_with_name_from_yaml, read_service, replace_service, replace_configmap, \
-    create_service_with_name, create_deployment_with_name
+    create_service_with_name, create_deployment_with_name, ensure_response_from_backend
 from suite.yaml_utils import get_paths_from_vsr_yaml, get_route_namespace_from_vs_yaml, get_first_vs_host_from_yaml
 
 
@@ -83,6 +83,8 @@ def vsr_externalname_setup(request, kube_apis,
     svc_name = create_service_from_yaml(kube_apis.v1,
                                         ns_1, f"{TEST_DATA}/{request.param['example']}/externalname-svc.yaml")
     wait_before_test(2)
+    req_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.port}"
+    ensure_response_from_backend(f"{req_url}{route.paths[0]}", vs_host)
 
     def fin():
         print("Delete test namespaces")

--- a/tests/suite/test_v_s_route_upstream_options.py
+++ b/tests/suite/test_v_s_route_upstream_options.py
@@ -2,48 +2,13 @@ import requests
 import pytest
 
 from settings import TEST_DATA
+from suite.custom_assertions import assert_event_and_get_count, assert_event_count_increased, assert_response_codes, \
+    assert_event, assert_event_starts_with_text_and_contains_errors
 from suite.custom_resources_utils import get_vs_nginx_template_conf, patch_v_s_route_from_yaml, patch_v_s_route, \
     generate_item_with_upstream_options
 from suite.resources_utils import get_first_pod_name, wait_before_test, replace_configmap_from_yaml, get_events
 
 
-def assert_response_codes(resp_1, resp_2, code=200):
-    assert resp_1.status_code == code
-    assert resp_2.status_code == code
-
-
-def get_event_count(event_text, events_list) -> int:
-    for i in range(len(events_list) - 1, -1, -1):
-        if event_text in events_list[i].message:
-            return events_list[i].count
-    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
-
-
-def assert_event_count_increased(event_text, count, events_list):
-    for i in range(len(events_list) - 1, -1, -1):
-        if event_text in events_list[i].message:
-            assert events_list[i].count > count
-            return
-    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
-
-
-def assert_event(event_text, events_list):
-    for i in range(len(events_list) - 1, -1, -1):
-        if event_text in events_list[i].message:
-            return
-    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
-
-
-def assert_event_starts_with_text_and_contains_errors(event_text, events_list, fields_list):
-    for i in range(len(events_list) - 1, -1, -1):
-        if str(events_list[i].message).startswith(event_text):
-            for field_error in fields_list:
-                assert field_error in events_list[i].message
-            return
-    pytest.fail(f"Failed to find the event starting with \"{event_text}\" in the list. Exiting...")
-
-
-@pytest.mark.vsr
 @pytest.mark.parametrize('crd_ingress_controller, v_s_route_setup',
                          [({"type": "complete", "extra_args": [f"-enable-custom-resources"]},
                            {"example": "virtual-server-route-upstream-options"})],
@@ -120,8 +85,8 @@ class TestVSRouteUpstreamOptions:
         vsr_m_event_text = f"Configuration for {text_m} was added or updated"
         events_ns_m = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
         events_ns_s = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        initial_count_vsr_m = get_event_count(vsr_m_event_text, events_ns_m)
-        initial_count_vsr_s = get_event_count(vsr_s_event_text, events_ns_s)
+        initial_count_vsr_m = assert_event_and_get_count(vsr_m_event_text, events_ns_m)
+        initial_count_vsr_s = assert_event_and_get_count(vsr_s_event_text, events_ns_s)
         print(f"Case 2: no key in ConfigMap, option specified in VSR")
         new_body_m = generate_item_with_upstream_options(
             f"{TEST_DATA}/virtual-server-route-upstream-options/route-multiple.yaml",
@@ -238,8 +203,8 @@ class TestVSRouteUpstreamOptions:
         vsr_m_event_text = f"Configuration for {text_m} was added or updated"
         events_ns_m = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
         events_ns_s = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        initial_count_vsr_m = get_event_count(vsr_m_event_text, events_ns_m)
-        initial_count_vsr_s = get_event_count(vsr_s_event_text, events_ns_s)
+        initial_count_vsr_m = assert_event_and_get_count(vsr_m_event_text, events_ns_m)
+        initial_count_vsr_s = assert_event_and_get_count(vsr_s_event_text, events_ns_s)
         print(f"Case 4: key specified in ConfigMap, option specified in VS")
         new_body_m = generate_item_with_upstream_options(
             f"{TEST_DATA}/virtual-server-route-upstream-options/route-multiple.yaml",
@@ -290,7 +255,7 @@ class TestVSRouteUpstreamOptionsValidation:
             "upstreams[0].lb-method", "upstreams[0].fail-timeout",
             "upstreams[0].max-fails", "upstreams[0].connect-timeout",
             "upstreams[0].read-timeout", "upstreams[0].send-timeout",
-            "upstreams[0].keepalive","upstreams[0].max-conns",
+            "upstreams[0].keepalive", "upstreams[0].max-conns",
             "upstreams[0].next-upstream",
             "upstreams[0].next-upstream-timeout", "upstreams[0].next-upstream-tries",
             "upstreams[0].client-max-body-size",
@@ -389,8 +354,8 @@ class TestOptionsSpecificForPlus:
         vsr_m_event_text = f"Configuration for {text_m} was added or updated"
         events_ns_m = get_events(kube_apis.v1, v_s_route_setup.route_m.namespace)
         events_ns_s = get_events(kube_apis.v1, v_s_route_setup.route_s.namespace)
-        initial_count_vsr_m = get_event_count(vsr_m_event_text, events_ns_m)
-        initial_count_vsr_s = get_event_count(vsr_s_event_text, events_ns_s)
+        initial_count_vsr_m = assert_event_and_get_count(vsr_m_event_text, events_ns_m)
+        initial_count_vsr_s = assert_event_and_get_count(vsr_s_event_text, events_ns_s)
         print(f"Case 2: no key in ConfigMap, option specified in VSR")
         new_body_m = generate_item_with_upstream_options(
             f"{TEST_DATA}/virtual-server-route-upstream-options/route-multiple.yaml",

--- a/tests/suite/test_virtual_server.py
+++ b/tests/suite/test_virtual_server.py
@@ -165,6 +165,7 @@ class TestVirtualServer:
         print("Step 13: restore CRD and VS and check")
         create_crd_from_yaml(kube_apis.api_extensions_v1_beta1, crd_name,
                              f"{DEPLOYMENTS}/common/custom-resource-definitions.yaml")
+        wait_before_test(1)
         create_virtual_server_from_yaml(kube_apis.custom_objects,
                                         f"{TEST_DATA}/virtual-server/standard/virtual-server.yaml",
                                         virtual_server_setup.namespace)

--- a/tests/suite/test_virtual_server_api.py
+++ b/tests/suite/test_virtual_server_api.py
@@ -32,8 +32,8 @@ class TestVSNginxPlusApi:
         resp = json.loads(requests.get(upstream_servers_url).text)
         new_reloads_count = get_nginx_generation_value(req_url)
         assert new_reloads_count == initial_reloads_count, "Expected: no new reloads"
-        assert resp[0]['max_conns'] is 32
-        assert resp[0]['max_fails'] is 25
+        assert resp[0]['max_conns'] == 32
+        assert resp[0]['max_fails'] == 25
         assert resp[0]['fail_timeout'] == '15s'
         assert resp[0]['slow_start'] == '10s'
 

--- a/tests/suite/test_virtual_server_external_name.py
+++ b/tests/suite/test_virtual_server_external_name.py
@@ -7,7 +7,7 @@ from suite.custom_resources_utils import get_vs_nginx_template_conf
 from suite.resources_utils import replace_configmap_from_yaml, \
     ensure_connection_to_public_endpoint, replace_configmap, create_service_from_yaml, get_first_pod_name, get_events, \
     read_service, replace_service, wait_before_test, delete_namespace, create_service_with_name, \
-    create_deployment_with_name, create_namespace_with_name_from_yaml
+    create_deployment_with_name, create_namespace_with_name_from_yaml, ensure_response_from_backend
 
 
 class ExternalNameSetup:
@@ -45,6 +45,7 @@ def vs_externalname_setup(request,
                                          virtual_server_setup.public_endpoint.port,
                                          virtual_server_setup.public_endpoint.port_ssl)
     ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+    ensure_response_from_backend(virtual_server_setup.backend_1_url, virtual_server_setup.vs_host)
 
     def fin():
         print("Clean up ExternalName Setup:")
@@ -61,7 +62,7 @@ def vs_externalname_setup(request,
 @pytest.mark.vs
 @pytest.mark.skip_for_nginx_oss
 @pytest.mark.parametrize('crd_ingress_controller, virtual_server_setup',
-                         [({"type": "complete", "extra_args": [f"-enable-custom-resources"]},
+                         [({"type": "complete", "extra_args": [f"-enable-custom-resources", "-v=3"]},
                            {"example": "virtual-server-externalname", "app_type": "simple"})],
                          indirect=True)
 class TestVSWithExternalNameService:

--- a/tests/suite/test_virtual_server_upstream_tls.py
+++ b/tests/suite/test_virtual_server_upstream_tls.py
@@ -2,42 +2,10 @@ import requests
 import pytest
 
 from settings import TEST_DATA
+from suite.custom_assertions import assert_event_and_get_count, assert_event_count_increased, assert_response_codes, \
+    assert_event, assert_no_new_events
 from suite.custom_resources_utils import get_vs_nginx_template_conf, patch_virtual_server_from_yaml
 from suite.resources_utils import get_first_pod_name, wait_before_test, get_events
-
-
-def assert_response_codes(resp_1, resp_2, code_1=200, code_2=200):
-    assert resp_1.status_code == code_1
-    assert resp_2.status_code == code_2
-
-
-def get_event_count(event_text, events_list) -> int:
-    for i in range(len(events_list) - 1, -1, -1):
-        if event_text in events_list[i].message:
-            return events_list[i].count
-    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
-
-
-def assert_event_count_increased(event_text, count, events_list):
-    for i in range(len(events_list) - 1, -1, -1):
-        if event_text in events_list[i].message:
-            assert events_list[i].count > count
-            return
-    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
-
-
-def assert_event(event_text, events_list):
-    for i in range(len(events_list) - 1, -1, -1):
-        if event_text in events_list[i].message:
-            return
-    pytest.fail(f"Failed to find the event \"{event_text}\" in the list. Exiting...")
-
-
-def assert_no_new_events(old_list, new_list):
-    assert len(old_list) == len(new_list), "expected: lists are the same"
-    for i in range(len(new_list) - 1, -1, -1):
-        if old_list[i].count != new_list[i].count:
-            pytest.fail(f"Expected: no new events. There is a new event found:\"{new_list[i].message}\". Exiting...")
 
 
 @pytest.mark.vs
@@ -103,7 +71,7 @@ class TestVirtualServerUpstreamTls:
         text = f"{virtual_server_setup.namespace}/{virtual_server_setup.vs_name}"
         vs_event_text = f"Configuration for {text} was added or updated"
         initial_events_vs = get_events(kube_apis.v1, virtual_server_setup.namespace)
-        initial_count = get_event_count(vs_event_text, initial_events_vs)
+        initial_count = assert_event_and_get_count(vs_event_text, initial_events_vs)
         patch_virtual_server_from_yaml(kube_apis.custom_objects,
                                        virtual_server_setup.vs_name,
                                        f"{TEST_DATA}/virtual-server-upstream-tls/virtual-server-disable-tls.yaml",

--- a/tests/suite/yaml_utils.py
+++ b/tests/suite/yaml_utils.py
@@ -16,19 +16,6 @@ def get_first_ingress_host_from_yaml(file) -> str:
             return dep['spec']['rules'][0]['host']
 
 
-def get_external_host_from_service_yaml(file) -> str:
-    """
-    Parse yaml file and return first spec.externalName appeared.
-
-    :param file: an absolute path to file
-    :return: str
-    """
-    with open(file) as f:
-        docs = yaml.safe_load_all(f)
-        for dep in docs:
-            return dep['spec']['externalName']
-
-
 def get_names_from_yaml(file) -> []:
     """
     Parse yaml file and return all the found metadata.name.


### PR DESCRIPTION
Gather common assertion methods in one place. Replace 'nginx.com' as ExternalName host with an internal backend.