### PR TITLE
Change how App Protect is installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ cmd/nginx-ingress/nginx-ingress
 *.crt
 *.key
 
+# RHEL license
+rhel_license
+
 # Visual Studio Code settings
 .vscode
 

--- a/build/appprotect/DockerfileWithAppProtectForPlus
+++ b/build/appprotect/DockerfileWithAppProtectForPlus
@@ -4,8 +4,11 @@ FROM debian:stretch-slim as base
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV APPPROTECT_VERSION 22+3.74.0-1~stretch
-ENV APPPROTECT_SIG_VERSION 2020.06.18-1~stretch
+ENV APPPROTECT_MODULE_VERSION 22+3.90.2-1~stretch
+ENV APPPROTECT_PLUGIN_VERSION 3.90.2-1~stretch
+ENV APPPROTECT_ENGINE_VERSION 4.1.1-1~stretch
+ENV APPPROTECT_COMPILER_VERSION 4.1.1-1~stretch
+ENV APPPROTECT_SIG_VERSION 2020.07.17-1~stretch
 ENV NGINX_PLUS_VERSION 22-1~stretch
 ENV NGINX_PLUS_RELEASE R22
 ARG IC_VERSION
@@ -46,7 +49,12 @@ RUN set -x \
 	&& echo "Acquire::https::app-protect-sigs.nginx.com::Verify-Host \"true\";" >> /etc/apt/apt.conf.d/90app-protect-sigs \
 	&& echo "Acquire::https::app-protect-sigs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90app-protect-sigs \
 	&& echo "Acquire::https::app-protect-sigs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90app-protect-sigs \
-	&& apt-get update && apt-get install -y nginx-plus=$NGINX_PLUS_VERSION app-protect=$APPPROTECT_VERSION \ 
+	&& apt-get update && apt-get install -y nginx-plus=$NGINX_PLUS_VERSION \
+	    nginx-plus-module-appprotect=$APPPROTECT_MODULE_VERSION \
+	    app-protect-plugin=$APPPROTECT_PLUGIN_VERSION \
+	    app-protect-engine=$APPPROTECT_ENGINE_VERSION \
+	    app-protect-compiler=$APPPROTECT_COMPILER_VERSION \
+	    app-protect=$APPPROTECT_MODULE_VERSION \
 	&& apt-get install -y app-protect-attack-signatures${APPPROTECT_SIG_VERSION:+=$APPPROTECT_SIG_VERSION} \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \

--- a/build/appprotect/DockerfileWithAppProtectForPlusForOpenShift
+++ b/build/appprotect/DockerfileWithAppProtectForPlusForOpenShift
@@ -9,9 +9,12 @@ LABEL name="NGINX Ingress Controller" \
       maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>" \
       vendor="NGINX Inc <kubernetes@nginx.com>"
 
+ENV APPPROTECT_MODULE_VERSION 22+3.90.2-1.el7.ngx
+ENV APPPROTECT_PLUGIN_VERSION 3.90.2-1.el7.ngx
+ENV APPPROTECT_ENGINE_VERSION 4.1.1-1.el7.ngx
+ENV APPPROTECT_COMPILER_VERSION 4.1.1-1.el7.ngx
+ENV APPPROTECT_SIG_VERSION 2020.07.17-1.el7.ngx
 ENV NGINX_PLUS_VERSION 22-1.el7.ngx
-ENV APPPROTECT_VERSION 22+3.74.0-1.el7.ngx
-ENV APPPROTECT_SIG_VERSION 2020.07.06-1.el7.ngx
 ARG IC_VERSION
 
 # Download certificate and key from the customer portal (https://cs.nginx.com)
@@ -51,7 +54,12 @@ RUN set -x \
 	&& yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-REGION-rhel-server-optional rhel-7-server-optional-rpms \
 	&& rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
 	&& yum clean all \
-	&& yum install -y nginx-plus-$NGINX_PLUS_VERSION app-protect-$APPPROTECT_VERSION \
+	&& yum install -y nginx-plus-$NGINX_PLUS_VERSION \
+	    nginx-plus-module-appprotect-$APPPROTECT_MODULE_VERSION \
+	    app-protect-plugin-$APPPROTECT_PLUGIN_VERSION \
+	    app-protect-engine-$APPPROTECT_ENGINE_VERSION \
+	    app-protect-compiler-$APPPROTECT_COMPILER_VERSION \
+	    app-protect-$APPPROTECT_MODULE_VERSION \
 	&& yum install -y app-protect-attack-signatures${APPPROTECT_SIG_VERSION:+-$APPPROTECT_SIG_VERSION} \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \


### PR DESCRIPTION
### Proposed changes
* In addition to installing app-protect package, install the following packages:
nginx-plus-module-appprotect, app-protect-plugin, app-protect-engine,
app-protect-compiler. This is necessary to ensure the version of each
package in the App Protect Dockerfiles, which will prevent possible errors of unmet dependencies during the image building.
* Update App Protect packages to their latest versions.
* Add rhel_license (required by DockerfileWithAppProtectForPlusForOpenShift)
to .gitignore.

Once merged, this will need to be cherry picked to https://github.com/nginxinc/kubernetes-ingress/pull/1055