### PR TITLE
Add pod PriorityClass support

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -112,6 +112,7 @@ Parameter | Description | Default
 `controller.nginxStatus.enable` | Enable the NGINX stub_status, or the NGINX Plus API. | true
 `controller.nginxStatus.port` | Set the port where the NGINX stub_status or the NGINX Plus API is exposed. | 8080
 `controller.nginxStatus.allowCidrs` | Whitelist IPv4 IP/CIDR blocks to allow access to NGINX stub_status or the NGINX Plus API. Separate multiple IP/CIDR by commas. | 127.0.0.1
+`controller.priorityClassName` | The PriorityClass of the Ingress controller pods. | None
 `controller.service.create` | Creates a service to expose the Ingress controller pods. | true
 `controller.service.type` | The type of service to create for the Ingress controller. | LoadBalancer
 `controller.service.externalTrafficPolicy` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | Local

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -39,6 +39,9 @@ spec:
       affinity:
 {{ toYaml .Values.controller.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName }}
+{{- end }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
       containers:
       - name: {{ include "nginx-ingress.name" . }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -38,6 +38,9 @@ spec:
       affinity:
 {{ toYaml .Values.controller.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName }}
+{{- end }}
       serviceAccountName: {{ include "nginx-ingress.serviceAccountName" . }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
       containers:

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -209,6 +209,9 @@ controller:
     ## The annotations of the Ingress Controller pod.
     annotations: {}
 
+  ## The PriorityClass of the ingress controller pods.
+  priorityClassName:
+
 rbac:
   ## Configures RBAC.
   create: true


### PR DESCRIPTION
### Proposed changes
PriorityClass for pods is a stable feature since Kubernetes 1.14
It will be useful to have it available to configure priorities for ingress controller. 