### PR TITLE
Fix tests for DaemonSet test-run

### DIFF
--- a/tests/suite/resources_utils.py
+++ b/tests/suite/resources_utils.py
@@ -227,6 +227,18 @@ def are_all_pods_in_ready_state(v1: CoreV1Api, namespace) -> bool:
     return pod_ready_amount == len(pods.items)
 
 
+def get_pods_amount(v1: CoreV1Api, namespace) -> int:
+    """
+    Get an amount of pods.
+
+    :param v1: CoreV1Api
+    :param namespace: namespace
+    :return: int
+    """
+    pods = v1.list_namespaced_pod(namespace)
+    return 0 if not pods.items else len(pods.items)
+
+
 def create_service_from_yaml(v1: CoreV1Api, namespace, yaml_manifest) -> str:
     """
     Create a service based on yaml file.

--- a/tests/suite/test_virtual_server_validation.py
+++ b/tests/suite/test_virtual_server_validation.py
@@ -5,14 +5,14 @@ from settings import TEST_DATA
 from suite.custom_assertions import assert_vs_conf_not_exists, assert_vs_conf_exists
 from suite.custom_resources_utils import patch_virtual_server_from_yaml,\
     delete_virtual_server, create_virtual_server_from_yaml
-from suite.resources_utils import wait_before_test, get_events, get_first_pod_name
+from suite.resources_utils import wait_before_test, get_events, get_first_pod_name, get_pods_amount
 
 
-def assert_reject_event_emitted(virtual_server_setup, new_list, previous_list):
+def assert_reject_events_emitted(virtual_server_setup, new_list, previous_list, expected_amount):
     item_name = f"{virtual_server_setup.namespace}/{virtual_server_setup.vs_name}"
     text_invalid = f"VirtualServer {item_name} is invalid and was rejected"
     new_event = new_list[len(new_list) - 1]
-    assert len(new_list) - len(previous_list) == 1
+    assert len(new_list) - len(previous_list) == expected_amount
     assert text_invalid in new_event.message
 
 
@@ -45,10 +45,11 @@ def assert_response_404(virtual_server_setup):
                          indirect=True)
 class TestVirtualServerValidation:
     def test_virtual_server_behavior(self,
-                                     kube_apis,
+                                     kube_apis, cli_arguments,
                                      ingress_controller_prerequisites,
                                      crd_ingress_controller,
                                      virtual_server_setup):
+        ic_pods_amount = get_pods_amount(kube_apis.v1, ingress_controller_prerequisites.namespace)
         ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
 
         print("Step 1: initial check")
@@ -64,7 +65,7 @@ class TestVirtualServerValidation:
                                        virtual_server_setup.namespace)
         wait_before_test(1)
         step_2_list = get_events(kube_apis.v1, virtual_server_setup.namespace)
-        assert_reject_event_emitted(virtual_server_setup, step_2_list, step_1_list)
+        assert_reject_events_emitted(virtual_server_setup, step_2_list, step_1_list, ic_pods_amount)
         assert_vs_conf_not_exists(kube_apis, ic_pod_name, ingress_controller_prerequisites.namespace,
                                   virtual_server_setup)
         assert_response_404(virtual_server_setup)
@@ -76,7 +77,7 @@ class TestVirtualServerValidation:
                                        virtual_server_setup.namespace)
         wait_before_test(1)
         step_3_list = get_events(kube_apis.v1, virtual_server_setup.namespace)
-        assert_reject_event_emitted(virtual_server_setup, step_3_list, step_2_list)
+        assert_reject_events_emitted(virtual_server_setup, step_3_list, step_2_list, ic_pods_amount)
         assert_vs_conf_not_exists(kube_apis, ic_pod_name, ingress_controller_prerequisites.namespace,
                                   virtual_server_setup)
         assert_response_404(virtual_server_setup)
@@ -100,7 +101,7 @@ class TestVirtualServerValidation:
                                         virtual_server_setup.namespace)
         wait_before_test(1)
         step_5_list = get_events(kube_apis.v1, virtual_server_setup.namespace)
-        assert_reject_event_emitted(virtual_server_setup, step_5_list, step_4_list)
+        assert_reject_events_emitted(virtual_server_setup, step_5_list, step_4_list, ic_pods_amount)
         assert_vs_conf_not_exists(kube_apis, ic_pod_name, ingress_controller_prerequisites.namespace,
                                   virtual_server_setup)
         assert_response_404(virtual_server_setup)


### PR DESCRIPTION
There is a difference in the amount of events generated for VS when there are 3 pods (DaemonSet) and 1 pod (Deployment). Take that into account in the tests.