### PR TITLE
Make installing CRDs via kubectl a prerequisite for helm2 clients

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -13,6 +13,19 @@ This chart deploys the NGINX Ingress controller in your Kubernetes cluster.
     - Build an Ingress controller image with NGINX Plus and push it to your private registry by following the instructions from [here](../../build/README.md).
     - Update the `controller.image.repository` field of the `values-plus.yaml` accordingly.
 
+## Getting the Chart Sources
+
+This step is required if you're installing the chart using its sources. Additionally, the step is also required for managing the custom resource definitions (CRDs), which the Ingress Controller requires by default: upgrading/deleting the CRDs, or installing the CRDs for Helm 2.x.
+
+1. Clone the Ingress controller repo:
+    ```console
+    $ git clone https://github.com/nginxinc/kubernetes-ingress/
+    ```
+2. Change your working directory to /deployments/helm-chart:
+    ```console
+    $ cd kubernetes-ingress/deployments/helm-chart
+    ```
+
 ## Installing the Chart
 
 ### Adding the Helm Repository
@@ -24,36 +37,15 @@ $ helm repo add nginx-edge https://helm.nginx.com/edge
 $ helm repo update
 ```
 
-### Getting the Chart Sources
-
-This step is required you're installing the chart using its sources, upgrading or deleting the chart.
-
-1. Clone the Ingress controller repo:
-    ```console
-    $ git clone https://github.com/nginxinc/kubernetes-ingress/
-    ```
-2. Change your working directory to /deployments/helm-chart:
-    ```console
-    $ cd kubernetes-ingress/deployments/helm-chart
-    ```
-
 ### Installing the CRDs
 
-By default, Helm installs a number of custom resource definitions (CRDs). Those CRDs are required for the VirtualServer, VirtualServerRoute, TransportServer and GlobalConfiguration custom resources.
+By default, the Ingress Controller requires a number of custom resource definitions (CRDs) installed in the cluster. Helm 3.x client will install those CRDs. If you're using a Helm 2.x client, you need to install the CRDs via `kubectl`:
 
-If you do not use those resources (which corresponds to `controller.enableCustomResources` set to `false`), you can skip the installation of the CRDs:
+```console
+$ kubectl create -f crds/
+```
 
-* Using Helm 3.x client:
-
-    Specify `--skip-crds` for the helm install command.
-
-    > **Note**: The following warning is expected and can be ignored: `skipping unknown hook: "crd-install"`.
-
-* Using a Helm 2.x client:
-
-    Set `controller.enableCustomResources` to `false`.
-
-> **Note**: If the CRDs are already installed in the cluster, Helm will skip the CRDs installation.
+If you do not use the custom resources that require those CRDs (which corresponds to `controller.enableCustomResources` set to `false` and `controller.appprotect.enable` set to `false`), you can skip the installation of the CRDs. For Helm 2.x, no action is needed, as it does not install the CRDs. For Helm 3.x, specify `--skip-crds` for the helm install command.
 
 ### Installing via Helm Repository
 
@@ -124,7 +116,7 @@ To install the chart with the release name my-release (my-release is the name th
 Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a release, run the following command to upgrade the CRDs:
 
 ```console
-$ kubectl apply -f deployments/helm-chart/crds/
+$ kubectl apply -f crds/
 ```
 > **Note**: The following warning is expected and can be ignored: `Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply`.
 
@@ -164,14 +156,14 @@ To uninstall/delete the release `my-release`:
     $ helm delete --purge my-release
     ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+The command removes all the Kubernetes components associated with the release and deletes the release.
 
 ### Uninstalling the CRDs
 
 Uninstalling the release does not remove the CRDs. To remove the CRDs, run:
 
 ```console
-$ kubectl delete -f deployments/helm-chart/crds/
+$ kubectl delete -f crds/
 ```
 > **Note**: This command will delete all the corresponding custom resources in your cluster across all namespaces. Please ensure there are no custom resources that you want to keep and there are no other Ingress Controller releases running in the cluster.
 

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -26,9 +26,7 @@ This step is required if you're installing the chart using its sources. Addition
     $ cd kubernetes-ingress/deployments/helm-chart
     ```
 
-## Installing the Chart
-
-### Adding the Helm Repository
+## Adding the Helm Repository
 
 This step is required if you're installing the chart via the helm repository.
 
@@ -36,6 +34,8 @@ This step is required if you're installing the chart via the helm repository.
 $ helm repo add nginx-edge https://helm.nginx.com/edge
 $ helm repo update
 ```
+
+## Installing the Chart
 
 ### Installing the CRDs
 

--- a/deployments/helm-chart/crds/ap-logconf.yaml
+++ b/deployments/helm-chart/crds/ap-logconf.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
-    "helm.sh/hook": crd-install
   creationTimestamp: null
   name: aplogconfs.appprotect.f5.com
   labels:

--- a/deployments/helm-chart/crds/ap-policy.yaml
+++ b/deployments/helm-chart/crds/ap-policy.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
-    "helm.sh/hook": crd-install
   creationTimestamp: null
   name: appolicies.appprotect.f5.com
   labels:

--- a/deployments/helm-chart/crds/globalconfiguration.yaml
+++ b/deployments/helm-chart/crds/globalconfiguration.yaml
@@ -4,8 +4,6 @@ metadata:
   name: globalconfigurations.k8s.nginx.org
   labels:
     app.kubernetes.io/name: "nginx-ingress"
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: k8s.nginx.org
   versions:

--- a/deployments/helm-chart/crds/policy.yaml
+++ b/deployments/helm-chart/crds/policy.yaml
@@ -4,8 +4,6 @@ metadata:
   name: policies.k8s.nginx.org
   labels:
     app.kubernetes.io/name: "nginx-ingress"
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: k8s.nginx.org
   versions:

--- a/deployments/helm-chart/crds/transportserver.yaml
+++ b/deployments/helm-chart/crds/transportserver.yaml
@@ -4,8 +4,6 @@ metadata:
   name: transportservers.k8s.nginx.org
   labels:
     app.kubernetes.io/name: "nginx-ingress"
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: k8s.nginx.org
   versions:

--- a/deployments/helm-chart/crds/virtualserver.yaml
+++ b/deployments/helm-chart/crds/virtualserver.yaml
@@ -4,8 +4,6 @@ metadata:
   name: virtualservers.k8s.nginx.org
   labels:
     app.kubernetes.io/name: "nginx-ingress"
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: k8s.nginx.org
   versions:

--- a/deployments/helm-chart/crds/virtualserverroute.yaml
+++ b/deployments/helm-chart/crds/virtualserverroute.yaml
@@ -4,8 +4,6 @@ metadata:
   name: virtualserverroutes.k8s.nginx.org
   labels:
     app.kubernetes.io/name: "nginx-ingress"
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: k8s.nginx.org
   versions:

--- a/deployments/helm-chart/templates/crds.yaml
+++ b/deployments/helm-chart/templates/crds.yaml
@@ -1,7 +1,0 @@
-{{- if .Values.controller.enableCustomResources }}
-{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-{{ $.Files.Get $path }}
----
-{{- end }}
-{{- end }}
-

--- a/docs-web/installation/installation-with-helm.md
+++ b/docs-web/installation/installation-with-helm.md
@@ -24,9 +24,7 @@ This step is required if you're installing the chart using its sources. Addition
     $ cd kubernetes-ingress/deployments/helm-chart
     ```
 
-## Installing the Chart
-
-### Adding the Helm Repository
+## Adding the Helm Repository
 
 This step is required if you're installing the chart via the helm repository.
 
@@ -34,6 +32,8 @@ This step is required if you're installing the chart via the helm repository.
 $ helm repo add nginx-edge https://helm.nginx.com/edge
 $ helm repo update
 ```
+
+## Installing the Chart
 
 ### Installing the CRDs
 

--- a/docs-web/installation/installation-with-helm.md
+++ b/docs-web/installation/installation-with-helm.md
@@ -11,6 +11,19 @@ This document describes how to install the NGINX Ingress Controller in your Kube
     - Build an Ingress controller image with NGINX Plus and push it to your private registry by following the instructions from [here](/nginx-ingress-controller/installation/building-ingress-controller-image).
     - Update the `controller.image.repository` field of the `values-plus.yaml` accordingly.
 
+## Getting the Chart Sources
+
+This step is required if you're installing the chart using its sources. Additionally, the step is also required for managing the custom resource definitions (CRDs), which the Ingress Controller requires by default: upgrading/deleting the CRDs, or installing the CRDs for Helm 2.x.
+
+1. Clone the Ingress controller repo:
+    ```console
+    $ git clone https://github.com/nginxinc/kubernetes-ingress/
+    ```
+2. Change your working directory to /deployments/helm-chart:
+    ```console
+    $ cd kubernetes-ingress/deployments/helm-chart
+    ```
+
 ## Installing the Chart
 
 ### Adding the Helm Repository
@@ -22,36 +35,15 @@ $ helm repo add nginx-edge https://helm.nginx.com/edge
 $ helm repo update
 ```
 
-### Getting the Chart Sources
-
-This step is required you're installing the chart using its sources, upgrading or deleting the chart.
-
-1. Clone the Ingress controller repo:
-    ```console
-    $ git clone https://github.com/nginxinc/kubernetes-ingress/
-    ```
-2. Change your working directory to /deployments/helm-chart:
-    ```console
-    $ cd kubernetes-ingress/deployments/helm-chart
-    ```
-
 ### Installing the CRDs
 
-By default, Helm installs a number of custom resource definitions (CRDs). Those CRDs are required for the VirtualServer, VirtualServerRoute, TransportServer and GlobalConfiguration custom resources.
+By default, the Ingress Controller requires a number of custom resource definitions (CRDs) installed in the cluster. Helm 3.x client will install those CRDs. If you're using a Helm 2.x client, you need to install the CRDs via `kubectl`:
 
-If you do not use those resources (which corresponds to `controller.enableCustomResources` set to `false`), you can skip the installation of the CRDs:
+```console
+$ kubectl create -f crds/
+```
 
-* Using Helm 3.x client:
-
-    Specify `--skip-crds` for the helm install command.
-
-    > **Note**: The following warning is expected and can be ignored: `skipping unknown hook: "crd-install"`.
-
-* Using a Helm 2.x client:
-
-    Set `controller.enableCustomResources` to `false`.
-
-> **Note**: If the CRDs are already installed in the cluster, Helm will skip the CRDs installation.
+If you do not use the custom resources that require those CRDs (which corresponds to `controller.enableCustomResources` set to `false` and `controller.appprotect.enable` set to `false`), you can skip the installation of the CRDs. For Helm 2.x, no action is needed, as it does not install the CRDs. For Helm 3.x, specify `--skip-crds` for the helm install command.
 
 ### Installing via Helm Repository
 
@@ -122,7 +114,7 @@ To install the chart with the release name my-release (my-release is the name th
 Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a release, run the following command to upgrade the CRDs:
 
 ```console
-$ kubectl apply -f deployments/helm-chart/crds/
+$ kubectl apply -f crds/
 ```
 > **Note**: The following warning is expected and can be ignored: `Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply`.
 
@@ -169,7 +161,7 @@ The command removes all the Kubernetes components associated with the chart and 
 Uninstalling the release does not remove the CRDs. To remove the CRDs, run:
 
 ```console
-$ kubectl delete -f deployments/helm-chart/crds/
+$ kubectl delete -f crds/
 ```
 > **Note**: This command will delete all the corresponding custom resources in your cluster across all namespaces. Please ensure there are no custom resources that you want to keep and there are no other Ingress Controller releases running in the cluster.
 


### PR DESCRIPTION
### Proposed changes
* Installing CRDs is now a prerequisite to installing the chart via helm2 clients.
* Helm chart no longer installs CRDs when using helm2.x client. `crd-install` hooks have been removed.
* General docs structure improvements.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
