### PR TITLE
Skip verify-crds when building in a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ ifneq ($(BUILD_IN_CONTAINER),1)
 endif
 
 verify-crds:
+ifneq ($(BUILD_IN_CONTAINER),1)
 	./hack/verify-crds.sh
+endif
 
 update-codegen:
 	./hack/update-codegen.sh


### PR DESCRIPTION
### Proposed changes
* `BUILD_IN_CONTAINER=0` should be used for development. `make BUILD_IN_CONTAINER=1` can skip `verify-crds` for this reason. This makes the build faster.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
