### PR TITLE
Add Makefile for Netlify to use to build docs

### DIFF
--- a/docs-web/Makefile
+++ b/docs-web/Makefile
@@ -1,0 +1,29 @@
+NETLIFY_ROOT	=	/opt/build/repo
+SITE_ROOT			= ${NETLIFY_ROOT}/site
+BUILDDIR			= ${NETLIFY_ROOT}/docs-web/build
+THEME_REPO		= ${THEME_REPO_URL}
+#DOCKER_IMAGE 	=
+
+.PHONY: all build clean setup
+
+#help:
+
+all: clean setup build
+#docker-all: docker setup build
+
+clean:
+	rm -rf ${SITE_ROOT}
+
+setup:
+	mkdir ${SITE_ROOT}
+	@git clone -q --single-branch --branch master https://$(GITHUB_PAT)@${THEME_REPO} ${SITE_ROOT}/docs-nginx-com
+	pip install -r ${SITE_ROOT}/docs-nginx-com/requirements.txt
+	rsync -avOz ${NETLIFY_ROOT}/docs-web/ ${SITE_ROOT}/docs-nginx-com/source/nginx-ingress-controller/ --exclude ${NETLIFY_ROOT}/docs-web/.netlify --exclude ${NETLIFY_ROOT}/docs-web/Makefile
+
+build:
+	sphinx-build -b dirhtml -d ${BUILDDIR}/doctrees ${SITE_ROOT}/docs-nginx-com/source ${BUILDDIR}/dirhtml
+	@echo "Build finished. The HTML pages are in ${BUILDDIR}/dirhtml."
+
+#docker:
+
+#docker-serve:

--- a/docs-web/Makefile
+++ b/docs-web/Makefile
@@ -14,7 +14,7 @@ setup:
 	mkdir ${SITE_ROOT}
 	@git clone -q --single-branch --branch master https://$(GITHUB_PAT)@${THEME_REPO} ${SITE_ROOT}/docs-nginx-com
 	pip install -r ${SITE_ROOT}/docs-nginx-com/requirements.txt
-	rsync -avOz ${NETLIFY_ROOT}/docs-web/ ${SITE_ROOT}/docs-nginx-com/source/nginx-ingress-controller/ --exclude ${NETLIFY_ROOT}/docs-web/.netlify --exclude ${NETLIFY_ROOT}/docs-web/Makefile
+	rsync -avOz ${NETLIFY_ROOT}/docs-web/ ${SITE_ROOT}/docs-nginx-com/source/nginx-ingress-controller/ --exclude ${NETLIFY_ROOT}/docs-web/Makefile
 
 build:
 	sphinx-build -b dirhtml -d ${BUILDDIR}/doctrees ${SITE_ROOT}/docs-nginx-com/source ${BUILDDIR}/dirhtml

--- a/docs-web/Makefile
+++ b/docs-web/Makefile
@@ -1,15 +1,11 @@
-NETLIFY_ROOT	=	/opt/build/repo
-SITE_ROOT			= ${NETLIFY_ROOT}/site
-BUILDDIR			= ${NETLIFY_ROOT}/docs-web/build
-THEME_REPO		= ${THEME_REPO_URL}
-#DOCKER_IMAGE 	=
+NETLIFY_ROOT = /opt/build/repo
+SITE_ROOT = ${NETLIFY_ROOT}/site
+BUILDDIR = ${NETLIFY_ROOT}/docs-web/build
+THEME_REPO = ${THEME_REPO_URL}
 
 .PHONY: all build clean setup
 
-#help:
-
 all: clean setup build
-#docker-all: docker setup build
 
 clean:
 	rm -rf ${SITE_ROOT}
@@ -23,7 +19,3 @@ setup:
 build:
 	sphinx-build -b dirhtml -d ${BUILDDIR}/doctrees ${SITE_ROOT}/docs-nginx-com/source ${BUILDDIR}/dirhtml
 	@echo "Build finished. The HTML pages are in ${BUILDDIR}/dirhtml."
-
-#docker:
-
-#docker-serve:

--- a/docs-web/Makefile
+++ b/docs-web/Makefile
@@ -11,7 +11,7 @@ clean:
 	rm -rf ${SITE_ROOT}
 
 setup:
-	mkdir ${SITE_ROOT}
+	mkdir -p ${SITE_ROOT}
 	@git clone -q --single-branch --branch master https://$(GITHUB_PAT)@${THEME_REPO} ${SITE_ROOT}/docs-nginx-com
 	pip install -r ${SITE_ROOT}/docs-nginx-com/requirements.txt
 	rsync -avOz ${NETLIFY_ROOT}/docs-web/ ${SITE_ROOT}/docs-nginx-com/source/nginx-ingress-controller/ --exclude ${NETLIFY_ROOT}/docs-web/Makefile


### PR DESCRIPTION
### Proposed changes

This pull request sets up the repo to use Netlify to build and host deploy previews for the IC documentation.

Next steps:
- Netlify support will activate automatic builds for this repo once this addition is merged to master.
- Netlify will automatically build docs and create deploy previews for all pull requests into master and release branches.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ N/A] I have added tests that prove my fix is effective or that my feature works
- [ N/A] I have checked that all unit tests pass after adding my changes
- [N/A ] I have updated necessary documentation
- [ x] I have rebased my branch onto master
- [ x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
