### PR TITLE
Add GlobalConfiguration support to helm chart

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -17,7 +17,7 @@ This chart deploys the NGINX Ingress controller in your Kubernetes cluster.
 
 ### Installing the CRDs
 
-By default, Helm installs a number of custom resource definitions (CRDs). Those CRDs are required for the VirtualServer, VirtualServerRoute and TransportServer custom resources.
+By default, Helm installs a number of custom resource definitions (CRDs). Those CRDs are required for the VirtualServer, VirtualServerRoute, TransportServer and GlobalConfiguration custom resources.
 
 If you do not use those resources (which corresponds to `controller.enableCustomResources` set to `false`), you can skip the installation of the CRDs:
 
@@ -161,7 +161,7 @@ The command removes all the Kubernetes components associated with the chart and 
 Uninstalling the release does not remove the CRDs. To remove the CRDs, run:
 
 ```console
-$ kubectl delete crds transportservers.k8s.nginx.org virtualservers.k8s.nginx.org virtualserverroutes.k8s.nginx.org
+$ kubectl delete crds transportservers.k8s.nginx.org virtualservers.k8s.nginx.org virtualserverroutes.k8s.nginx.org globalconfigurations.k8s.nginx.org
 ```
 
 > **Note**: The following command will delete all the corresponding custom resources in your cluster across all namespaces. Please ensure there are no custom resources that you want to keep and there are no other Ingress Controller releases running in the cluster.
@@ -209,7 +209,9 @@ Parameter | Description | Default
 `controller.useIngressClassOnly` | Ignore Ingress resources without the `"kubernetes.io/ingress.class"` annotation or the `"ingressClassName"` field in VirtualServer/VirtualServerRoute. | false
 `controller.watchNamespace` | Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces. | ""
 `controller.enableCustomResources` | Enable the custom resources. | true
-`controller.enableTLSPassthrough` | Enable TLS Passthrough on port 443. Requires `controller.enableCustomResources`. | false 
+`controller.enableTLSPassthrough` | Enable TLS Passthrough on port 443. Requires `controller.enableCustomResources`. | false
+`controller.globalConfiguration.create` | Creates the GlobalConfiguration custom resource. Requires `controller.enableCustomResources`. | false
+`controller.globalConfiguration.spec` | The spec of the GlobalConfiguration for customizing NGINX configuration. | {}
 `controller.enableSnippets` | Enable custom NGINX configuration snippets in VirtualServer and VirtualServerRoute resources. | false
 `controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress controller. | false
 `controller.healthStatusURI` | Sets the URI of health status location in the default server. Requires `contoller.healthStatus`. | "/nginx-health"

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -211,7 +211,7 @@ Parameter | Description | Default
 `controller.enableCustomResources` | Enable the custom resources. | true
 `controller.enableTLSPassthrough` | Enable TLS Passthrough on port 443. Requires `controller.enableCustomResources`. | false
 `controller.globalConfiguration.create` | Creates the GlobalConfiguration custom resource. Requires `controller.enableCustomResources`. | false
-`controller.globalConfiguration.spec` | The spec of the GlobalConfiguration for customizing NGINX configuration. | {}
+`controller.globalConfiguration.spec` | The spec of the GlobalConfiguration for defining the global configuration parameters of the Ingress Controller. | {}
 `controller.enableSnippets` | Enable custom NGINX configuration snippets in VirtualServer and VirtualServerRoute resources. | false
 `controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress controller. | false
 `controller.healthStatusURI` | Sets the URI of health status location in the default server. Requires `contoller.healthStatus`. | "/nginx-health"

--- a/deployments/helm-chart/crds/globalconfiguration.yaml
+++ b/deployments/helm-chart/crds/globalconfiguration.yaml
@@ -1,0 +1,56 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalconfigurations.k8s.nginx.org
+  labels:
+    app.kubernetes.io/name: "nginx-ingress"
+  annotations:
+    "helm.sh/hook": crd-install
+spec:
+  group: k8s.nginx.org
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: globalconfigurations
+    singular: globalconfiguration
+    kind: GlobalConfiguration
+    shortNames:
+    - gc
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      description: GlobalConfiguration defines the GlobalConfiguration resource.
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GlobalConfigurationSpec is the spec of the GlobalConfiguration
+            resource.
+          type: object
+          properties:
+            listeners:
+              type: array
+              items:
+                description: Listener defines a listener.
+                type: object
+                properties:
+                  name:
+                    type: string
+                  port:
+                    type: integer
+                  protocol:
+                    type: string

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -128,8 +128,11 @@ spec:
           - -enable-prometheus-metrics={{ .Values.prometheus.create }}
           - -prometheus-metrics-listen-port={{ .Values.prometheus.port }}
           - -enable-custom-resources={{ .Values.controller.enableCustomResources }}
-{{- if .Values.controller.enableCustomResources  }}
+{{- if .Values.controller.enableCustomResources }}
           - -enable-tls-passthrough={{ .Values.controller.enableTLSPassthrough }}
           - -enable-snippets={{ .Values.controller.enableSnippets }}
+{{- if .Values.controller.globalConfiguration.create }}
+          - -global-configuration=$(POD_NAMESPACE)/{{ .Release.Name }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -126,8 +126,11 @@ spec:
           - -enable-prometheus-metrics={{ .Values.prometheus.create }}
           - -prometheus-metrics-listen-port={{ .Values.prometheus.port }}
           - -enable-custom-resources={{ .Values.controller.enableCustomResources }}
-{{- if .Values.controller.enableCustomResources  }}
+{{- if .Values.controller.enableCustomResources }}
           - -enable-tls-passthrough={{ .Values.controller.enableTLSPassthrough }}
           - -enable-snippets={{ .Values.controller.enableSnippets }}
+{{- if .Values.controller.globalConfiguration.create }}
+          - -global-configuration=$(POD_NAMESPACE)/{{ .Release.Name }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deployments/helm-chart/templates/controller-globalconfiguration.yaml
+++ b/deployments/helm-chart/templates/controller-globalconfiguration.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.controller.globalConfiguration.create }}
+apiVersion: k8s.nginx.org/v1alpha1
+kind: GlobalConfiguration
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nginx-ingress.labels" . | nindent 4 }}
+spec:
+{{ toYaml .Values.controller.globalConfiguration.spec | indent 2 }}
+{{- end }}

--- a/deployments/helm-chart/templates/controller-globalconfiguration.yaml
+++ b/deployments/helm-chart/templates/controller-globalconfiguration.yaml
@@ -2,7 +2,7 @@
 apiVersion: k8s.nginx.org/v1alpha1
 kind: GlobalConfiguration
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "nginx-ingress.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-ingress.labels" . | nindent 4 }}

--- a/deployments/helm-chart/templates/rbac.yaml
+++ b/deployments/helm-chart/templates/rbac.yaml
@@ -72,6 +72,7 @@ rules:
   resources:
   - virtualservers
   - virtualserverroutes
+  - globalconfigurations
   - transportservers
   verbs:
   - list

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -38,7 +38,7 @@ controller:
 
     ## The annotations of the Ingress Controller configmap.
     annotations: {}
-    
+
     ## The entries of the ConfigMap for customizing NGINX configuration.
     entries: {}
 
@@ -123,6 +123,20 @@ controller:
 
   ## Enable TLS Passthrough on port 443. Requires controller.enableCustomResources.
   enableTLSPassthrough: false
+
+  globalConfiguration:
+    ## Creates the GlobalConfiguration custom resource. Requires controller.enableCustomResources.
+    create: false
+
+    ## The spec of the GlobalConfiguration for customizing NGINX configuration.
+    spec: {}
+      # listeners:
+      # - name: dns-udp
+      #   port: 5353
+      #   protocol: UDP
+      # - name: dns-tcp
+      #   port: 5353
+      #   protocol: TCP
 
   ## Enable custom NGINX configuration snippets in VirtualServer and VirtualServerRoute resources.
   enableSnippets: false

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -128,7 +128,7 @@ controller:
     ## Creates the GlobalConfiguration custom resource. Requires controller.enableCustomResources.
     create: false
 
-    ## The spec of the GlobalConfiguration for customizing NGINX configuration.
+    ## The spec of the GlobalConfiguration for defining the global configuration parameters of the Ingress Controller.
     spec: {}
       # listeners:
       # - name: dns-udp

--- a/docs-web/installation/installation-with-helm.md
+++ b/docs-web/installation/installation-with-helm.md
@@ -15,7 +15,7 @@ This document describes how to install the NGINX Ingress Controller in your Kube
 
 ### Installing the CRDs
 
-By default, Helm installs a number of custom resource definitions (CRDs). Those CRDs are required for the VirtualServer, VirtualServerRoute and TransportServer custom resources.
+By default, Helm installs a number of custom resource definitions (CRDs). Those CRDs are required for the VirtualServer, VirtualServerRoute, TransportServer and GlobalConfiguration custom resources.
 
 If you do not use those resources (which corresponds to `controller.enableCustomResources` set to `false`), you can skip the installation of the CRDs:
 
@@ -158,7 +158,7 @@ The command removes all the Kubernetes components associated with the chart and 
 Uninstalling the release does not remove the CRDs. To remove the CRDs, run:
 
 ```console
-$ kubectl delete crds transportservers.k8s.nginx.org virtualservers.k8s.nginx.org virtualserverroutes.k8s.nginx.org
+$ kubectl delete crds transportservers.k8s.nginx.org virtualservers.k8s.nginx.org virtualserverroutes.k8s.nginx.org globalconfigurations.k8s.nginx.org
 ```
 
 > **Note**: The following command will delete all the corresponding custom resources in your cluster across all namespaces. Please ensure there are no custom resources that you want to keep and there are no other Ingress Controller releases running in the cluster.
@@ -273,6 +273,12 @@ The following tables lists the configurable parameters of the NGINX Ingress cont
    * - ``controller.enableTLSPassthrough``
      - Enable TLS Passthrough on port 443. Requires ``controller.enableCustomResources``.
      - false
+   * - ``controller.globalConfiguration.create``
+     - Creates the GlobalConfiguration custom resource. Requires ``controller.enableCustomResources``.
+     - false
+   * - ``controller.globalConfiguration.spec``
+     - The spec of the GlobalConfiguration for customizing NGINX configuration.
+     - {}
    * - ``controller.enableSnippets``
      - Enable custom NGINX configuration snippets in VirtualServer and VirtualServerRoute resources.
      - false

--- a/docs-web/installation/installation-with-helm.md
+++ b/docs-web/installation/installation-with-helm.md
@@ -277,7 +277,7 @@ The following tables lists the configurable parameters of the NGINX Ingress cont
      - Creates the GlobalConfiguration custom resource. Requires ``controller.enableCustomResources``.
      - false
    * - ``controller.globalConfiguration.spec``
-     - The spec of the GlobalConfiguration for customizing NGINX configuration.
+     - The spec of the GlobalConfiguration for defining the global configuration parameters of the Ingress Controller.
      - {}
    * - ``controller.enableSnippets``
      - Enable custom NGINX configuration snippets in VirtualServer and VirtualServerRoute resources.

--- a/docs-web/installation/installation-with-manifests.md
+++ b/docs-web/installation/installation-with-manifests.md
@@ -56,7 +56,7 @@ If you would like to use the TCP and UDP load balancing features of the Ingress 
     ```
     $ kubectl apply -f common/global-configuration.yaml
     ```
-    **Note**: Make sure to references this resource in the [`-global-configuration`](/nginx-ingress-controller/configuration/global-configuration/command-line-arguments#cmdoption-global-configuration) command-line argument.
+    **Note**: Make sure to reference this resource in the [`-global-configuration`](/nginx-ingress-controller/configuration/global-configuration/command-line-arguments#cmdoption-global-configuration) command-line argument.
 
 > **Feature Status**: The TransportServer and GlobalConfiguration resources are available as a preview feature: it is suitable for experimenting and testing; however, it must be used with caution in production environments. Additionally, while the feature is in preview, we might introduce some backward-incompatible changes to the resources specification in the next releases.
 


### PR DESCRIPTION
### Proposed changes
* Add support to deploy GlobalConfiguration custom resources via helm chart.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
