### PR TITLE
Fix X-Forwarded-Proto proxy header for TLSRedirect

### DIFF
--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -145,7 +145,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
 
         proxy_pass {{ $l.ProxyPass }};
         proxy_next_upstream {{ $l.ProxyNextUpstream }};

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -114,7 +114,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
 
         proxy_pass {{ $l.ProxyPass }};
         proxy_next_upstream {{ $l.ProxyNextUpstream }};


### PR DESCRIPTION
### Bug
When redirecting basedOn `x-forwarded-proto` the `X-Forwarded-Proto` proxy header value is incorrectly.

### Proposed changes
* When redirecting basedOn `x-forwarded-proto` the `X-Forwarded-Proto` proxy header is now set correctly.

Given the following config:
```yaml
redirect:
  enable: true
  code: 301
  basedOn: x-forwarded-proto
```
#### Before changes
* `proxy_set_header X-Forwarded-Proto $scheme;`

#### After changes
* `proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;`

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
