### PR TITLE
Use a tmp folder for ubi Dockerfile due to permission issue

### DIFF
--- a/build/openshift/Dockerfile
+++ b/build/openshift/Dockerfile
@@ -65,8 +65,8 @@ ARG GIT_COMMIT
 WORKDIR /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/cmd/nginx-ingress
 COPY . /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
 RUN CGO_ENABLED=0 GOFLAGS='-mod=vendor' \
-	go build -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
+	go build -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /tmp/nginx-ingress
 
 
 FROM base AS container
-COPY --from=builder /nginx-ingress /
+COPY --from=builder /tmp/nginx-ingress /


### PR DESCRIPTION
### Proposed changes
Pipelines fail due to permissions in the image. This only happens in CI/CD that's why it was hard to spot.
