### PR TITLE
Update rest of OpenAPI validation tests

### DIFF
--- a/tests/suite/test_v_s_route_upstream_tls.py
+++ b/tests/suite/test_v_s_route_upstream_tls.py
@@ -97,7 +97,7 @@ class TestVSRouteUpstreamTls:
                                       f"{TEST_DATA}/virtual-server-route-upstream-tls/route-single-invalid.yaml",
                                       v_s_route_setup.route_s.namespace)
         except ApiException as ex:
-            assert ex.status == 422 and "spec.upstreams.tls.enable: Invalid value" in ex.body
+            assert ex.status == 422 and "spec.upstreams.tls.enable" in ex.body
         except Exception as ex:
             pytest.fail(f"An unexpected exception is raised: {ex}")
         else:

--- a/tests/suite/test_virtual_server_tls_redirect.py
+++ b/tests/suite/test_virtual_server_tls_redirect.py
@@ -199,10 +199,10 @@ class TestVirtualServerTLSRedirect:
                                            virtual_server_setup.namespace)
         except ApiException as ex:
             assert ex.status == 422 \
-                   and "spec.tls.redirect.enable: Invalid value" in ex.body \
-                   and "spec.tls.redirect.code: Invalid value" in ex.body \
-                   and "spec.tls.redirect.basedOn: Invalid value" in ex.body \
-                   and "spec.tls.secret: Invalid value" in ex.body
+                   and "spec.tls.redirect.enable" in ex.body \
+                   and "spec.tls.redirect.code" in ex.body \
+                   and "spec.tls.redirect.basedOn" in ex.body \
+                   and "spec.tls.secret" in ex.body
         except Exception as ex:
             pytest.fail(f"An unexpected exception is raised: {ex}")
         else:

--- a/tests/suite/test_virtual_server_upstream_tls.py
+++ b/tests/suite/test_virtual_server_upstream_tls.py
@@ -50,7 +50,7 @@ class TestVirtualServerUpstreamTls:
                                            f"{TEST_DATA}/virtual-server-upstream-tls/virtual-server-invalid.yaml",
                                            virtual_server_setup.namespace)
         except ApiException as ex:
-            assert ex.status == 422 and "spec.upstreams.tls.enable: Invalid value" in ex.body
+            assert ex.status == 422 and "spec.upstreams.tls.enable" in ex.body
         except Exception as ex:
             pytest.fail(f"An unexpected exception is raised: {ex}")
         else:


### PR DESCRIPTION
There were 3 more failing tests after previous update. Fix them. This is already in 1.7-rc1.