### PR TITLE
Update vs/vsr status when IC becomes the leader

### DIFF
--- a/deployments/helm-chart/templates/rbac.yaml
+++ b/deployments/helm-chart/templates/rbac.yaml
@@ -49,6 +49,7 @@ rules:
   verbs:
   - create
   - patch
+  - list
 - apiGroups:
   - extensions
   resources:

--- a/deployments/rbac/rbac.yaml
+++ b/deployments/rbac/rbac.yaml
@@ -44,6 +44,7 @@ rules:
   verbs:
   - create
   - patch
+  - list
 - apiGroups:
   - extensions
   resources:

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -219,7 +219,7 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 		}
 	}
 
-	if input.ReportIngressStatus && input.IsLeaderElectionEnabled {
+	if input.IsLeaderElectionEnabled {
 		lbc.addLeaderHandler(createLeaderHandler(lbc))
 	}
 

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1409,6 +1409,8 @@ func getStatusFromEventTitle(eventTitle string) string {
 	case "AddedOrUpdated", "Updated":
 		return conf_v1.StateValid
 	}
+
+	return ""
 }
 
 func (lbc *LoadBalancerController) updateVirtualServersStatusFromEvents() error {
@@ -1424,7 +1426,7 @@ func (lbc *LoadBalancerController) updateVirtualServersStatusFromEvents() error 
 		}
 
 		if len(events.Items) == 0 {
-			break
+			continue
 		}
 
 		var timestamp time.Time
@@ -1443,7 +1445,7 @@ func (lbc *LoadBalancerController) updateVirtualServersStatusFromEvents() error 
 	return nil
 }
 
-func (lbc *LoadBalancerController) updateVirtualServerRoutessStatusFromEvents() error {
+func (lbc *LoadBalancerController) updateVirtualServerRoutesStatusFromEvents() error {
 	var allErrs []error
 	for _, obj := range lbc.virtualServerRouteLister.List() {
 		vsr := obj.(*conf_v1.VirtualServerRoute)
@@ -1456,7 +1458,7 @@ func (lbc *LoadBalancerController) updateVirtualServerRoutessStatusFromEvents() 
 		}
 
 		if len(events.Items) == 0 {
-			break
+			continue
 		}
 
 		var timestamp time.Time

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -1630,3 +1630,62 @@ func TestGetEndpointsBySubselectedPods(t *testing.T) {
 		})
 	}
 }
+
+func TestGetStatusFromEventTitle(t *testing.T) {
+	tests := []struct {
+		eventTitle string
+		expected   string
+	}{
+		{
+			eventTitle: "",
+			expected:   "Unknown",
+		},
+		{
+			eventTitle: "AddedOrUpdatedWithError",
+			expected:   "Invalid",
+		},
+		{
+			eventTitle: "Rejected",
+			expected:   "Invalid",
+		},
+		{
+			eventTitle: "NoVirtualServersFound",
+			expected:   "Invalid",
+		},
+		{
+			eventTitle: "Missing Secret",
+			expected:   "Invalid",
+		},
+		{
+			eventTitle: "UpdatedWithError",
+			expected:   "Invalid",
+		},
+		{
+			eventTitle: "AddedOrUpdatedWithWarning",
+			expected:   "Warning",
+		},
+		{
+			eventTitle: "UpdatedWithWarning",
+			expected:   "Warning",
+		},
+		{
+			eventTitle: "AddedOrUpdated",
+			expected:   "Valid",
+		},
+		{
+			eventTitle: "Updated",
+			expected:   "Valid",
+		},
+		{
+			eventTitle: "New State",
+			expected:   "Unknown",
+		},
+	}
+
+	for _, test := range tests {
+		result := getStatusFromEventTitle(test.eventTitle)
+		if result != test.expected {
+			t.Errorf("getStatusFromEventTitle(%v) returned %v but expected %v", test.eventTitle, result, test.expected)
+		}
+	}
+}

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -1638,7 +1638,7 @@ func TestGetStatusFromEventTitle(t *testing.T) {
 	}{
 		{
 			eventTitle: "",
-			expected:   "Unknown",
+			expected:   "",
 		},
 		{
 			eventTitle: "AddedOrUpdatedWithError",
@@ -1678,7 +1678,7 @@ func TestGetStatusFromEventTitle(t *testing.T) {
 		},
 		{
 			eventTitle: "New State",
-			expected:   "Unknown",
+			expected:   "",
 		},
 	}
 

--- a/internal/k8s/leader.go
+++ b/internal/k8s/leader.go
@@ -60,15 +60,17 @@ func createLeaderHandler(lbc *LoadBalancerController) leaderelection.LeaderCallb
 				}
 			}
 
-			glog.V(3).Info("updating VirtualServer and VirtualServerRoutes status")
-			err := lbc.updateVirtualServersStatusFromEvents()
-			if err != nil {
-				glog.V(3).Infof("error updating VirtualServers status when starting leading: %v", err)
-			}
+			if lbc.areCustomResourcesEnabled {
+				glog.V(3).Info("updating VirtualServer and VirtualServerRoutes status")
+				err := lbc.updateVirtualServersStatusFromEvents()
+				if err != nil {
+					glog.V(3).Infof("error updating VirtualServers status when starting leading: %v", err)
+				}
 
-			err = lbc.updateVirtualServerRoutessStatusFromEvents()
-			if err != nil {
-				glog.V(3).Infof("error updating VirtualServerRoutes status when starting leading: %v", err)
+				err = lbc.updateVirtualServerRoutesStatusFromEvents()
+				if err != nil {
+					glog.V(3).Infof("error updating VirtualServerRoutes status when starting leading: %v", err)
+				}
 			}
 		},
 		OnStoppedLeading: func() {

--- a/internal/k8s/leader.go
+++ b/internal/k8s/leader.go
@@ -61,9 +61,14 @@ func createLeaderHandler(lbc *LoadBalancerController) leaderelection.LeaderCallb
 			}
 
 			glog.V(3).Info("updating VirtualServer and VirtualServerRoutes status")
-			err := lbc.updateVirtualServerVirtualServerRouteStatusesFromEvents()
+			err := lbc.updateVirtualServersStatusFromEvents()
 			if err != nil {
-				glog.V(3).Infof("error updating status when starting leading: %v", err)
+				glog.V(3).Infof("error updating VirtualServers status when starting leading: %v", err)
+			}
+
+			err = lbc.updateVirtualServerRoutessStatusFromEvents()
+			if err != nil {
+				glog.V(3).Infof("error updating VirtualServerRoutes status when starting leading: %v", err)
 			}
 		},
 		OnStoppedLeading: func() {


### PR DESCRIPTION
### Proposed changes
When updating VS and VSR statuses of created resources during a leading election process, those resources won't have their status updated until they're synced again and the KIC instance has become the leader.

With this change, KIC will trigger an update of all VS/VSR statuses based on their last event when the KIC becomes the leader.
