### PR TITLE
Update README with wrong link

### DIFF
--- a/examples/complete-example/README.md
+++ b/examples/complete-example/README.md
@@ -57,5 +57,5 @@ certificate and the --resolve option to set the Host header of a request with ``
     ```
 
 1. You can view an NGINX status page, either stub_status for NGINX, or the Live Activity Monitoring Dashboard for NGINX Plus:
-    1. Follow the [instructions](../../docs/installation.md#5-access-the-live-activity-monitoring-dashboard--stub_status-page) to access the status page.
+    1. Follow the [instructions](https://docs.nginx.com/nginx-ingress-controller/logging-and-monitoring/status-page/) to access the status page.
     1. For NGINX Plus, If you go to the Upstream tab, you'll see: ![dashboard](dashboard.png)


### PR DESCRIPTION
Wrong link for status page enable in the complete example

### Proposed changes
The link to enable the status page pointed to a non-existent section.  This updates the link to go to the right document.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
