### PR TITLE
Wrong link for status page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,3 +1,3 @@
 # Installing the Ingress Controller
 
-This doc is now available at https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-manifests/
+This doc is now available at https://docs.nginx.com/nginx-ingress-controller/logging-and-monitoring/status-page/


### PR DESCRIPTION
The status page port-forward link is incorrect, this is the right one.

### Proposed changes
Fixing incorrect link that a customer pointed out for NGINX Plus status page enable

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
