### PR TITLE
Add default-server-access-log-off to configmap

### DIFF
--- a/docs-web/configuration/global-configuration/configmap-resource.md
+++ b/docs-web/configuration/global-configuration/configmap-resource.md
@@ -198,6 +198,10 @@ See the doc about [VirtualServer and VirtualServerRoute resources](/nginx-ingres
      - Disables the `access log <http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log>`_.
      - ``False``
      - 
+   * - ``default-server-access-log-off``
+     - Disables the `access log <http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log>`_ for the default server. If access log is disabled globally (``access-log-off: "True"``), then the default server access log is always disabled.
+     - ``False``
+     - 
    * - ``log-format``
      - Sets the custom `log format <http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format>`_.
      - See the `template file <https://github.com/nginxinc/kubernetes-ingress/blob/master/internal/configs/version1/nginx.tmpl>`_ for the access log.

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -3,83 +3,84 @@ package configs
 // ConfigParams holds NGINX configuration parameters that affect the main NGINX config
 // as well as configs for Ingress resources.
 type ConfigParams struct {
-	LocationSnippets              []string
-	ServerSnippets                []string
-	ServerTokens                  string
-	ProxyConnectTimeout           string
-	ProxyReadTimeout              string
-	ProxySendTimeout              string
 	ClientMaxBodySize             string
-	HTTP2                         bool
-	RedirectToHTTPS               bool
-	SSLRedirect                   bool
-	MainMainSnippets              []string
-	MainHTTPSnippets              []string
-	MainStreamSnippets            []string
-	MainServerNamesHashBucketSize string
-	MainServerNamesHashMaxSize    string
-	MainAccessLogOff              bool
-	MainLogFormat                 []string
-	MainLogFormatEscaping         string
-	MainErrorLogLevel             string
-	MainStreamLogFormat           []string
-	MainStreamLogFormatEscaping   string
-	ProxyBuffering                bool
-	ProxyBuffers                  string
-	ProxyBufferSize               string
-	ProxyMaxTempFileSize          string
-	ProxyProtocol                 bool
-	ProxyHideHeaders              []string
-	ProxyPassHeaders              []string
-	UpstreamZoneSize              string
-	HSTS                          bool
-	HSTSBehindProxy               bool
-	HSTSMaxAge                    int64
-	HSTSIncludeSubdomains         bool
-	LBMethod                      string
-	MainWorkerProcesses           string
-	MainWorkerCPUAffinity         string
-	MainWorkerShutdownTimeout     string
-	MainWorkerConnections         string
-	MainWorkerRlimitNofile        string
-	Keepalive                     int
-	MaxFails                      int
-	MaxConns                      int
+	DefaultServerAccessLogOff     bool
 	FailTimeout                   string
 	HealthCheckEnabled            bool
 	HealthCheckMandatory          bool
 	HealthCheckMandatoryQueue     int64
-	SlowStart                     string
-	ResolverAddresses             []string
-	ResolverIPV6                  bool
-	ResolverValid                 string
-	ResolverTimeout               string
-	MainKeepaliveTimeout          string
+	HSTS                          bool
+	HSTSBehindProxy               bool
+	HSTSIncludeSubdomains         bool
+	HSTSMaxAge                    int64
+	HTTP2                         bool
+	Keepalive                     int
+	LBMethod                      string
+	LocationSnippets              []string
+	MainAccessLogOff              bool
+	MainErrorLogLevel             string
+	MainHTTPSnippets              []string
 	MainKeepaliveRequests         int64
-	VariablesHashBucketSize       uint64
-	VariablesHashMaxSize          uint64
-	MainOpenTracingLoadModule     bool
+	MainKeepaliveTimeout          string
+	MainLogFormat                 []string
+	MainLogFormatEscaping         string
+	MainMainSnippets              []string
 	MainOpenTracingEnabled        bool
+	MainOpenTracingLoadModule     bool
 	MainOpenTracingTracer         string
 	MainOpenTracingTracerConfig   string
+	MainServerNamesHashBucketSize string
+	MainServerNamesHashMaxSize    string
+	MainStreamLogFormat           []string
+	MainStreamLogFormatEscaping   string
+	MainStreamSnippets            []string
+	MainWorkerConnections         string
+	MainWorkerCPUAffinity         string
+	MainWorkerProcesses           string
+	MainWorkerRlimitNofile        string
+	MainWorkerShutdownTimeout     string
+	MaxConns                      int
+	MaxFails                      int
+	ProxyBuffering                bool
+	ProxyBuffers                  string
+	ProxyBufferSize               string
+	ProxyConnectTimeout           string
+	ProxyHideHeaders              []string
+	ProxyMaxTempFileSize          string
+	ProxyPassHeaders              []string
+	ProxyProtocol                 bool
+	ProxyReadTimeout              string
+	ProxySendTimeout              string
+	RedirectToHTTPS               bool
+	ResolverAddresses             []string
+	ResolverIPV6                  bool
+	ResolverTimeout               string
+	ResolverValid                 string
+	ServerSnippets                []string
+	ServerTokens                  string
+	SlowStart                     string
+	SSLRedirect                   bool
+	UpstreamZoneSize              string
+	VariablesHashBucketSize       uint64
+	VariablesHashMaxSize          uint64
 
 	RealIPHeader    string
-	SetRealIPFrom   []string
 	RealIPRecursive bool
+	SetRealIPFrom   []string
 
-	MainServerSSLProtocols           string
-	MainServerSSLPreferServerCiphers bool
 	MainServerSSLCiphers             string
 	MainServerSSLDHParam             string
 	MainServerSSLDHParamFileContent  *string
+	MainServerSSLPreferServerCiphers bool
+	MainServerSSLProtocols           string
 
-	MainTemplate    *string
 	IngressTemplate *string
+	MainTemplate    *string
 
-	JWTRealm    string
 	JWTKey      string
-	JWTToken    string
 	JWTLoginURL string
+	JWTRealm    string
+	JWTToken    string
 
 	Ports    []int
 	SSLPorts []int

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -237,6 +237,14 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool) *ConfigParams {
 		}
 	}
 
+	if defaultServerAccessLogOff, exists, err := GetMapKeyAsBool(cfgm.Data, "default-server-access-log-off", cfgm); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfgParams.DefaultServerAccessLogOff = defaultServerAccessLogOff
+		}
+	}
+
 	if proxyBuffering, exists, err := GetMapKeyAsBool(cfgm.Data, "proxy-buffering", cfgm); exists {
 		if err != nil {
 			glog.Error(err)
@@ -451,47 +459,48 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool) *ConfigParams {
 // GenerateNginxMainConfig generates MainConfig.
 func GenerateNginxMainConfig(staticCfgParams *StaticConfigParams, config *ConfigParams) *version1.MainConfig {
 	nginxCfg := &version1.MainConfig{
+		AccessLogOff:                   config.MainAccessLogOff,
+		DefaultServerAccessLogOff:      config.DefaultServerAccessLogOff,
+		ErrorLogLevel:                  config.MainErrorLogLevel,
 		HealthStatus:                   staticCfgParams.HealthStatus,
 		HealthStatusURI:                staticCfgParams.HealthStatusURI,
+		HTTP2:                          config.HTTP2,
+		HTTPSnippets:                   config.MainHTTPSnippets,
+		KeepaliveRequests:              config.MainKeepaliveRequests,
+		KeepaliveTimeout:               config.MainKeepaliveTimeout,
+		LogFormat:                      config.MainLogFormat,
+		LogFormatEscaping:              config.MainLogFormatEscaping,
+		MainSnippets:                   config.MainMainSnippets,
 		NginxStatus:                    staticCfgParams.NginxStatus,
 		NginxStatusAllowCIDRs:          staticCfgParams.NginxStatusAllowCIDRs,
 		NginxStatusPort:                staticCfgParams.NginxStatusPort,
-		StubStatusOverUnixSocketForOSS: staticCfgParams.StubStatusOverUnixSocketForOSS,
-		MainSnippets:                   config.MainMainSnippets,
-		HTTPSnippets:                   config.MainHTTPSnippets,
-		StreamSnippets:                 config.MainStreamSnippets,
+		OpenTracingEnabled:             config.MainOpenTracingEnabled,
+		OpenTracingLoadModule:          config.MainOpenTracingLoadModule,
+		OpenTracingTracer:              config.MainOpenTracingTracer,
+		OpenTracingTracerConfig:        config.MainOpenTracingTracerConfig,
+		ProxyProtocol:                  config.ProxyProtocol,
+		ResolverAddresses:              config.ResolverAddresses,
+		ResolverIPV6:                   config.ResolverIPV6,
+		ResolverTimeout:                config.ResolverTimeout,
+		ResolverValid:                  config.ResolverValid,
 		ServerNamesHashBucketSize:      config.MainServerNamesHashBucketSize,
 		ServerNamesHashMaxSize:         config.MainServerNamesHashMaxSize,
-		AccessLogOff:                   config.MainAccessLogOff,
-		LogFormat:                      config.MainLogFormat,
-		LogFormatEscaping:              config.MainLogFormatEscaping,
-		ErrorLogLevel:                  config.MainErrorLogLevel,
-		StreamLogFormat:                config.MainStreamLogFormat,
-		StreamLogFormatEscaping:        config.MainStreamLogFormatEscaping,
-		SSLProtocols:                   config.MainServerSSLProtocols,
+		ServerTokens:                   config.ServerTokens,
 		SSLCiphers:                     config.MainServerSSLCiphers,
 		SSLDHParam:                     config.MainServerSSLDHParam,
 		SSLPreferServerCiphers:         config.MainServerSSLPreferServerCiphers,
-		HTTP2:                          config.HTTP2,
-		ServerTokens:                   config.ServerTokens,
-		ProxyProtocol:                  config.ProxyProtocol,
-		WorkerProcesses:                config.MainWorkerProcesses,
-		WorkerCPUAffinity:              config.MainWorkerCPUAffinity,
-		WorkerShutdownTimeout:          config.MainWorkerShutdownTimeout,
-		WorkerConnections:              config.MainWorkerConnections,
-		WorkerRlimitNofile:             config.MainWorkerRlimitNofile,
-		ResolverAddresses:              config.ResolverAddresses,
-		ResolverIPV6:                   config.ResolverIPV6,
-		ResolverValid:                  config.ResolverValid,
-		ResolverTimeout:                config.ResolverTimeout,
-		KeepaliveTimeout:               config.MainKeepaliveTimeout,
-		KeepaliveRequests:              config.MainKeepaliveRequests,
+		SSLProtocols:                   config.MainServerSSLProtocols,
+		StreamLogFormat:                config.MainStreamLogFormat,
+		StreamLogFormatEscaping:        config.MainStreamLogFormatEscaping,
+		StreamSnippets:                 config.MainStreamSnippets,
+		StubStatusOverUnixSocketForOSS: staticCfgParams.StubStatusOverUnixSocketForOSS,
 		VariablesHashBucketSize:        config.VariablesHashBucketSize,
 		VariablesHashMaxSize:           config.VariablesHashMaxSize,
-		OpenTracingLoadModule:          config.MainOpenTracingLoadModule,
-		OpenTracingEnabled:             config.MainOpenTracingEnabled,
-		OpenTracingTracer:              config.MainOpenTracingTracer,
-		OpenTracingTracerConfig:        config.MainOpenTracingTracerConfig,
+		WorkerConnections:              config.MainWorkerConnections,
+		WorkerCPUAffinity:              config.MainWorkerCPUAffinity,
+		WorkerProcesses:                config.MainWorkerProcesses,
+		WorkerRlimitNofile:             config.MainWorkerRlimitNofile,
+		WorkerShutdownTimeout:          config.MainWorkerShutdownTimeout,
 	}
 	return nginxCfg
 }

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -124,47 +124,48 @@ type Location struct {
 
 // MainConfig describe the main NGINX configuration file.
 type MainConfig struct {
-	ServerNamesHashBucketSize      string
-	ServerNamesHashMaxSize         string
 	AccessLogOff                   bool
-	LogFormat                      []string
-	LogFormatEscaping              string
+	DefaultServerAccessLogOff      bool
 	ErrorLogLevel                  string
-	StreamLogFormat                []string
-	StreamLogFormatEscaping        string
 	HealthStatus                   bool
 	HealthStatusURI                string
+	HTTP2                          bool
+	HTTPSnippets                   []string
+	KeepaliveRequests              int64
+	KeepaliveTimeout               string
+	LogFormat                      []string
+	LogFormatEscaping              string
+	MainSnippets                   []string
 	NginxStatus                    bool
 	NginxStatusAllowCIDRs          []string
 	NginxStatusPort                int
-	StubStatusOverUnixSocketForOSS bool
-	MainSnippets                   []string
-	HTTPSnippets                   []string
-	StreamSnippets                 []string
-	SSLProtocols                   string
-	SSLPreferServerCiphers         bool
-	SSLCiphers                     string
-	SSLDHParam                     string
-	HTTP2                          bool
-	ServerTokens                   string
-	ProxyProtocol                  bool
-	WorkerProcesses                string
-	WorkerCPUAffinity              string
-	WorkerShutdownTimeout          string
-	WorkerConnections              string
-	WorkerRlimitNofile             string
-	ResolverAddresses              []string
-	ResolverIPV6                   bool
-	ResolverValid                  string
-	ResolverTimeout                string
-	KeepaliveTimeout               string
-	KeepaliveRequests              int64
-	VariablesHashBucketSize        uint64
-	VariablesHashMaxSize           uint64
-	OpenTracingLoadModule          bool
 	OpenTracingEnabled             bool
+	OpenTracingLoadModule          bool
 	OpenTracingTracer              string
 	OpenTracingTracerConfig        string
+	ProxyProtocol                  bool
+	ResolverAddresses              []string
+	ResolverIPV6                   bool
+	ResolverTimeout                string
+	ResolverValid                  string
+	ServerNamesHashBucketSize      string
+	ServerNamesHashMaxSize         string
+	ServerTokens                   string
+	SSLCiphers                     string
+	SSLDHParam                     string
+	SSLPreferServerCiphers         bool
+	SSLProtocols                   string
+	StreamLogFormat                []string
+	StreamLogFormatEscaping        string
+	StreamSnippets                 []string
+	StubStatusOverUnixSocketForOSS bool
+	VariablesHashBucketSize        uint64
+	VariablesHashMaxSize           uint64
+	WorkerConnections              string
+	WorkerCPUAffinity              string
+	WorkerProcesses                string
+	WorkerRlimitNofile             string
+	WorkerShutdownTimeout          string
 }
 
 // NewUpstreamWithDefaultServer creates an upstream with the default server.

--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -102,7 +102,9 @@ http {
 
         server_name _;
         server_tokens "{{.ServerTokens}}";
+        {{if .DefaultServerAccessLogOff}}
         access_log off;
+        {{end}}
 
         {{if .OpenTracingEnabled}}
         opentracing off;

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -96,7 +96,9 @@ http {
 
         server_name _;
         server_tokens "{{.ServerTokens}}";
+        {{if .DefaultServerAccessLogOff}}
         access_log off;
+        {{end}}
 
         {{if .OpenTracingEnabled}}
         opentracing off;


### PR DESCRIPTION
### Proposed changes
This PR adds a new ConfigMap `default-server-access-log-off` that enables/disables logging for the default server.
If logging is disabled at the `http` level, logging for the default server is always disabled.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
