### PR TITLE
Update controller.go

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1438,6 +1438,9 @@ func (lbc *LoadBalancerController) createIngress(ing *extensions.Ingress) (*conf
 	for _, tls := range ing.Spec.TLS {
 		secretName := tls.SecretName
 		secretKey := ing.Namespace + "/" + secretName
+		if strings.Contains(secretName, "/") {
+			secretKey = secretName
+		}
 		secret, err := lbc.getAndValidateSecret(secretKey)
 		if err != nil {
 			glog.Warningf("Error trying to get the secret %v for Ingress %v: %v", secretName, ing.Name, err)


### PR DESCRIPTION
Allow to use tls secret from another namespace

### Proposed changes
Allow to set _secretName_ from another namespace
Example:

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: load-certificates
  namespace: default
spec:
  tls:
  - hosts:
    - "test.2.example.com"
    secretName: ingress-nginx/wild-second-domain-certs
  rules:
  - host: "test.2.example.com"
    http:
      paths:
      - backend:
          serviceName: my-service
          servicePort: 8080
        path: /
```

