### PR TITLE
Set up Netlify builds to use dev resources so the site doesn't look like docs.nginx.com

### DIFF
--- a/docs-web/Makefile
+++ b/docs-web/Makefile
@@ -14,7 +14,10 @@ setup:
 	mkdir ${SITE_ROOT}
 	@git clone -q --single-branch --branch master https://$(GITHUB_PAT)@${THEME_REPO} ${SITE_ROOT}/docs-nginx-com
 	pip install -r ${SITE_ROOT}/docs-nginx-com/requirements.txt
-	rsync -avOz ${NETLIFY_ROOT}/docs-web/ ${SITE_ROOT}/docs-nginx-com/source/nginx-ingress-controller/ --exclude ${NETLIFY_ROOT}/docs-web/Makefile
+	rsync -avOz ${NETLIFY_ROOT}/docs-web/ ${SITE_ROOT}/docs-nginx-com/source/nginx-ingress-controller/ --exclude ${NETLIFY_ROOT}/docs-web/Makefile --exclude ${NETLIFY_ROOT}/docs-web/_source
+	cp ${NETLIFY_ROOT}/docs-web/_source/home_page_body.html ${SITE_ROOT}/docs-nginx-com/_themes/docs-theme/includes/home_page_body.html
+	cp ${NETLIFY_ROOT}/docs-web/_source/dev-home.txt ${SITE_ROOT}/docs-nginx-com/source/index.rst
+	cp ${NETLIFY_ROOT}/docs-web/_source/dev-home.txt ${SITE_ROOT}/docs-nginx-com/source/home.rst
 
 build:
 	sphinx-build -b dirhtml -d ${BUILDDIR}/doctrees ${SITE_ROOT}/docs-nginx-com/source ${BUILDDIR}/dirhtml

--- a/docs-web/_source/dev-home.txt
+++ b/docs-web/_source/dev-home.txt
@@ -1,0 +1,18 @@
+.. meta::
+   :description: This is the development documentation for NGINX Ingress Controller.
+
+NGINX Ingress Controller Development Documentation
+==================================================
+
+Welcome to the development documentation for NGINX Ingress Controller. This documentation represents content under review or in a pre-release status. 
+
+To view the production documentation, please visit https://docs.nginx.com/nginx-ingress-controller.
+
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 1
+
+   nginx-ingress-controller/index
+   

--- a/docs-web/_source/home_page_body.html
+++ b/docs-web/_source/home_page_body.html
@@ -1,0 +1,20 @@
+<div class="nginx-doc-content">
+  <div class="nginx-doc-content-inner">
+    
+    <div class="nginx-doc-content-menu">
+			<h2>Welcome to the development documentation for NGINX Ingress Controller.</h2> 
+			<p>This documentation represents content under review or in a pre-release status. 
+			<br>
+			   To view the production documentation, please visit <a href="https://docs.nginx.com/nginx-ingress-controller" target="_blank" alt="NGINX Ingress Controller Documentation on docs.nginx.com">https://docs.nginx.com/nginx-ingress-controller</a>.</p>
+		<div class="product-list-17-col">
+		  <div class="product-17-icon"><img src="_static/images/icons/NGINX-product-icon.svg" alt="NGINX and NGINX Plus Ingress Controller for Kubernetes"></div>
+		  <div class="product-17-details">
+			<h3>NGINX Ingress Controller</h3>
+			<p>NGINX and NGINX Plus Ingress Controller for Kubernetes</p>
+			<a href="nginx-ingress-controller/" class="learn-more-link">View docs</a>
+      </div>
+	  </div> <!-- nginx-doc-menu-block1 -->
+    </div> <!-- nginx-doc-content-menu -->
+
+  </div> <!-- nginx-doc-content-inner -->
+</div>


### PR DESCRIPTION

### Proposed changes

Now that we have the Netlify builds working, we need to use a different landing page so the site doesn't get confused with docs.nginx.com. This PR contains resources and updates to the docs Makefile to achieve this goal.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ n/a] I have added tests that prove my fix is effective or that my feature works
- [ x] I have checked that all unit tests pass after adding my changes
- [ x] I have updated necessary documentation
- [ x] I have rebased my branch onto master
- [n/a ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
