### PR TITLE
Remove nginx binary call from Openshift Dockerfile

### DIFF
--- a/build/openshift/Dockerfile
+++ b/build/openshift/Dockerfile
@@ -22,7 +22,6 @@ RUN set -x \
 	&& echo "module_hotfixes=true" >> /etc/yum.repos.d/nginx.repo \
 	&& yum update -y \
 	&& yum install -y nginx-${NGINX_VERSION} \
-	&& nginx \
 	&& mkdir -p /var/lib/nginx \
 	&& mkdir -p /etc/nginx/secrets \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \


### PR DESCRIPTION
### Proposed changes
It was my understanding that base images we used for Debian already had this implemented, I know this is not a requirement to run the IC, but for consistency I decided to add the call to nginx process here.

It seems this is not the case, and nginx is not started (debian images use it as entrypoint, but because we use it as base image, entrypoint is not called).

So removing the unused call, which **could be useful for checking that nginx is installed properly**, but nothing else.

