### PR TITLE
Add tests to cover additional cases

### DIFF
--- a/tests/data/virtual-server-tls-redirect/virtual-server-no-tls-termination-redirect.yaml
+++ b/tests/data/virtual-server-tls-redirect/virtual-server-no-tls-termination-redirect.yaml
@@ -1,0 +1,26 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server-tls
+spec:
+  host: virtual-server-tls.example.com
+  tls:
+    secret: "" # no TLS termination
+    redirect:
+      enable: True
+      code: 308
+      basedOn: x-forwarded-proto
+  upstreams:
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  - name: backend1
+    service: backend1-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/suite/test_virtual_server_tls_redirect.py
+++ b/tests/suite/test_virtual_server_tls_redirect.py
@@ -2,8 +2,8 @@ import pytest
 import requests
 
 from settings import TEST_DATA
-from suite.custom_resources_utils import patch_virtual_server_from_yaml
-from suite.resources_utils import wait_before_test
+from suite.custom_resources_utils import patch_virtual_server_from_yaml, get_vs_nginx_template_conf
+from suite.resources_utils import wait_before_test, get_first_pod_name
 
 
 @pytest.mark.vs
@@ -12,13 +12,21 @@ from suite.resources_utils import wait_before_test
                            {"example": "virtual-server-tls-redirect", "app_type": "simple"})],
                          indirect=True)
 class TestVirtualServerTLSRedirect:
-    def test_tls_redirect_defaults(self, kube_apis, crd_ingress_controller, virtual_server_setup):
+    def test_tls_redirect_defaults(self, kube_apis, ingress_controller_prerequisites,
+                                   crd_ingress_controller, virtual_server_setup):
         patch_virtual_server_from_yaml(kube_apis.custom_objects,
                                        virtual_server_setup.vs_name,
                                        f"{TEST_DATA}/virtual-server-tls-redirect/virtual-server-default-redirect.yaml",
                                        virtual_server_setup.namespace)
         wait_before_test(1)
 
+        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        config = get_vs_nginx_template_conf(kube_apis.v1,
+                                            virtual_server_setup.namespace,
+                                            virtual_server_setup.vs_name,
+                                            ic_pod_name,
+                                            ingress_controller_prerequisites.namespace)
+        assert "proxy_set_header X-Forwarded-Proto $scheme;" in config
         resp_1 = requests.get(virtual_server_setup.backend_1_url,
                               headers={"host": virtual_server_setup.vs_host},
                               allow_redirects=False)
@@ -37,13 +45,21 @@ class TestVirtualServerTLSRedirect:
         assert resp_3.status_code == 200, "Expected: no redirect for scheme=https"
         assert resp_4.status_code == 200, "Expected: no redirect for scheme=https"
 
-    def test_tls_redirect_based_on_header(self, kube_apis, crd_ingress_controller, virtual_server_setup):
+    def test_tls_redirect_based_on_header(self, kube_apis, ingress_controller_prerequisites,
+                                          crd_ingress_controller, virtual_server_setup):
         patch_virtual_server_from_yaml(kube_apis.custom_objects,
                                        virtual_server_setup.vs_name,
                                        f"{TEST_DATA}/virtual-server-tls-redirect/virtual-server-header-redirect.yaml",
                                        virtual_server_setup.namespace)
         wait_before_test(1)
 
+        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        config = get_vs_nginx_template_conf(kube_apis.v1,
+                                            virtual_server_setup.namespace,
+                                            virtual_server_setup.vs_name,
+                                            ic_pod_name,
+                                            ingress_controller_prerequisites.namespace)
+        assert "proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;" in config
         resp_1 = requests.get(virtual_server_setup.backend_1_url,
                               headers={"host": virtual_server_setup.vs_host, "x-forwarded-proto": "http"},
                               allow_redirects=False)
@@ -80,13 +96,21 @@ class TestVirtualServerTLSRedirect:
         assert resp_7.status_code == 200, "Expected: no redirect for x-forwarded-proto=https"
         assert resp_8.status_code == 200, "Expected: no redirect for x-forwarded-proto=https"
 
-    def test_tls_redirect_based_on_scheme(self, kube_apis, crd_ingress_controller, virtual_server_setup):
+    def test_tls_redirect_based_on_scheme(self, kube_apis, ingress_controller_prerequisites,
+                                          crd_ingress_controller, virtual_server_setup):
         patch_virtual_server_from_yaml(kube_apis.custom_objects,
                                        virtual_server_setup.vs_name,
                                        f"{TEST_DATA}/virtual-server-tls-redirect/virtual-server-scheme-redirect.yaml",
                                        virtual_server_setup.namespace)
         wait_before_test(1)
 
+        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        config = get_vs_nginx_template_conf(kube_apis.v1,
+                                            virtual_server_setup.namespace,
+                                            virtual_server_setup.vs_name,
+                                            ic_pod_name,
+                                            ingress_controller_prerequisites.namespace)
+        assert "proxy_set_header X-Forwarded-Proto $scheme;" in config
         resp_1 = requests.get(virtual_server_setup.backend_1_url,
                               headers={"host": virtual_server_setup.vs_host},
                               allow_redirects=False)
@@ -104,3 +128,56 @@ class TestVirtualServerTLSRedirect:
                               allow_redirects=False, verify=False)
         assert resp_3.status_code == 200, "Expected: no redirect for scheme=https"
         assert resp_4.status_code == 200, "Expected: no redirect for scheme=https"
+
+    def test_tls_redirect_without_tls_termination(self, kube_apis, ingress_controller_prerequisites,
+                                                  crd_ingress_controller, virtual_server_setup):
+        source_yaml = f"{TEST_DATA}/virtual-server-tls-redirect/virtual-server-no-tls-termination-redirect.yaml"
+        patch_virtual_server_from_yaml(kube_apis.custom_objects,
+                                       virtual_server_setup.vs_name,
+                                       source_yaml,
+                                       virtual_server_setup.namespace)
+        wait_before_test(1)
+
+        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        config = get_vs_nginx_template_conf(kube_apis.v1,
+                                            virtual_server_setup.namespace,
+                                            virtual_server_setup.vs_name,
+                                            ic_pod_name,
+                                            ingress_controller_prerequisites.namespace)
+        assert "proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;" in config
+
+        resp_1 = requests.get(virtual_server_setup.backend_1_url,
+                              headers={"host": virtual_server_setup.vs_host, "x-forwarded-proto": "http"},
+                              allow_redirects=False)
+        resp_2 = requests.get(virtual_server_setup.backend_2_url,
+                              headers={"host": virtual_server_setup.vs_host, "x-forwarded-proto": "http"},
+                              allow_redirects=False)
+        assert resp_1.status_code == 308, "Expected: a redirect for x-forwarded-proto=http"
+        assert resp_2.status_code == 308, "Expected: a redirect for x-forwarded-proto=http"
+
+        resp_3 = requests.get(virtual_server_setup.backend_1_url_ssl,
+                              headers={"host": virtual_server_setup.vs_host, "x-forwarded-proto": "http"},
+                              allow_redirects=False, verify=False)
+        resp_4 = requests.get(virtual_server_setup.backend_2_url_ssl,
+                              headers={"host": virtual_server_setup.vs_host, "x-forwarded-proto": "http"},
+                              allow_redirects=False, verify=False)
+        assert resp_3.status_code == 404, "Expected: 404 for x-forwarded-proto=http and scheme=https"
+        assert resp_4.status_code == 404, "Expected: 404 for x-forwarded-proto=http and scheme=https"
+
+        resp_5 = requests.get(virtual_server_setup.backend_1_url,
+                              headers={"host": virtual_server_setup.vs_host, "x-forwarded-proto": "https"},
+                              allow_redirects=False)
+        resp_6 = requests.get(virtual_server_setup.backend_2_url,
+                              headers={"host": virtual_server_setup.vs_host, "x-forwarded-proto": "https"},
+                              allow_redirects=False)
+        assert resp_5.status_code == 200, "Expected: no redirect for x-forwarded-proto=https"
+        assert resp_6.status_code == 200, "Expected: no redirect for x-forwarded-proto=https"
+
+        resp_7 = requests.get(virtual_server_setup.backend_1_url_ssl,
+                              headers={"host": virtual_server_setup.vs_host, "x-forwarded-proto": "https"},
+                              allow_redirects=False, verify=False)
+        resp_8 = requests.get(virtual_server_setup.backend_2_url_ssl,
+                              headers={"host": virtual_server_setup.vs_host, "x-forwarded-proto": "https"},
+                              allow_redirects=False, verify=False)
+        assert resp_7.status_code == 404, "Expected: no redirect for x-forwarded-proto=https and scheme=https"
+        assert resp_8.status_code == 404, "Expected: no redirect for x-forwarded-proto=https and scheme=https"


### PR DESCRIPTION
Cover the case for TLS Redirect when TLS Termination is not configured and add additional assert for resulting config.