### PR TITLE
Add Openshift Dockerfile for NGINX Plus

### DIFF
--- a/build/openshift/DockerfileForPlus
+++ b/build/openshift/DockerfileForPlus
@@ -1,0 +1,94 @@
+ARG GOLANG_CONTAINER=registry.access.redhat.com/ubi8/go-toolset:latest
+
+FROM registry.access.redhat.com/ubi8/ubi:8.1 AS base
+
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
+
+ENV NGINX_PLUS_VERSION 20-1.el8.ngx
+ARG IC_VERSION
+
+# Download certificate and key from the customer portal (https://cs.nginx.com)
+# and copy to the build context
+RUN mkdir /etc/ssl/nginx/
+COPY nginx-repo.crt nginx-repo.key /etc/ssl/nginx/
+
+# Make sure the certificate and key have correct permissions
+RUN chmod 644 /etc/ssl/nginx/*
+
+# Install NGINX Plus
+RUN set -x \
+	&& groupadd --system --gid 101 nginx \
+	&& useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx \
+	&& yum install -y wget \
+	&& wget https://nginx.org/keys/nginx_signing.key \
+	&& \
+	NGINX_GPGKEY=nginx_signing.key; \
+	found=''; \
+	for server in \
+		ha.pool.sks-keyservers.net \
+		hkp://p80.pool.sks-keyservers.net:80 \
+		pgp.mit.edu \
+	; do \
+		echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
+		rpm --define="%_hkp_keyserver $server" --import $NGINX_GPGKEY && found=yes && break; \
+	done; \
+	test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
+	echo "[nginx-plus]" >> /etc/yum.repos.d/nginx-plus-8.repo \
+	&& echo "name=nginx-plus repo" >> /etc/yum.repos.d/nginx-plus-8.repo \
+	&& echo "baseurl=https://plus-pkgs.nginx.com/centos/8/\$basearch/" >> /etc/yum.repos.d/nginx-plus-8.repo \
+	&& echo "sslclientcert=/etc/ssl/nginx/nginx-repo.crt" >> /etc/yum.repos.d/nginx-plus-8.repo \
+	&& echo "sslclientkey=/etc/ssl/nginx/nginx-repo.key" >> /etc/yum.repos.d/nginx-plus-8.repo \
+	&& echo "gpgcheck=1" >> /etc/yum.repos.d/nginx-plus-8.repo \
+	&& echo "enabled=1" >> /etc/yum.repos.d/nginx-plus-8.repo \
+	&& yum install -y nginx-plus-${NGINX_PLUS_VERSION} \
+	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
+	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
+	&& yum remove -y wget \
+	&& rm -rf /etc/ssl/nginx \
+	&& rm /etc/yum.repos.d/nginx-plus-8.repo \
+	&& rm nginx_signing.key
+
+
+# forward nginx access and error logs to stdout and stderr of the ingress
+# controller process
+RUN ln -sf /proc/1/fd/1 /var/log/nginx/access.log \
+	&& ln -sf /proc/1/fd/1 /var/log/nginx/stream-access.log \
+	&& ln -sf /proc/1/fd/2 /var/log/nginx/error.log
+
+RUN mkdir -p /var/lib/nginx \
+	&& mkdir -p /etc/nginx/secrets \
+	&& chown -R nginx:0 /etc/nginx \
+	&& chown -R nginx:0 /var/cache/nginx \
+	&& chown -R nginx:0 /var/lib/nginx/ \
+	&& rm /etc/nginx/conf.d/*
+
+EXPOSE 80 443
+
+COPY internal/configs/version1/nginx-plus.ingress.tmpl \
+	internal/configs/version1/nginx-plus.tmpl \
+	internal/configs/version2/nginx-plus.virtualserver.tmpl /
+
+# Uncomment the line below if you would like to add the default.pem to the image
+# and use it as a certificate and key for the default server
+# ADD default.pem /etc/nginx/secrets/default
+
+USER nginx
+
+ENTRYPOINT ["/nginx-ingress"]
+
+
+FROM base AS local
+COPY nginx-ingress /
+
+
+FROM $GOLANG_CONTAINER AS builder
+ARG VERSION
+ARG GIT_COMMIT
+WORKDIR /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/cmd/nginx-ingress
+COPY . /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
+RUN CGO_ENABLED=0 GOFLAGS='-mod=vendor' \
+	go build -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /tmp/nginx-ingress
+
+
+FROM base AS container
+COPY --from=builder /tmp/nginx-ingress /

--- a/docs-web/installation/building-ingress-controller-image.md
+++ b/docs-web/installation/building-ingress-controller-image.md
@@ -64,12 +64,14 @@ The **Makefile** contains the following main variables for you to customize (eit
 * **VERSION** -- the current version of the controller.
 * **TAG** -- the tag added to the image. It's set to the value of the `VERSION` variable by default.
 * **PUSH_TO_GCR**. If you’re running your Kubernetes in GCE and using Google Container Registry, make sure that `PUSH_TO_GCR = 1`. This means using the `gcloud docker push` command to push the image, which is convenient when pushing images to GCR. By default, the variable is unset and the regular `docker push` command is used to push the image to the registry.
+* **DOCKERFILEPATH** -- the path to the Dockerfiles folder. The default is `build`.
 * **DOCKERFILE** -- the path to a Dockerfile. We provide five Dockerfiles:
   1. `Dockerfile`, for building a debian-based image with NGINX. It's used by default.
   1. `DockerfileForAlpine`, for building an alpine-based image with NGINX.
   1. `DockerfileForPlus`, for building an debian-based image with NGINX Plus.
   1. `DockerfileWithOpentracing`, for building a debian-based image with NGINX, [opentracing](https://github.com/opentracing-contrib/nginx-opentracing) module and the [Jaeger](https://www.jaegertracing.io/) tracer.
   1. `DockerfileWithOpentracingForPlus`, for building a debian-based image with NGINX Plus, [opentracing](https://github.com/opentracing-contrib/nginx-opentracing) module and the [Jaeger](https://www.jaegertracing.io/) tracer.
+  1. `openshift/DockerfileForPlus`, for building an ubi-based image with NGINX Plus for [Openshift](https://www.openshift.com/) clusters.
 * **GENERATE_DEFAULT_CERT_AND_KEY** - The Ingress controller requires a certificate and a key for the default HTTP/HTTPS server. You can reference them in a TLS Secret in a command-line argument to the Ingress controller. As an alternative, you can add a file in the PEM format with your certificate and key to the image as `/etc/nginx/secrets/default`. Optionally, you can generate a self-signed certificate and a key during the build process. Set `GENERATE_DEFAULT_CERT_AND_KEY` to `1` to generate a certificate and a key in the `default.pem` file. Note that you must add the `ADD` instruction in the Dockerfile to copy the cert and the key to the image. The default value of `GENERATE_DEFAULT_CERT_AND_KEY` is `0`.
 * **DOCKER_BUILD_OPTIONS** -- the [options](https://docs.docker.com/engine/reference/commandline/build/#options) for the `docker build` command. For example, `--pull`.
 * **BUILD_IN_CONTAINER** -- By default, to compile the controller we use the [golang](https://hub.docker.com/_/golang/) container that we run as part of the building process. If you want to compile the controller using your local golang environment:


### PR DESCRIPTION
### Proposed changes
This PR adds a new _DockerfileForPlus_ under the `build/openshift` folder. This Dockerfile is to build an ubi-based image for NGINX Plus. This is intended for Openshift clusters only. 
