### PR TITLE
Fix bug in VSR Status Report when NGINX fails to reload

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -605,6 +605,10 @@ func (lbc *LoadBalancerController) syncConfig(task task) {
 		msg := fmt.Sprintf("Configuration for %v/%v was updated %s", vsEx.VirtualServer.Namespace, vsEx.VirtualServer.Name, vsEventWarningMessage)
 		lbc.recorder.Eventf(vsEx.VirtualServer, vsEventType, vsEventTitle, msg)
 
+		if updateErr != nil {
+			vsState = conf_v1.StateInvalid
+		}
+
 		if lbc.reportVsVsrStatusEnabled() {
 			err = lbc.statusUpdater.UpdateVirtualServerStatus(vsEx.VirtualServer, vsState, vsEventTitle, msg)
 
@@ -628,6 +632,10 @@ func (lbc *LoadBalancerController) syncConfig(task task) {
 
 			msg := fmt.Sprintf("Configuration for %v/%v was updated %s", vsr.Namespace, vsr.Name, vsrEventWarningMessage)
 			lbc.recorder.Eventf(vsr, vsrEventType, vsrEventTitle, msg)
+
+			if updateErr != nil {
+				vsrState = conf_v1.StateInvalid
+			}
 
 			if lbc.reportVsVsrStatusEnabled() {
 				err = lbc.statusUpdater.UpdateVirtualServerRouteStatus(vsr, vsrState, vsrEventTitle, vsrEventWarningMessage)
@@ -991,6 +999,10 @@ func (lbc *LoadBalancerController) syncVirtualServer(task task) {
 		}
 		msg := fmt.Sprintf("Configuration for %v/%v was added or updated %s", vsr.Namespace, vsr.Name, vsrEventWarningMessage)
 		lbc.recorder.Eventf(vsr, vsrEventType, vsrEventTitle, msg)
+
+		if addErr != nil {
+			state = conf_v1.StateInvalid
+		}
 
 		if lbc.reportVsVsrStatusEnabled() {
 			vss := []*conf_v1.VirtualServer{vs}
@@ -1505,6 +1517,11 @@ func (lbc *LoadBalancerController) updateVirtualServersStatusFromEvents() error 
 			allErrs = append(allErrs, err)
 		}
 	}
+
+	if len(allErrs) > 0 {
+		return fmt.Errorf("not all VirtualServers statuses were updated: %v", allErrs)
+	}
+
 	return nil
 }
 
@@ -1544,7 +1561,7 @@ func (lbc *LoadBalancerController) updateVirtualServerRoutesStatusFromEvents() e
 	}
 
 	if len(allErrs) > 0 {
-		return fmt.Errorf("not all VirtualServer or VirtualServerRoutes statuses were updated: %v", allErrs)
+		return fmt.Errorf("not all VirtualServerRoutes statuses were updated: %v", allErrs)
 	}
 
 	return nil


### PR DESCRIPTION
### Proposed changes
The problem was that the status of the VSR was not updated when there were `add errors`, but only when there were warnings, that's why message/reason were ok, but the `state` was still `Valid`

Tagging @vepatel just in case this causes problems in e2e tests