### PR TITLE
Allow nginx debug binary to use ports 80 and 443

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p /var/lib/nginx \
 	&& apt-get update \
 	&& apt-get install -y libcap2-bin \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
+	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& chown -R nginx:0 /etc/nginx \
 	&& chown -R nginx:0 /var/cache/nginx \
 	&& chown -R nginx:0 /var/lib/nginx \

--- a/build/DockerfileForAlpine
+++ b/build/DockerfileForAlpine
@@ -10,6 +10,7 @@ RUN mkdir -p /etc/nginx/secrets \
 	&& mkdir -p /var/lib/nginx \
 	&& apk add --no-cache libcap \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
+	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& chown -R nginx:0 /etc/nginx \
 	&& chown -R nginx:0 /var/cache/nginx \
 	&& chown -R nginx:0 /var/lib/nginx \

--- a/build/DockerfileForPlus
+++ b/build/DockerfileForPlus
@@ -38,6 +38,7 @@ RUN set -x \
   && printf "deb https://plus-pkgs.nginx.com/debian stretch nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
   && apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION} \
   && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
+  && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
   && apt-get remove --purge --auto-remove -y gnupg1 \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /etc/ssl/nginx \

--- a/build/DockerfileWithOpentracing
+++ b/build/DockerfileWithOpentracing
@@ -78,6 +78,7 @@ RUN mkdir -p /var/lib/nginx \
     && apt-get update \
     && apt-get install -y libcap2-bin \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
+    && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
     && chown -R nginx:0 /etc/nginx \
     && chown -R nginx:0 /var/cache/nginx \
     && chown -R nginx:0 /var/lib/nginx \

--- a/build/DockerfileWithOpentracingForPlus
+++ b/build/DockerfileWithOpentracingForPlus
@@ -51,6 +51,7 @@ RUN set -x \
     # Install OpenTracing module
     nginx-plus-module-opentracing=${NGINX_OPENTRACING_MODULE_VERSION} \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
+    && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
     && apt-get remove --purge --auto-remove -y gnupg1 \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /etc/ssl/nginx \


### PR DESCRIPTION
### Proposed changes
Add `net_bind_service` capabilities to NGINX debug binary to work with the new non-root feature.
