### PR TITLE
Add a test for the Prometheus Exporter in IC

### DIFF
--- a/tests/data/common/service/loadbalancer-with-additional-ports.yaml
+++ b/tests/data/common/service/loadbalancer-with-additional-ports.yaml
@@ -4,7 +4,8 @@ metadata:
   name: nginx-ingress
   namespace: nginx-ingress
 spec:
-  type: NodePort 
+  externalTrafficPolicy: Local
+  type: LoadBalancer
   ports:
   - port: 80
     targetPort: 80
@@ -18,5 +19,9 @@ spec:
     targetPort: 8080
     protocol: TCP
     name: api
+  - port: 9113
+    targetPort: 9113
+    protocol: TCP
+    name: exporter
   selector:
     app: nginx-ingress

--- a/tests/data/common/service/nodeport-with-additional-ports.yaml
+++ b/tests/data/common/service/nodeport-with-additional-ports.yaml
@@ -4,8 +4,7 @@ metadata:
   name: nginx-ingress
   namespace: nginx-ingress
 spec:
-  externalTrafficPolicy: Local
-  type: LoadBalancer
+  type: NodePort 
   ports:
   - port: 80
     targetPort: 80
@@ -19,5 +18,9 @@ spec:
     targetPort: 8080
     protocol: TCP
     name: api
+  - port: 9113
+    targetPort: 9113
+    protocol: TCP
+    name: exporter
   selector:
     app: nginx-ingress

--- a/tests/suite/resources_utils.py
+++ b/tests/suite/resources_utils.py
@@ -286,19 +286,21 @@ def create_service_with_name(v1: CoreV1Api, namespace, name) -> str:
         return create_service(v1, namespace, dep)
 
 
-def get_service_node_ports(v1: CoreV1Api, name, namespace) -> (int, int, int):
+def get_service_node_ports(v1: CoreV1Api, name, namespace) -> (int, int, int, int):
     """
     Get service allocated node_ports.
 
     :param v1: CoreV1Api
     :param name:
     :param namespace:
-    :return: (plain_port, ssl_port, api_port)
+    :return: (plain_port, ssl_port, api_port, exporter_port)
     """
     resp = v1.read_namespaced_service(name, namespace)
-    assert len(resp.spec.ports) == 3, "An unexpected amount of ports in a service. Check the configuration"
+    assert len(resp.spec.ports) == 4, "An unexpected amount of ports in a service. Check the configuration"
     print(f"Service with an API port: {resp.spec.ports[2].node_port}")
-    return resp.spec.ports[0].node_port, resp.spec.ports[1].node_port, resp.spec.ports[2].node_port
+    print(f"Service with an Exporter port: {resp.spec.ports[3].node_port}")
+    return resp.spec.ports[0].node_port, resp.spec.ports[1].node_port,\
+        resp.spec.ports[2].node_port, resp.spec.ports[3].node_port
 
 
 def wait_for_public_ip(v1: CoreV1Api, namespace: str) -> str:

--- a/tests/suite/test_prometheus_exporter.py
+++ b/tests/suite/test_prometheus_exporter.py
@@ -1,0 +1,57 @@
+import pytest
+import requests
+
+from kubernetes.client import V1ContainerPort
+
+from suite.resources_utils import wait_until_all_pods_are_ready, ensure_connection
+
+
+@pytest.fixture(scope="class")
+def enable_exporter_port(cli_arguments, kube_apis,
+                         ingress_controller_prerequisites, ingress_controller) -> None:
+    """
+    Set containerPort for Prometheus Exporter.
+
+    :param cli_arguments: context
+    :param kube_apis: client apis
+    :param ingress_controller_prerequisites
+    :param ingress_controller: IC name
+    :return:
+    """
+    namespace = ingress_controller_prerequisites.namespace
+    port = V1ContainerPort(9113, None, None, "prometheus", 'TCP')
+    print("------------------------- Enable 9113 port in IC -----------------------------------")
+    body = kube_apis.apps_v1_api.read_namespaced_deployment(ingress_controller, namespace)
+    body.spec.template.spec.containers[0].ports.append(port)
+
+    if cli_arguments['deployment-type'] == 'deployment':
+        kube_apis.apps_v1_api.patch_namespaced_deployment(ingress_controller, namespace, body)
+    else:
+        kube_apis.apps_v1_api.patch_namespaced_daemon_set(ingress_controller, namespace, body)
+    wait_until_all_pods_are_ready(kube_apis.v1, namespace)
+
+
+@pytest.mark.ingresses
+@pytest.mark.smoke
+@pytest.mark.parametrize('ingress_controller, expected_metrics',
+                         [
+                             pytest.param({"extra_args": ["-enable-prometheus-metrics"]},
+                                          ['nginx_ingress_controller_nginx_reload_errors_total{class="nginx"} 0',
+                                           'nginx_ingress_controller_ingress_resources_total{class="nginx",type="master"} 0',
+                                           'nginx_ingress_controller_ingress_resources_total{class="nginx",type="minion"} 0',
+                                           'nginx_ingress_controller_ingress_resources_total{class="nginx",type="regular"} 0',
+                                           'nginx_ingress_controller_nginx_last_reload_milliseconds',
+                                           'nginx_ingress_controller_nginx_last_reload_status{class="nginx"} 1',
+                                           'nginx_ingress_controller_nginx_reload_errors_total{class="nginx"} 0',
+                                           'nginx_ingress_controller_nginx_reloads_total{class="nginx"}'])
+                          ],
+                         indirect=["ingress_controller"])
+class TestPrometheusExporter:
+    def test_metrics(self, ingress_controller_endpoint, ingress_controller, enable_exporter_port, expected_metrics):
+        req_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
+        ensure_connection(req_url, 200)
+        resp = requests.get(req_url)
+        assert resp.status_code == 200, f"Expected 200 code for /metrics but got {resp.status_code}"
+        resp_content = resp.content.decode('utf-8')
+        for item in expected_metrics:
+            assert item in resp_content


### PR DESCRIPTION
Include exporter port (9113) into common LB/NodePort. Automate a "smoke" test for Prometheus Exporter in IC.