### PR TITLE
set up netlify deploys for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ default.pem
 
 # Platform specific CRD schema generation scripts
 hack/controller-gen-*
+
+# Ignore local docs dependencies
+docs-web/.netlify/state.json
+site/
+venv/

--- a/docs-web/Makefile
+++ b/docs-web/Makefile
@@ -1,0 +1,21 @@
+NETLIFY_ROOT = /opt/build/repo
+SITE_ROOT = ${NETLIFY_ROOT}/site
+BUILDDIR = ${NETLIFY_ROOT}/docs-web/build
+THEME_REPO = ${THEME_REPO_URL}
+
+.PHONY: all build clean setup
+
+all: clean setup build
+
+clean:
+	rm -rf ${SITE_ROOT}
+
+setup:
+	mkdir ${SITE_ROOT}
+	@git clone -q --single-branch --branch master https://$(GITHUB_PAT)@${THEME_REPO} ${SITE_ROOT}/docs-nginx-com
+	pip install -r ${SITE_ROOT}/docs-nginx-com/requirements.txt
+	rsync -avOz ${NETLIFY_ROOT}/docs-web/ ${SITE_ROOT}/docs-nginx-com/source/nginx-ingress-controller/ --exclude ${NETLIFY_ROOT}/docs-web/Makefile
+
+build:
+	sphinx-build -b dirhtml -d ${BUILDDIR}/doctrees ${SITE_ROOT}/docs-nginx-com/source ${BUILDDIR}/dirhtml
+	@echo "Build finished. The HTML pages are in ${BUILDDIR}/dirhtml."


### PR DESCRIPTION
### Proposed changes

This pull request sets up the repo to use Netlify to build and host deploy previews for the IC documentation.

Details:

- Netlify will automatically build docs and create deploy previews for pull requests, commits to master, and commits to release branches from this repo. **Pull requests from forks will not be built automatically**, but they can be built with site owner approval.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have rebased my branch onto master
- [ N/A ] I have added tests that prove my fix is effective or that my feature works
- [ N/A ] I have checked that all unit tests pass after adding my changes
- [ N/A ] I have updated necessary documentation
- [N/A] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork

Related MR: https://github.com/nginxinc/kubernetes-ingress/pull/933