### PR TITLE
Add release-1.6 pipeline manifest

### DIFF
--- a/build/ci/Jenkinsfile
+++ b/build/ci/Jenkinsfile
@@ -1,7 +1,8 @@
 node {
   git(
     url: "${libsLocation}",
-    credentialsId: "${githubCreds}"
+    credentialsId: "${githubCreds}",
+    branch: "kubernetes-ingress-release-1.6"
   )
   load 'kubernetes-ingress/Jenkinsfile'
 }

--- a/build/ci/JenkinsfileForks
+++ b/build/ci/JenkinsfileForks
@@ -1,7 +1,8 @@
 node {
   git(
     url: "${libsLocation}",
-    credentialsId: "${githubCreds}"
+    credentialsId: "${githubCreds}",
+    branch: "kubernetes-ingress-release-1.6"
   )
   load 'kubernetes-ingress/JenkinsfileForks'
 }


### PR DESCRIPTION
### Proposed changes
Add a release-1.6 specific pipeline manifest to avoid unnecessary cherry picks from master.
