### PR TITLE
Ensure clean up in fixtures and fix condition

### DIFF
--- a/tests/suite/fixtures.py
+++ b/tests/suite/fixtures.py
@@ -8,9 +8,10 @@ import yaml
 from kubernetes import config, client
 from kubernetes.client import CoreV1Api, ExtensionsV1beta1Api, RbacAuthorizationV1beta1Api, CustomObjectsApi, \
     ApiextensionsV1beta1Api, AppsV1Api
+from kubernetes.client.rest import ApiException
 
-from suite.custom_resources_utils import create_crds_from_yaml, delete_crd, create_virtual_server_from_yaml, \
-    delete_virtual_server, create_v_s_route_from_yaml, delete_v_s_route
+from suite.custom_resources_utils import create_crds_from_yaml, create_virtual_server_from_yaml, \
+    delete_virtual_server, create_v_s_route_from_yaml, delete_v_s_route, delete_crds_from_yaml
 from suite.kube_config_utils import ensure_context_in_config, get_current_context_name
 from suite.resources_utils import create_namespace_with_name_from_yaml, delete_namespace, create_ns_and_sa_from_yaml, \
     patch_rbac, create_example_app, wait_until_all_pods_are_ready, delete_common_app, \
@@ -133,6 +134,7 @@ def ingress_controller(cli_arguments, kube_apis, ingress_controller_prerequisite
     :return:
     """
     namespace = ingress_controller_prerequisites.namespace
+    name = "nginx-ingress"
     print("------------------------- Create IC without CRDs -----------------------------------")
     try:
         extra_args = request.param.get('extra_args', None)
@@ -140,7 +142,12 @@ def ingress_controller(cli_arguments, kube_apis, ingress_controller_prerequisite
     except AttributeError:
         print("IC will start with CRDs disabled and without any additional cli-arguments")
         extra_args = ["-enable-custom-resources=false"]
-    name = create_ingress_controller(kube_apis.v1, kube_apis.apps_v1_api, cli_arguments, namespace, extra_args)
+    try:
+        name = create_ingress_controller(kube_apis.v1, kube_apis.apps_v1_api, cli_arguments, namespace, extra_args)
+    except ApiException as ex:
+        # Finalizer doesn't start if fixture creation was incomplete, ensure clean up here
+        print(f"Failed to complete IC fixture: {ex}\nClean up the cluster as much as possible.")
+        delete_ingress_controller(kube_apis.apps_v1_api, name, cli_arguments['deployment-type'], namespace)
 
     def fin():
         print("Delete IC:")
@@ -291,27 +298,37 @@ def crd_ingress_controller(cli_arguments, kube_apis, ingress_controller_prerequi
     :return:
     """
     namespace = ingress_controller_prerequisites.namespace
-    print("------------------------- Update ClusterRole -----------------------------------")
-    if request.param['type'] == 'rbac-without-vs':
-        patch_rbac(kube_apis.rbac_v1_beta1, f"{TEST_DATA}/virtual-server/rbac-without-vs.yaml")
-    print("------------------------- Register CRD -----------------------------------")
-    crd_names = create_crds_from_yaml(kube_apis.api_extensions_v1_beta1,
-                                      f"{DEPLOYMENTS}/common/custom-resource-definitions.yaml")
-    print("------------------------- Create IC -----------------------------------")
-    name = create_ingress_controller(kube_apis.v1, kube_apis.apps_v1_api, cli_arguments, namespace,
-                                     request.param.get('extra_args', None))
-    ensure_connection_to_public_endpoint(ingress_controller_endpoint.public_ip,
-                                         ingress_controller_endpoint.port,
-                                         ingress_controller_endpoint.port_ssl)
-
-    def fin():
-        for crd_name in crd_names:
-            print("Remove the CRD:")
-            delete_crd(kube_apis.api_extensions_v1_beta1, crd_name)
-        print("Remove the IC:")
-        delete_ingress_controller(kube_apis.apps_v1_api, name, cli_arguments['deployment-type'], namespace)
+    name = "nginx-ingress"
+    try:
+        print("------------------------- Update ClusterRole -----------------------------------")
+        if request.param['type'] == 'rbac-without-vs':
+            patch_rbac(kube_apis.rbac_v1_beta1, f"{TEST_DATA}/virtual-server/rbac-without-vs.yaml")
+        print("------------------------- Register CRD -----------------------------------")
+        create_crds_from_yaml(kube_apis.api_extensions_v1_beta1,
+                              f"{DEPLOYMENTS}/common/custom-resource-definitions.yaml")
+        print("------------------------- Create IC -----------------------------------")
+        name = create_ingress_controller(kube_apis.v1, kube_apis.apps_v1_api, cli_arguments, namespace,
+                                         request.param.get('extra_args', None))
+        ensure_connection_to_public_endpoint(ingress_controller_endpoint.public_ip,
+                                             ingress_controller_endpoint.port,
+                                             ingress_controller_endpoint.port_ssl)
+    except ApiException as ex:
+        # Finalizer method doesn't start if fixture creation was incomplete, ensure clean up here
+        print(f"Failed to complete CRD IC fixture: {ex}\nClean up the cluster as much as possible.")
+        delete_crds_from_yaml(kube_apis.api_extensions_v1_beta1,
+                              f"{DEPLOYMENTS}/common/custom-resource-definitions.yaml")
         print("Restore the ClusterRole:")
         patch_rbac(kube_apis.rbac_v1_beta1, f"{DEPLOYMENTS}/rbac/rbac.yaml")
+        print("Remove the IC:")
+        delete_ingress_controller(kube_apis.apps_v1_api, name, cli_arguments['deployment-type'], namespace)
+
+    def fin():
+        delete_crds_from_yaml(kube_apis.api_extensions_v1_beta1,
+                              f"{DEPLOYMENTS}/common/custom-resource-definitions.yaml")
+        print("Restore the ClusterRole:")
+        patch_rbac(kube_apis.rbac_v1_beta1, f"{DEPLOYMENTS}/rbac/rbac.yaml")
+        print("Remove the IC:")
+        delete_ingress_controller(kube_apis.apps_v1_api, name, cli_arguments['deployment-type'], namespace)
 
     request.addfinalizer(fin)
 

--- a/tests/suite/resources_utils.py
+++ b/tests/suite/resources_utils.py
@@ -411,8 +411,8 @@ def ensure_item_removal(get_item, *args, **kwargs) -> None:
             get_item(*args, **kwargs)
             counter = counter + 1
         if counter >= 30:
-            # Due to k8s issue with namespaces, they sometimes stuck in Terminating state, skip such cases
-            if "namespace" in str(get_item):
+            # Due to k8s issue with namespaces, they sometimes get stuck in Terminating state, skip such cases
+            if "_namespace " in str(get_item):
                 print(f"Failed to remove namespace '{args}' after 30 seconds, skip removal. Remove manually.")
             else:
                 pytest.fail("Failed to remove the item after 30 seconds")


### PR DESCRIPTION
This is to keep up with the improvements in master: pytest fixtures work in such a way that if an exception occurs during fixture creation the finalizer doesn't start. Handle this case and ensure clean-up. Also fix removal condition for namespace removal.