### PR TITLE
Fix error logging of master/minion ingresses

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -603,7 +603,7 @@ func (lbc *LoadBalancerController) GetManagedIngresses() ([]extensions.Ingress, 
 		if isMinion(&ing) {
 			master, err := lbc.FindMasterForMinion(&ing)
 			if err != nil {
-				glog.Errorf("Ignoring Ingress %v(Minion): %v", ing, err)
+				glog.Errorf("Ignoring Ingress %v(Minion): %v", ing.Name, err)
 				continue
 			}
 			if !lbc.configurator.HasIngress(master) {
@@ -612,7 +612,7 @@ func (lbc *LoadBalancerController) GetManagedIngresses() ([]extensions.Ingress, 
 			if _, exists := mergeableIngresses[master.Name]; !exists {
 				mergeableIngress, err := lbc.createMergableIngresses(master)
 				if err != nil {
-					glog.Errorf("Ignoring Ingress %v(Master): %v", master, err)
+					glog.Errorf("Ignoring Ingress %v(Master): %v", master.Name, err)
 					continue
 				}
 				mergeableIngresses[master.Name] = mergeableIngress
@@ -1294,7 +1294,7 @@ func (lbc *LoadBalancerController) createIngresses(ings []extensions.Ingress) (r
 			}
 			mergeableIng, err := lbc.createMergableIngresses(master)
 			if err != nil {
-				glog.Errorf("Ignoring Ingress %v(Master): %v", master, err)
+				glog.Errorf("Ignoring Ingress %v(Master): %v", master.Name, err)
 				continue
 			}
 


### PR DESCRIPTION
### Bug

Under certain conditions of invalid minions/master ingress the entire struct is logged out instead of just the name.

Case1.
* Minons present with no master deployed

Case2.
* Master in an undesirable state. Multiple Hosts, etc.

```
1 controller.go:607] 
Ignoring Ingress {{ } {cafe-ingress-tea-minion  default /apis/extensions/v1beta1/namespaces/default/ingresses/cafe-ingress-tea-minion 2e3abe60-716a-4e7f-bae6-9ebee0bca5d7 1934716 1 2020-05-15 13:41:37 +0000 UTC <nil> <nil> map[] map[kubernetes.io/ingress.class:nginx nginx.org/mergeable-ingress-type:minion] [] []  [{kubectl Update extensions/v1beta1 2020-05-15 13:41:37 +0000 UTC FieldsV1 &FieldsV1{Raw:*[123 34 102 58 109 101 116 97 100 97 116 97 34 58 123 34 102 58 97 110 110 111 116 97 116 105 111 110 115 34 58 123 34 46 34 58 123 125 44 34 102 58 107 117 98 101 114 110 101 116 101 115 46 105 111 47 105 110 103 114 101 115 115 46 99 108 97 115 115 34 58 123 125 44 34 102 58 110 103 105 110 120 46 111 114 103 47 109 101 114 103 101 97 98 108 101 45 105 110 103 114 101 115 115 45 116 121 112 101 34 58 123 125 125 125 44 34 102 58 115 112 101 99 34 58 123 34 102 58 114 117 108 101 115 34 58 123 125 125 125],}}]} {<nil> nil [] [{cafe.example.com {&HTTPIngressRuleValue{Paths:[]HTTPIngressPath{HTTPIngressPath{Path:/tea,Backend:IngressBackend{ServiceName:tea-svc,ServicePort:{0 80 },Resource:nil,},PathType:*ImplementationSpecific,},},}}}]} {{[]}}}(Minion): 
Could not find a Master for Minion: 'default/cafe-ingress-tea-minion'
```


### Proposed changes

If you deploy a master ingress with no minion. It logs the entire Ingress name.
```
Ignoring Ingress cafe-ingress-tea-minion(Minion): 
Could not find a Master for Minion: 'default/cafe-ingress-tea-minion'
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
