### PR TITLE
Add regex support to location paths

### DIFF
--- a/docs/virtualserver-and-virtualserverroute.md
+++ b/docs/virtualserver-and-virtualserverroute.md
@@ -63,6 +63,12 @@ spec:
   - path: /coffee
     action:
       pass: coffee
+  - path: ~ ^/decaf/.*\\.jpg$
+    action:
+      pass: coffee
+  - path: = /green/tea
+    action:
+      pass: tea
 ```
 
 | Field | Description | Type | Required |
@@ -113,7 +119,7 @@ The route defines rules for matching client requests to actions like passing a r
 
 | Field | Description | Type | Required |
 | ----- | ----------- | ---- | -------- |
-| `path` | The path of the route. NGINX will match it against the URI of a request. The path must start with `/` and must not include any whitespace characters, `{`, `}` or `;`. For example, `/`, `/path` are valid. The path must be unique among the paths of all routes of the VirtualServer. | `string` | Yes |
+| `path` | The path of the route. NGINX will match it against the URI of a request. Possible values are: a prefix (`/`, `/path`), an exact match (`=/exact/match`), a case insensitive regular expression (`~*^/Bar.*\\.jpg`) or a case sensitive regular expression (`~^/foo.*\\.jpg`). In the case of a prefix (must start with `/`) or an exact match (must start with `=`), the path must not include any whitespace characters, `{`, `}` or `;`. In the case of the regex matches, all double quotes `"` must be escaped and the match can't end in an unescaped backslash `\`. The path must be unique among the paths of all routes of the VirtualServer. Check the [location](http://nginx.org/en/docs/http/ngx_http_core_module.html#location) directive for more information. | `string` | Yes |
 | `action` | The default action to perform for a request. | [`action`](#Action) | No* |
 | `splits` | The default splits configuration for traffic splitting. Must include at least 2 splits. | [`[]split`](#Split) | No* |
 | `matches` | The matching rules for advanced content-based routing. Requires the default `action` or `splits`.  Unmatched requests will be handled by the default `action` or `splits`. |[`matches`](#Match) | No |
@@ -193,7 +199,7 @@ action:
 
 | Field | Description | Type | Required |
 | ----- | ----------- | ---- | -------- |
-| `path` | The path of the subroute. NGINX will match it against the URI of a request. The path must start with the same path as the path of the route of the VirtualServer that references this resource. It must not include any whitespace characters, `{`, `}` or `;`. The path must be unique among the paths of all subroutes of the VirtualServerRoute. | `string` | Yes |
+| `path` | The path of the subroute. NGINX will match it against the URI of a request. Possible values are: a prefix (`/`, `/path`), an exact match (`=/exact/match`), a case insensitive regular expression (`~*^/Bar.*\\.jpg`) or a case sensitive regular expression (`~^/foo.*\\.jpg`). In the case of a prefix, the path must start with the same path as the path of the route of the VirtualServer that references this resource. In the case of an exact or regex match, the path must be the same as the path of the route of the VirtualServer that references this resource. In the case of a prefix or an exact match, the path must not include any whitespace characters, `{`, `}` or `;`.  In the case of the regex matches, all double quotes `"` must be escaped and the match can't end in an unescaped backslash `\`. The path must be unique among the paths of all subroutes of the VirtualServerRoute. | `string` | Yes |
 | `action` | The default action to perform for a request. | [`action`](#Action) | No* |
 | `splits` | The default splits configuration for traffic splitting. Must include at least 2 splits. | [`[]split`](#Split) | No* |
 | `matches` | The matching rules for advanced content-based routing. Requires the default `action` or `splits`.  Unmatched requests will be handled by the default `action` or `splits`. |[`matches`](#Match) | No |

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -499,9 +499,21 @@ func generateBool(s *bool, defaultS bool) bool {
 	return defaultS
 }
 
+func generatePath(path string) string {
+	// Wrap the regular expression (if present) inside double quotes (") to avoid NGINX parsing errors
+	if strings.HasPrefix(path, "~*") {
+		return fmt.Sprintf(`~* "%v"`, strings.TrimPrefix(strings.TrimPrefix(path, "~*"), " "))
+	}
+	if strings.HasPrefix(path, "~") {
+		return fmt.Sprintf(`~ "%v"`, strings.TrimPrefix(strings.TrimPrefix(path, "~"), " "))
+	}
+
+	return path
+}
+
 func generateLocation(path string, upstreamName string, upstream conf_v1alpha1.Upstream, cfgParams *ConfigParams) version2.Location {
 	return version2.Location{
-		Path:                     path,
+		Path:                     generatePath(path),
 		Snippets:                 cfgParams.LocationSnippets,
 		ProxyConnectTimeout:      generateString(upstream.ProxyConnectTimeout, cfgParams.ProxyConnectTimeout),
 		ProxyReadTimeout:         generateString(upstream.ProxyReadTimeout, cfgParams.ProxyReadTimeout),

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -2883,3 +2883,34 @@ func TestGenerateSessionCookie(t *testing.T) {
 		}
 	}
 }
+
+func TestGeneratePath(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{
+			path:     "/",
+			expected: "/",
+		},
+		{
+			path:     "=/exact/match",
+			expected: "=/exact/match",
+		},
+		{
+			path:     `~ *\\.jpg`,
+			expected: `~ "*\\.jpg"`,
+		},
+		{
+			path:     `~* *\\.PNG`,
+			expected: `~* "*\\.PNG"`,
+		},
+	}
+
+	for _, test := range tests {
+		result := generatePath(test.path)
+		if result != test.expected {
+			t.Errorf("generatePath() returned %v, but expected %v.", result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
### Proposed changes
Add the ability to use exact matches (`=`) and case sensitive/insensitive regular expressions (`~`, `~*`) in VS/VSR route paths.

@tellet Please have a look at the Test methods and let me know if more edge cases can be added to improve validation, thank you.


