### PR TITLE
Enable leader election as default

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -101,8 +101,8 @@ var (
 	reportIngressStatus = flag.Bool("report-ingress-status", false,
 		"Update the address field in the status of Ingresses resources. Requires the -external-service flag, or the 'external-status-address' key in the ConfigMap.")
 
-	leaderElectionEnabled = flag.Bool("enable-leader-election", false,
-		"Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress, VirtualServer and VirtualServerRoute resources -- only one replica will report status. See -report-ingress-status flag.")
+	leaderElectionEnabled = flag.Bool("enable-leader-election", true,
+		"Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress, VirtualServer and VirtualServerRoute resources -- only one replica will report status (default true). See -report-ingress-status flag.")
 
 	leaderElectionLockName = flag.String("leader-election-lock-name", "nginx-ingress-leader-election",
 		`Specifies the name of the ConfigMap, within the same namespace as the controller, used as the lock for leader election. Requires -enable-leader-election.`)

--- a/deployments/daemon-set/nginx-ingress.yaml
+++ b/deployments/daemon-set/nginx-ingress.yaml
@@ -52,6 +52,5 @@ spec:
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress
-         #- -enable-leader-election
          #- -enable-prometheus-metrics
          #- -global-configuration=$(POD_NAMESPACE)/nginx-configuration

--- a/deployments/daemon-set/nginx-plus-ingress.yaml
+++ b/deployments/daemon-set/nginx-plus-ingress.yaml
@@ -53,6 +53,5 @@ spec:
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress
-         #- -enable-leader-election
          #- -enable-prometheus-metrics
          #- -global-configuration=$(POD_NAMESPACE)/nginx-configuration

--- a/deployments/deployment/nginx-ingress.yaml
+++ b/deployments/deployment/nginx-ingress.yaml
@@ -51,6 +51,5 @@ spec:
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress
-         #- -enable-leader-election
          #- -enable-prometheus-metrics
          #- -global-configuration=$(POD_NAMESPACE)/nginx-configuration

--- a/deployments/deployment/nginx-plus-ingress.yaml
+++ b/deployments/deployment/nginx-plus-ingress.yaml
@@ -52,6 +52,5 @@ spec:
          #- -v=3 # Enables extensive logging. Useful for troubleshooting.
          #- -report-ingress-status
          #- -external-service=nginx-ingress
-         #- -enable-leader-election
          #- -enable-prometheus-metrics
          #- -global-configuration=$(POD_NAMESPACE)/nginx-configuration

--- a/docs-web/configuration/global-configuration/command-line-arguments.md
+++ b/docs-web/configuration/global-configuration/command-line-arguments.md
@@ -31,7 +31,7 @@ Below we describe the available command-line arguments:
 
 .. option:: -enable-leader-election
 
-	Enables Leader election to avoid multiple replicas of the controller reporting the status of Ingress, VirtualServer and VirtualServerRoute resources -- only one replica will report status.
+	Enables Leader election to avoid multiple replicas of the controller reporting the status of Ingress, VirtualServer and VirtualServerRoute resources -- only one replica will report status (default true).
 
 	See :option:`-report-ingress-status` flag.
 

--- a/docs-web/configuration/global-configuration/reporting-resources-status.md
+++ b/docs-web/configuration/global-configuration/reporting-resources-status.md
@@ -17,9 +17,6 @@ The Ingress controller must be configured to report an Ingress status:
 2. Define a source for an external address. This can be either of:
     1. A user defined address, specified in the `external-status-address` ConfigMap key.
     2. A Service of the type LoadBalancer configured with an external IP or address and specified by the `-external-service` command-line flag.
-3. If you're running multiple replicas of the Ingress controller, enable leader election with the `-enable-leader-election` flag
-to ensure that only one replica updates an Ingress status.
-4. By default, the Ingress controller will use a ConfigMap with the name `nginx-ingress-leader-election` as the lock. This can be customised via the `-leader-election-lock-name` flag.
 
 See the docs about [ConfigMap keys](/nginx-ingress-controller/configuration/global-configuration/configmap-resource) and [Command-line arguments](/nginx-ingress-controller/configuration/global-configuration/command-line-arguments).
 
@@ -110,9 +107,6 @@ The Ingress controller must be configured to report a VirtualServer or VirtualSe
 1. If you want the Ingress controller to report the `externalEndpoints`, define a source for an external address (Note: the rest of the fields will be reported without the external address configured). This can be either of:
     1. A user defined address, specified in the `external-status-address` ConfigMap key.
     2. A Service of the type LoadBalancer configured with an external IP or address and specified by the `-external-service` command-line flag.
-1. If you're running multiple replicas of the Ingress controller, enable leader election with the `-enable-leader-election` flag
-to ensure that only one replica updates an Ingress status.
-1. By default, the Ingress controller will use a ConfigMap with the name `nginx-ingress-leader-election` as the lock. This can be customised via the `-leader-election-lock-name` flag.
 
 See the docs about [ConfigMap keys](/nginx-ingress-controller/configuration/global-configuration/configmap-resource) and [Command-line arguments](/nginx-ingress-controller/configuration/global-configuration/command-line-arguments).
 


### PR DESCRIPTION
### Proposed changes
With the new feature in https://github.com/nginxinc/kubernetes-ingress/pull/973, it is required to have leader election to avoid multiple replicas to try to update the VS/VSR status.

When the KIC is deployed using Helm, `leaderElection` is enabled by default. With this change, we do the same when the users deploy the KIC manually deploying the manifests.