### PR TITLE
Remove testing namespaces in the end of test-run, improve stability.

### DIFF
--- a/tests/suite/resources_utils.py
+++ b/tests/suite/resources_utils.py
@@ -649,10 +649,24 @@ def delete_namespace(v1: CoreV1Api, namespace) -> None:
     print(f"Delete a namespace: {namespace}")
     delete_options = client.V1DeleteOptions()
     delete_options.grace_period_seconds = 0
-    delete_options.propagation_policy = 'Foreground'
+    delete_options.propagation_policy = 'Background'
     v1.delete_namespace(namespace, delete_options)
     ensure_item_removal(v1.read_namespace, namespace)
     print(f"Namespace was removed with name '{namespace}'")
+
+
+def delete_testing_namespaces(v1: CoreV1Api) -> []:
+    """
+    List and remove all the testing namespaces.
+
+    Testing namespaces are the ones starting with "test-namespace-"
+
+    :param v1: CoreV1Api
+    :return:
+    """
+    namespaces_list = v1.list_namespace()
+    for namespace in list(filter(lambda ns: ns.metadata.name.startswith("test-namespace-"), namespaces_list.items)):
+        delete_namespace(v1, namespace.metadata.name)
 
 
 def get_file_contents(v1: CoreV1Api, file_path, pod_name, pod_namespace) -> str:

--- a/tests/suite/test_v_s_route_split_traffic.py
+++ b/tests/suite/test_v_s_route_split_traffic.py
@@ -3,6 +3,7 @@ import requests
 import yaml
 
 from settings import TEST_DATA
+from suite.resources_utils import ensure_response_from_backend
 from suite.yaml_utils import get_paths_from_vsr_yaml
 
 
@@ -47,6 +48,7 @@ class TestVSRTrafficSplitting:
     def test_several_requests(self, kube_apis, crd_ingress_controller, v_s_route_setup, v_s_route_app_setup):
         split_path = get_paths_from_vsr_yaml(f"{TEST_DATA}/virtual-server-route-split-traffic/route-multiple.yaml")
         req_url = f"http://{v_s_route_setup.public_endpoint.public_ip}:{v_s_route_setup.public_endpoint.port}{split_path[0]}"
+        ensure_response_from_backend(req_url, v_s_route_setup.vs_host)
         weights = get_weights_of_splitting(
             f"{TEST_DATA}/virtual-server-route-split-traffic/route-multiple.yaml")
         upstreams = get_upstreams_of_splitting(

--- a/tests/suite/test_virtual_server_split_traffic.py
+++ b/tests/suite/test_virtual_server_split_traffic.py
@@ -4,6 +4,7 @@ import requests
 import yaml
 
 from settings import TEST_DATA
+from suite.resources_utils import ensure_response_from_backend
 
 
 def get_weights_of_splitting(file) -> []:
@@ -46,6 +47,7 @@ def get_upstreams_of_splitting(file) -> []:
                          indirect=True)
 class TestTrafficSplitting:
     def test_several_requests(self, kube_apis, crd_ingress_controller, virtual_server_setup):
+        ensure_response_from_backend(virtual_server_setup.backend_1_url, virtual_server_setup.vs_host)
         weights = get_weights_of_splitting(
             f"{TEST_DATA}/virtual-server-split-traffic/standard/virtual-server.yaml")
         upstreams = get_upstreams_of_splitting(


### PR DESCRIPTION
Each test creates a namespace of its won. After this all the test-namespaces will be removed in the end of the test-run (previously: after each test).