### PR TITLE
Enable CRDs by default

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -124,7 +124,7 @@ The external address of the service is used when reporting the status of Ingress
 	prometheusMetricsListenPort = flag.Int("prometheus-metrics-listen-port", 9113,
 		"Set the port where the Prometheus metrics are exposed. [1023 - 65535]")
 
-	enableCustomResources = flag.Bool("enable-custom-resources", false,
+	enableCustomResources = flag.Bool("enable-custom-resources", true,
 		"Enable custom resources")
 )
 

--- a/deployments/daemon-set/nginx-ingress.yaml
+++ b/deployments/daemon-set/nginx-ingress.yaml
@@ -49,7 +49,6 @@ spec:
         args:
           - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
           - -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret
-          - -enable-custom-resources
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress

--- a/deployments/daemon-set/nginx-ingress.yaml
+++ b/deployments/daemon-set/nginx-ingress.yaml
@@ -49,9 +49,9 @@ spec:
         args:
           - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
           - -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret
+          - -enable-custom-resources
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress
          #- -enable-leader-election
          #- -enable-prometheus-metrics
-         #- -enable-custom-resources

--- a/deployments/daemon-set/nginx-plus-ingress.yaml
+++ b/deployments/daemon-set/nginx-plus-ingress.yaml
@@ -50,9 +50,9 @@ spec:
           - -nginx-plus
           - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
           - -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret
+          - -enable-custom-resources
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress
          #- -enable-leader-election
          #- -enable-prometheus-metrics
-         #- -enable-custom-resources

--- a/deployments/daemon-set/nginx-plus-ingress.yaml
+++ b/deployments/daemon-set/nginx-plus-ingress.yaml
@@ -50,7 +50,6 @@ spec:
           - -nginx-plus
           - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
           - -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret
-          - -enable-custom-resources
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress

--- a/deployments/deployment/nginx-ingress.yaml
+++ b/deployments/deployment/nginx-ingress.yaml
@@ -48,7 +48,6 @@ spec:
         args:
           - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
           - -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret
-          - -enable-custom-resources
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress

--- a/deployments/deployment/nginx-ingress.yaml
+++ b/deployments/deployment/nginx-ingress.yaml
@@ -48,9 +48,9 @@ spec:
         args:
           - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
           - -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret
+          - -enable-custom-resources
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress
          #- -enable-leader-election
          #- -enable-prometheus-metrics
-         #- -enable-custom-resources

--- a/deployments/deployment/nginx-plus-ingress.yaml
+++ b/deployments/deployment/nginx-plus-ingress.yaml
@@ -49,9 +49,9 @@ spec:
           - -nginx-plus
           - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
           - -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret
+          - -enable-custom-resources
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress
          #- -enable-leader-election
          #- -enable-prometheus-metrics
-         #- -enable-custom-resources

--- a/deployments/deployment/nginx-plus-ingress.yaml
+++ b/deployments/deployment/nginx-plus-ingress.yaml
@@ -49,7 +49,6 @@ spec:
           - -nginx-plus
           - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
           - -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret
-          - -enable-custom-resources
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -84,7 +84,7 @@ Parameter | Description | Default
 `controller.ingressClass` | A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its class - i.e. have the annotation `"kubernetes.io/ingress.class"` equal to the class. Additionally, the Ingress controller processes Ingress resources that do not have that annotation which can be disabled by setting the "-use-ingress-class-only" flag. | nginx
 `controller.useIngressClassOnly` | Ignore Ingress resources without the `"kubernetes.io/ingress.class"` annotation. | false
 `controller.watchNamespace` | Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces. | ""
-`controller.enableCustomResources` | Enable the custom resources. | false
+`controller.enableCustomResources` | Enable the custom resources. | true
 `controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress controller. | false
 `controller.healthStatusURI` | Sets the URI of health status location in the default server. Requires `contoller.healthStatus`. | "/nginx-health"
 `controller.nginxStatus.enable` | Enable the NGINX stub_status, or the NGINX Plus API. | true

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -104,7 +104,7 @@ controller:
   watchNamespace: ""
 
   ## Enable the custom resources.
-  enableCustomResources: false
+  enableCustomResources: true
 
   ## Add a location based on the value of health-status-uri to the default server. The location responds with the 200 status code for any request.
   ## Useful for external health-checking of the Ingress controller.

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -14,7 +14,7 @@ Usage of ./nginx-ingress:
        Format: <namespace>/<name>. If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection.
     	If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress controller will fail to start.
   -enable-custom-resources
-    	Enable custom resources
+       Enable custom resources (default true)
   -enable-leader-election
     	Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources -- only one replica will report status. See -report-ingress-status flag.
   -external-service string

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,7 +32,8 @@ The installation manifests are located in the [deployments](../deployments) fold
     ```
     $ kubectl apply -f common/custom-resource-definitions.yaml
     ```
-    Note: in Step 3, make sure the Ingress controller starts with the `-enable-custom-resources` [command-line argument](cli-arguments.md).
+
+    **Note**: If you want to use the ingress resource instead, you must skip this step. Additionally in Step 3 remove the `-enable-custom-resources` [command-line argument](cli-arguments.md).
 
 ## 2. Configure RBAC
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,8 +33,6 @@ The installation manifests are located in the [deployments](../deployments) fold
     $ kubectl apply -f common/custom-resource-definitions.yaml
     ```
 
-    **Note**: If you want to use the ingress resource instead, you must skip this step. Additionally in Step 3 remove the `-enable-custom-resources` [command-line argument](cli-arguments.md).
-
 ## 2. Configure RBAC
 
 If RBAC is enabled in your cluster, create a cluster role and bind it to the service account, created in Step 1:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,7 +28,7 @@ The installation manifests are located in the [deployments](../deployments) fold
     $ kubectl apply -f common/nginx-config.yaml
     ```
 
-1. (Optional) To use the [VirtualServer and VirtualServerRoute](virtualserver-and-virtualserverroute.md) resources, create the corresponding resource definitions:
+1. Create custom resource definitions for [VirtualServer and VirtualServerRoute](virtualserver-and-virtualserverroute.md) resources:
     ```
     $ kubectl apply -f common/custom-resource-definitions.yaml
     ```

--- a/docs/virtualserver-and-virtualserverroute.md
+++ b/docs/virtualserver-and-virtualserverroute.md
@@ -4,8 +4,6 @@ The VirtualServer and VirtualServerRoute resources are new load balancing config
 
 This document is the reference documentation for the resources. To see additional examples of using the resources for specific use cases, go to the [examples-of-custom-resources](../examples-of-custom-resources) folder.
 
-**Feature Status**: The VirtualServer and VirtualServerRoute resources are available as a preview feature: it is suitable for experimenting and testing; however, it must be used with caution in production environments. Additionally, while the feature is in preview, we might introduce some backward-incompatible changes to the resources specification in the next releases.
-
 ## Contents
 
 - [VirtualServer and VirtualServerRoute Resources](#virtualserver-and-virtualserverroute-resources)


### PR DESCRIPTION
### Proposed changes
CRDs were made GA in https://github.com/nginxinc/kubernetes-ingress/pull/772

CRDs should now be enabled by default in our provided manifests and helm chart.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
