### PR TITLE
Update OpenAPI validation to cover k8s 1.14 and 1.15

### DIFF
--- a/tests/suite/test_v_s_route.py
+++ b/tests/suite/test_v_s_route.py
@@ -339,7 +339,7 @@ class TestVirtualServerRouteValidation:
                                       route_yaml,
                                       v_s_route_setup.route_s.namespace)
         except ApiException as ex:
-            assert ex.status == 422 and "spec.subroutes.action.pass: Invalid value" in ex.body
+            assert ex.status == 422 and "spec.subroutes.action.pass" in ex.body
         except Exception as ex:
             pytest.fail(f"An unexpected exception is raised: {ex}")
         else:

--- a/tests/suite/test_v_s_route_canned_responses.py
+++ b/tests/suite/test_v_s_route_canned_responses.py
@@ -125,9 +125,9 @@ class TestVSRCannedResponses:
                                       v_s_route_setup.route_m.name, vsr_src, v_s_route_setup.namespace)
         except ApiException as ex:
             assert ex.status == 422 \
-                   and "spec.subroutes.action.return.type: Invalid value" in ex.body \
-                   and "spec.subroutes.action.return.body: Invalid value" in ex.body \
-                   and "spec.subroutes.action.return.code: Invalid value" in ex.body
+                   and "spec.subroutes.action.return.type" in ex.body \
+                   and "spec.subroutes.action.return.body" in ex.body \
+                   and "spec.subroutes.action.return.code" in ex.body
         except Exception as ex:
             pytest.fail(f"An unexpected exception is raised: {ex}")
         else:

--- a/tests/suite/test_v_s_route_error_pages.py
+++ b/tests/suite/test_v_s_route_error_pages.py
@@ -113,14 +113,14 @@ class TestVSRErrorPages:
                                       v_s_route_setup.route_m.namespace)
         except ApiException as ex:
             assert ex.status == 422 \
-                   and "spec.subroutes.errorPages.codes: Invalid value" in ex.body \
-                   and "spec.subroutes.errorPages.redirect.code: Invalid value" in ex.body \
-                   and "spec.subroutes.errorPages.redirect.url: Invalid value" in ex.body \
-                   and "spec.subroutes.errorPages.return.code: Invalid value" in ex.body \
-                   and "spec.subroutes.errorPages.return.type: Invalid value" in ex.body \
-                   and "spec.subroutes.errorPages.return.body: Invalid value" in ex.body \
-                   and "spec.subroutes.errorPages.return.headers.name: Invalid value" in ex.body \
-                   and "spec.subroutes.errorPages.return.headers.value: Invalid value" in ex.body
+                   and "spec.subroutes.errorPages.codes" in ex.body \
+                   and "spec.subroutes.errorPages.redirect.code" in ex.body \
+                   and "spec.subroutes.errorPages.redirect.url" in ex.body \
+                   and "spec.subroutes.errorPages.return.code" in ex.body \
+                   and "spec.subroutes.errorPages.return.type" in ex.body \
+                   and "spec.subroutes.errorPages.return.body" in ex.body \
+                   and "spec.subroutes.errorPages.return.headers.name" in ex.body \
+                   and "spec.subroutes.errorPages.return.headers.value" in ex.body
         except Exception as ex:
             pytest.fail(f"An unexpected exception is raised: {ex}")
         else:

--- a/tests/suite/test_v_s_route_redirects.py
+++ b/tests/suite/test_v_s_route_redirects.py
@@ -97,8 +97,8 @@ class TestVSRRedirects:
                                       v_s_route_setup.route_m.name, vsr_src, v_s_route_setup.namespace)
         except ApiException as ex:
             assert ex.status == 422 \
-                   and "spec.subroutes.action.redirect.url: Invalid value" in ex.body \
-                   and "spec.subroutes.action.redirect.code: Invalid value" in ex.body
+                   and "spec.subroutes.action.redirect.url" in ex.body \
+                   and "spec.subroutes.action.redirect.code" in ex.body
         except Exception as ex:
             pytest.fail(f"An unexpected exception is raised: {ex}")
         else:

--- a/tests/suite/test_virtual_server_canned_responses.py
+++ b/tests/suite/test_virtual_server_canned_responses.py
@@ -113,9 +113,9 @@ class TestVSCannedResponse:
                                            virtual_server_setup.namespace)
         except ApiException as ex:
             assert ex.status == 422 \
-                   and "spec.routes.action.return.type: Invalid value" in ex.body \
-                   and "spec.routes.action.return.body: Invalid value" in ex.body \
-                   and "spec.routes.action.return.code: Invalid value" in ex.body
+                   and "spec.routes.action.return.type" in ex.body \
+                   and "spec.routes.action.return.body" in ex.body \
+                   and "spec.routes.action.return.code" in ex.body
         except Exception as ex:
             pytest.fail(f"An unexpected exception is raised: {ex}")
         else:

--- a/tests/suite/test_virtual_server_error_pages.py
+++ b/tests/suite/test_virtual_server_error_pages.py
@@ -87,14 +87,14 @@ class TestVSErrorPages:
                                            virtual_server_setup.namespace)
         except ApiException as ex:
             assert ex.status == 422 \
-                   and "spec.routes.errorPages.codes: Invalid value" in ex.body \
-                   and "spec.routes.errorPages.redirect.code: Invalid value" in ex.body \
-                   and "spec.routes.errorPages.redirect.url: Invalid value" in ex.body \
-                   and "spec.routes.errorPages.return.code: Invalid value" in ex.body \
-                   and "spec.routes.errorPages.return.type: Invalid value" in ex.body \
-                   and "spec.routes.errorPages.return.body: Invalid value" in ex.body \
-                   and "spec.routes.errorPages.return.headers.name: Invalid value" in ex.body \
-                   and "spec.routes.errorPages.return.headers.value: Invalid value" in ex.body
+                   and "spec.routes.errorPages.codes" in ex.body \
+                   and "spec.routes.errorPages.redirect.code" in ex.body \
+                   and "spec.routes.errorPages.redirect.url" in ex.body \
+                   and "spec.routes.errorPages.return.code" in ex.body \
+                   and "spec.routes.errorPages.return.type" in ex.body \
+                   and "spec.routes.errorPages.return.body" in ex.body \
+                   and "spec.routes.errorPages.return.headers.name" in ex.body \
+                   and "spec.routes.errorPages.return.headers.value" in ex.body
         except Exception as ex:
             pytest.fail(f"An unexpected exception is raised: {ex}")
         else:

--- a/tests/suite/test_virtual_server_redirects.py
+++ b/tests/suite/test_virtual_server_redirects.py
@@ -88,8 +88,8 @@ class TestVSRedirects:
                                            virtual_server_setup.namespace)
         except ApiException as ex:
             assert ex.status == 422 \
-                   and "spec.routes.action.redirect.url: Invalid value" in ex.body \
-                   and "spec.routes.action.redirect.code: Invalid value" in ex.body
+                   and "spec.routes.action.redirect.url" in ex.body \
+                   and "spec.routes.action.redirect.code" in ex.body
         except Exception as ex:
             pytest.fail(f"An unexpected exception is raised: {ex}")
         else:


### PR DESCRIPTION
OpenApi validation message in k8s 1.14 (and 1.15) is slightly different from what the tests expect
Compare: k8s 1.17 "spec.subroutes.action.pass: Invalid value" and k8s 1.14 "spec.subroutes.action.pass in body must be of type string". Respect that in the tests.