### PR TITLE
Improve TLS redirect in VS

### DIFF
--- a/docs/virtualserver-and-virtualserverroute.md
+++ b/docs/virtualserver-and-virtualserverroute.md
@@ -84,13 +84,12 @@ The tls field defines TLS configuration for a VirtualServer. For example:
 ```yaml
 secret: cafe-secret
 redirect:
-  code: 302
-  basedOn: x-forwarded-proto
+  enable: true
 ```
 
 | Field | Description | Type | Required |
 | ----- | ----------- | ---- | -------- |
-| `secret` | The name of a secret with a TLS certificate and key. The secret must belong to the same namespace as the VirtualServer. The secret must contain keys named `tls.crt` and `tls.key` that contain the certificate and private key as described [here](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls). If the secret doesn't exist, NGINX will break any attempt to establish a TLS connection to the host of the VirtualServer. | `string` | Yes |
+| `secret` | The name of a secret with a TLS certificate and key. The secret must belong to the same namespace as the VirtualServer. The secret must contain keys named `tls.crt` and `tls.key` that contain the certificate and private key as described [here](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls). If the secret doesn't exist, NGINX will break any attempt to establish a TLS connection to the host of the VirtualServer. | `string` | No |
 | `redirect` | The redirect configuration of the TLS for a VirtualServer. | [`tls.redirect`](#VirtualServerTLSRedirect) | No |
 
 ### VirtualServer.TLS.Redirect

--- a/pkg/apis/configuration/validation/validation.go
+++ b/pkg/apis/configuration/validation/validation.go
@@ -404,7 +404,7 @@ func validateSecretName(name string, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if name == "" {
-		return append(allErrs, field.Required(fieldPath, ""))
+		return allErrs
 	}
 
 	for _, msg := range validation.IsDNS1123Subdomain(name) {

--- a/pkg/apis/configuration/validation/validation_test.go
+++ b/pkg/apis/configuration/validation/validation_test.go
@@ -93,6 +93,9 @@ func TestValidateTLS(t *testing.T) {
 	validTLSes := []*v1alpha1.TLS{
 		nil,
 		{
+			Secret: "",
+		},
+		{
 			Secret: "my-secret",
 		},
 		{
@@ -130,9 +133,6 @@ func TestValidateTLS(t *testing.T) {
 	}
 
 	invalidTLSes := []*v1alpha1.TLS{
-		{
-			Secret: "",
-		},
 		{
 			Secret: "-",
 		},


### PR DESCRIPTION
### Proposed changes
* Make `tls.secret` optional in the VS.

This allows a conditional redirect  based on the value of `x_forwarded_proto` to be configured which is important for the use case of deploying a proxy in front of the ingress controller to do TLS termination.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
