### PR TITLE
Update debian base image to buster

### DIFF
--- a/build/DockerfileForPlus
+++ b/build/DockerfileForPlus
@@ -1,10 +1,10 @@
 ARG GOLANG_CONTAINER=golang:latest
 
-FROM debian:stretch-slim AS base
+FROM debian:buster-slim AS base
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_PLUS_VERSION 20-1~stretch
+ENV NGINX_PLUS_VERSION 20-1~buster
 ARG IC_VERSION
 
 # Download certificate and key from the customer portal (https://cs.nginx.com)
@@ -36,7 +36,7 @@ RUN set -x \
 	&& echo "Acquire::https::plus-pkgs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90nginx \
 	&& echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
 	&& echo "Acquire::https::plus-pkgs.nginx.com::User-Agent  \"k8s-ic-$IC_VERSION-apt\";" >> /etc/apt/apt.conf.d/90nginx \
-	&& printf "deb https://plus-pkgs.nginx.com/debian stretch nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
+	&& printf "deb https://plus-pkgs.nginx.com/debian buster nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
 	&& apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION} \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \

--- a/build/DockerfileWithOpentracing
+++ b/build/DockerfileWithOpentracing
@@ -49,7 +49,7 @@ RUN set -x \
 	&& cp objs/ngx_http_opentracing_module.so /ngx_http_opentracing_module.so
 
 
-FROM debian:stretch-slim AS tracer-downloader
+FROM debian:buster-slim AS tracer-downloader
 ARG JAEGER_VERSION=v0.4.2
 RUN set -x \
 	&& apt-get update \

--- a/build/DockerfileWithOpentracingForPlus
+++ b/build/DockerfileWithOpentracingForPlus
@@ -1,6 +1,6 @@
 ARG GOLANG_CONTAINER=golang:latest
 
-FROM debian:stretch-slim AS tracer-downloader
+FROM debian:buster-slim AS tracer-downloader
 ARG JAEGER_VERSION=v0.4.2
 
 RUN set -x \
@@ -9,11 +9,11 @@ RUN set -x \
 	&& wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/${JAEGER_VERSION}/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so
 
 # Final Image
-FROM debian:stretch-slim AS base
+FROM debian:buster-slim AS base
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_PLUS_VERSION 20-1~stretch
-ENV NGINX_OPENTRACING_MODULE_VERSION 20+0.9.0-1~stretch
+ENV NGINX_PLUS_VERSION 20-1~buster
+ENV NGINX_OPENTRACING_MODULE_VERSION 20+0.9.0-1~buster
 
 ARG IC_VERSION
 
@@ -46,7 +46,7 @@ RUN set -x \
 	&& echo "Acquire::https::plus-pkgs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90nginx \
 	&& echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
 	&& echo "Acquire::https::plus-pkgs.nginx.com::User-Agent  \"k8s-ic-$IC_VERSION-apt\";" >> /etc/apt/apt.conf.d/90nginx \
-	&& printf "deb https://plus-pkgs.nginx.com/debian stretch nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
+	&& printf "deb https://plus-pkgs.nginx.com/debian buster nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
 	&& apt-get update && apt-get install -y \
 	nginx-plus=${NGINX_PLUS_VERSION} \
 	# Install OpenTracing module


### PR DESCRIPTION
### Proposed changes
* Update images to use `debian:buster` base.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
