### PR TITLE
Update IC configuration and improve a flaky test.

### DIFF
--- a/tests/suite/fixtures.py
+++ b/tests/suite/fixtures.py
@@ -121,12 +121,13 @@ def ingress_controller(cli_arguments, kube_apis, ingress_controller_prerequisite
     :return:
     """
     namespace = ingress_controller_prerequisites.namespace
-    print("------------------------- Create IC -----------------------------------")
-    extra_args = None
+    print("------------------------- Create IC without CRDs -----------------------------------")
     try:
         extra_args = request.param.get('extra_args', None)
+        extra_args.append("-enable-custom-resources=false")
     except AttributeError:
-        print("IC will start without any additional arguments")
+        print("IC will start with CRDs disabled and without any additional cli-arguments")
+        extra_args = ["-enable-custom-resources=false"]
     name = create_ingress_controller(kube_apis.v1, kube_apis.apps_v1_api, cli_arguments, namespace, extra_args)
 
     def fin():

--- a/tests/suite/test_externalname_service.py
+++ b/tests/suite/test_externalname_service.py
@@ -4,7 +4,7 @@ import pytest
 from settings import TEST_DATA
 from suite.fixtures import PublicEndpoint
 from suite.resources_utils import create_ingress_from_yaml, create_service_with_name, \
-    create_namespace_with_name_from_yaml, create_deployment_with_name, delete_namespace
+    create_namespace_with_name_from_yaml, create_deployment_with_name, delete_namespace, ensure_response_from_backend
 from suite.resources_utils import replace_configmap_from_yaml, create_service_from_yaml
 from suite.resources_utils import replace_configmap, delete_ingress, delete_service, get_ingress_nginx_template_conf
 from suite.resources_utils import get_first_pod_name, ensure_connection_to_public_endpoint, wait_before_test
@@ -80,6 +80,7 @@ class TestExternalNameService:
     def test_resolver(self, external_name_setup):
         wait_before_test()
         req_url = f"http://{external_name_setup.public_endpoint.public_ip}:{external_name_setup.public_endpoint.port}/"
+        ensure_response_from_backend(req_url, external_name_setup.ingress_host)
         resp = requests.get(req_url, headers={"host": external_name_setup.ingress_host}, verify=False)
         assert resp.status_code == 200
 


### PR DESCRIPTION
Set `enable-custom-resources` for non-CRD IC and set a delay for a flaky test