### PR TITLE
Ensure clean up in fixtures and fix condition

### DIFF
--- a/tests/suite/resources_utils.py
+++ b/tests/suite/resources_utils.py
@@ -425,8 +425,8 @@ def ensure_item_removal(get_item, *args, **kwargs) -> None:
             get_item(*args, **kwargs)
             counter = counter + 1
         if counter >= 30:
-            # Due to k8s issue with namespaces, they sometimes stuck in Terminating state, skip such cases
-            if "namespace" in str(get_item):
+            # Due to k8s issue with namespaces, they sometimes get stuck in Terminating state, skip such cases
+            if "_namespace " in str(get_item):
                 print(f"Failed to remove namespace '{args}' after 30 seconds, skip removal. Remove manually.")
             else:
                 pytest.fail("Failed to remove the item after 30 seconds")


### PR DESCRIPTION
Pytest fixtures work in such a way that if an exception occurs during fixture creation the finalizer doesn't start. Handle this case and ensure clean-up. 

Fix removal condition for namespace removal.