### PR TITLE
Fix errorpages body yaml docs

### DIFF
--- a/docs-web/configuration/virtualserver-and-virtualserverroute-resources.md
+++ b/docs-web/configuration/virtualserver-and-virtualserverroute-resources.md
@@ -1024,7 +1024,8 @@ codes: [401, 403]
 return:
   code: 200
   type: application/json
-  body: "{\"msg\": \"You don't have permission to do this\"}"
+  body: |
+    {\"msg\": \"You don't have permission to do this\"}
   headers:
   - name: x-debug-original-statuses
     value: ${upstream_status}


### PR DESCRIPTION
### Proposed changes
The docs of the Body field for an Error Page are not correct. If you use the docs as it is, IC will fail validation because of the unescaped strings. Needs to be multiline.


