### PR TITLE
Fix VSR updates when namespace is set implicitly

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -722,9 +722,11 @@ func (lbc *LoadBalancerController) syncVirtualServerRoute(task task) {
 	}
 
 	vsCount := lbc.enqueueVirtualServersForVirtualServerRouteKey(key)
+
 	if vsCount == 0 {
 		lbc.recorder.Eventf(vsr, api_v1.EventTypeWarning, "NoVirtualServersFound", "No VirtualServer references VirtualServerRoute %s", key)
 	}
+
 }
 
 func (lbc *LoadBalancerController) syncIngMinion(task task) {

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -722,11 +722,9 @@ func (lbc *LoadBalancerController) syncVirtualServerRoute(task task) {
 	}
 
 	vsCount := lbc.enqueueVirtualServersForVirtualServerRouteKey(key)
-
 	if vsCount == 0 {
 		lbc.recorder.Eventf(vsr, api_v1.EventTypeWarning, "NoVirtualServersFound", "No VirtualServer references VirtualServerRoute %s", key)
 	}
-
 }
 
 func (lbc *LoadBalancerController) syncIngMinion(task task) {
@@ -1396,7 +1394,13 @@ func findVirtualServersForVirtualServerRouteKey(virtualServers []*conf_v1.Virtua
 
 	for _, vs := range virtualServers {
 		for _, r := range vs.Spec.Routes {
-			if r.Route == key {
+			// if route is defined without a namespace, use the namespace of VirtualServer.
+			vsrKey := r.Route
+			if !strings.Contains(r.Route, "/") {
+				vsrKey = fmt.Sprintf("%s/%s", vs.Namespace, r.Route)
+			}
+
+			if vsrKey == key {
 				result = append(result, vs)
 				break
 			}


### PR DESCRIPTION
### Bug
* When the namespace of the `VirtualServerRoute` is set implicitly. Updates to that resource are not applied.

### Proposed changes
* When the namespace of the `VirtualServerRoute` is set implicitly. The `VirtualServerRoute` will now use the namespace of the `VirtualServer`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
