### PR TITLE
Remove $GOPATH of builder from logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endif
 
 binary:
 ifneq ($(BUILD_IN_CONTAINER),1)
-	CGO_ENABLED=0 GO111MODULE=on GOFLAGS='$(GOFLAGS)' GOOS=linux go build -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o nginx-ingress github.com/nginxinc/kubernetes-ingress/cmd/nginx-ingress
+	CGO_ENABLED=0 GO111MODULE=on GOFLAGS='$(GOFLAGS)' GOOS=linux go build -trimpath -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o nginx-ingress github.com/nginxinc/kubernetes-ingress/cmd/nginx-ingress
 endif
 
 container: test verify-codegen verify-crds binary certificate-and-key

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -46,7 +46,7 @@ ARG GIT_COMMIT
 WORKDIR /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/cmd/nginx-ingress
 COPY . /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
 RUN CGO_ENABLED=0 GOFLAGS='-mod=vendor' \
-	go build -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
+	go build -trimpath -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
 
 
 FROM base AS container

--- a/build/DockerfileForAlpine
+++ b/build/DockerfileForAlpine
@@ -45,7 +45,7 @@ ARG GIT_COMMIT
 WORKDIR /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/cmd/nginx-ingress
 COPY . /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
 RUN CGO_ENABLED=0 GOFLAGS='-mod=vendor' \
-	go build -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
+	go build -trimpath -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
 
 
 FROM base AS container

--- a/build/DockerfileForPlus
+++ b/build/DockerfileForPlus
@@ -87,7 +87,7 @@ ARG GIT_COMMIT
 WORKDIR /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/cmd/nginx-ingress
 COPY . /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
 RUN CGO_ENABLED=0 GOFLAGS='-mod=vendor' \
-	go build -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
+	go build -trimpath -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
 
 
 FROM base AS container

--- a/build/DockerfileWithOpentracing
+++ b/build/DockerfileWithOpentracing
@@ -111,7 +111,7 @@ ARG GIT_COMMIT
 WORKDIR /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/cmd/nginx-ingress
 COPY . /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
 RUN CGO_ENABLED=0 GOFLAGS='-mod=vendor' \
-	go build -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
+	go build -trimpath -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
 
 
 FROM base AS container

--- a/build/DockerfileWithOpentracingForPlus
+++ b/build/DockerfileWithOpentracingForPlus
@@ -103,7 +103,7 @@ ARG GIT_COMMIT
 WORKDIR /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/cmd/nginx-ingress
 COPY . /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
 RUN CGO_ENABLED=0 GOFLAGS='-mod=vendor' \
-	go build -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
+	go build -trimpath -installsuffix cgo -ldflags "-w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
 
 
 FROM base AS container


### PR DESCRIPTION
### Proposed changes
Logs no longer contain the `$GOPATH` of wherever the ingress controller binary was compiled.

### Example
If you deploy the Ingress Controller with a CRD missing.

#### Before fix
```
reflector.go:178] github.com/nginxinc/kubernetes-ingress/nginx-ingress/internal/k8s/controller.go:409: 
Failed to list *v1.VirtualServer: the server could not find the requested resource (get virtualservers.k8s.nginx.org)
```

#### After fix
```
reflector.go:178] k8s.io/client-go@v0.18.0/tools/cache/reflector.go:125: 
Failed to list *v1.VirtualServer: the server could not find the requested resource (get virtualservers.k8s.nginx.org)
```

Tested against NGINX Plus `BUILD_IN_CONTAINER=0` and `BUILD_IN_CONTAINER=1`

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
