### PR TITLE
Remove upgrade of packages in Dockerfile for ubi

### DIFF
--- a/build/openshift/Dockerfile
+++ b/build/openshift/Dockerfile
@@ -20,7 +20,6 @@ RUN set -x \
 	&& echo "gpgcheck=0" >> /etc/yum.repos.d/nginx.repo \
 	&& echo "enabled=1" >> /etc/yum.repos.d/nginx.repo \
 	&& echo "module_hotfixes=true" >> /etc/yum.repos.d/nginx.repo \
-	&& yum update -y \
 	&& yum install -y nginx-${NGINX_VERSION} \
 	&& mkdir -p /var/lib/nginx \
 	&& mkdir -p /etc/nginx/secrets \


### PR DESCRIPTION
### Proposed changes
The problem is, RH packages are not reliable and might cause problems (like today). We really don't need to upgrade packages (we don't do this in any of the other dockerfiles). Removing the upgrade. 