### PR TITLE
Add support for NGINX Service Mesh internal routes

### DIFF
--- a/docs-web/configuration/global-configuration/command-line-arguments.md
+++ b/docs-web/configuration/global-configuration/command-line-arguments.md
@@ -178,8 +178,16 @@ Below we describe the available command-line arguments:
 .. option:: -spire-agent-address <string>
 
 	Specifies the address of a running Spire agent. **For use with NGINX Service Mesh only**.
+    Requires :option:`-nginx-plus`.
 
 	- If the argument is set, but the Ingress Controller is unable to connect to the Spire Agent, the Ingress Controller will fail to start.
+
+.. option:: -enable-internal-routes
+
+	Enable support for internal routes with NGINX Service Mesh. **For use with NGINX Service Mesh only**.
+    Requires :option:`-nginx-plus` and :option:`-spire-agent-address`.
+
+    - If the argument is set, but `nginx-plus` is set to false, or the `spire-agent-address` is not provided, the Ingress Controller will fail to start.
 
 .. option:: -enable-app-protect
 

--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -20,6 +20,9 @@ const AppProtectLogConfAnnotation = "appprotect.f5.com/app-protect-security-log"
 // AppProtectLogConfDstAnnotation is where the NGINX AppProtect Log Configuration is specified
 const AppProtectLogConfDstAnnotation = "appprotect.f5.com/app-protect-security-log-destination"
 
+// nginxMeshInternalRoute specifies if the ingress resource is an internal route.
+const nginxMeshInternalRouteAnnotation = "nsm.nginx.com/internal-route"
+
 var masterBlacklist = map[string]bool{
 	"nginx.org/rewrites":                      true,
 	"nginx.org/ssl-services":                  true,
@@ -67,7 +70,7 @@ var minionInheritanceList = map[string]bool{
 	"nginx.org/fail-timeout":             true,
 }
 
-func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool, hasAppProtect bool) ConfigParams {
+func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool, hasAppProtect bool, enableInternalRoutes bool) ConfigParams {
 	cfgParams := *baseCfgParams
 
 	if lbMethod, exists := ingEx.Ingress.Annotations["nginx.org/lb-method"]; exists {
@@ -346,6 +349,15 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 			}
 		}
 
+	}
+	if enableInternalRoutes {
+		if spiffeServerCerts, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, nginxMeshInternalRouteAnnotation, ingEx.Ingress); exists {
+			if err != nil {
+				glog.Error(err)
+			} else {
+				cfgParams.SpiffeServerCerts = spiffeServerCerts
+			}
+		}
 	}
 	return cfgParams
 }

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -96,7 +96,7 @@ type ConfigParams struct {
 	Ports    []int
 	SSLPorts []int
 
-	SpiffeCerts bool
+	SpiffeServerCerts bool
 }
 
 // StaticConfigParams holds immutable NGINX configuration parameters that affect the main NGINX config.
@@ -110,7 +110,9 @@ type StaticConfigParams struct {
 	TLSPassthrough                 bool
 	EnableSnippets                 bool
 	SpiffeCerts                    bool
+	EnableInternalRoutes           bool
 	MainAppProtectLoadModule       bool
+	PodName                        string
 }
 
 // GlobalConfigParams holds global configuration parameters. For now, it only holds listeners.

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -4,8 +4,9 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/nginxinc/kubernetes-ingress/internal/configs/version1"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/nginxinc/kubernetes-ingress/internal/configs/version1"
 )
 
 // ParseConfigMap parses ConfigMap into ConfigParams.
@@ -542,6 +543,8 @@ func GenerateNginxMainConfig(staticCfgParams *StaticConfigParams, config *Config
 		AppProtectCookieSeed:               config.MainAppProtectCookieSeed,
 		AppProtectCPUThresholds:            config.MainAppProtectCPUThresholds,
 		AppProtectPhysicalMemoryThresholds: config.MainAppProtectPhysicalMemoryThresholds,
+		InternalRouteServer:                staticCfgParams.EnableInternalRoutes,
+		InternalRouteServerName:            staticCfgParams.PodName,
 	}
 	return nginxCfg
 }

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -426,5 +427,28 @@ func TestGenerateTLSPassthroughHostsConfig(t *testing.T) {
 
 	if !reflect.DeepEqual(resultDuplicatedHosts, expectedDuplicatedHosts) {
 		t.Errorf("generateTLSPassthroughHostsConfig() returned %v but expected %v", resultDuplicatedHosts, expectedDuplicatedHosts)
+	}
+}
+
+func TestAddInternalRouteConfig(t *testing.T) {
+	cnf, err := createTestConfigurator()
+	if err != nil {
+		t.Errorf("Failed to create a test configurator: %v", err)
+	}
+	// set pod name in env
+	err = os.Setenv("POD_NAME", "nginx-ingress")
+	if err != nil {
+		t.Errorf("Failed to set pod name in environment: %v", err)
+	}
+	err = cnf.AddInternalRouteConfig()
+	if err != nil {
+		t.Errorf("AddInternalRouteConfig returned:  \n%v, but expected: \n%v", err, nil)
+	}
+
+	if !cnf.staticCfgParams.EnableInternalRoutes {
+		t.Errorf("AddInternalRouteConfig failed to set EnableInteralRoutes field of staticCfgParams to true")
+	}
+	if cnf.staticCfgParams.PodName != "nginx-ingress" {
+		t.Errorf("AddInternalRouteConfig failed to set PodName field of staticCfgParams")
 	}
 }

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nginxinc/kubernetes-ingress/internal/configs/version1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/nginxinc/kubernetes-ingress/internal/configs/version1"
 )
 
 func TestGenerateNginxCfg(t *testing.T) {
@@ -715,14 +716,11 @@ func createExpectedConfigForCrossNamespaceMergeableCafeIngress() version1.Ingres
 func TestGenerateNginxCfgForSpiffe(t *testing.T) {
 	cafeIngressEx := createCafeIngressEx()
 	configParams := NewDefaultConfigParams()
-	configParams.SpiffeCerts = true
 
 	expected := createExpectedConfigForCafeIngressEx()
-	expected.SpiffeCerts = true
-	for _, s := range expected.Servers {
-		for i := range s.Locations {
-			s.Locations[i].SSL = true
-		}
+	expected.SpiffeClientCerts = true
+	for i := range expected.Servers[0].Locations {
+		expected.Servers[0].Locations[i].SSL = true
 	}
 
 	pems := map[string]string{
@@ -734,5 +732,92 @@ func TestGenerateNginxCfgForSpiffe(t *testing.T) {
 
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("generateNginxCfg returned \n%v,  but expected \n%v", result, expected)
+	}
+}
+
+func TestGenerateNginxCfgForInternalRoute(t *testing.T) {
+	internalRouteAnnotation := "nsm.nginx.com/internal-route"
+	cafeIngressEx := createCafeIngressEx()
+	cafeIngressEx.Ingress.Annotations[internalRouteAnnotation] = "true"
+	configParams := NewDefaultConfigParams()
+
+	expected := createExpectedConfigForCafeIngressEx()
+	expected.Servers[0].SpiffeCerts = true
+	expected.Ingress.Annotations[internalRouteAnnotation] = "true"
+
+	pems := map[string]string{
+		"cafe.example.com": "/etc/nginx/secrets/default-cafe-secret",
+	}
+
+	apResources := make(map[string]string)
+	result := generateNginxCfg(&cafeIngressEx, pems, apResources, false, configParams, false, false, "", &StaticConfigParams{SpiffeCerts: true, EnableInternalRoutes: true})
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("generateNginxCfg returned \n%+v,  but expected \n%+v", result, expected)
+	}
+}
+
+func TestIsSSLEnabled(t *testing.T) {
+	type testCase struct {
+		IsSSLService,
+		SpiffeServerCerts,
+		SpiffeCerts,
+		Expected bool
+	}
+	var testCases = []testCase{
+		{
+			IsSSLService:      false,
+			SpiffeServerCerts: false,
+			SpiffeCerts:       false,
+			Expected:          false,
+		},
+		{
+			IsSSLService:      false,
+			SpiffeServerCerts: true,
+			SpiffeCerts:       true,
+			Expected:          false,
+		},
+		{
+			IsSSLService:      false,
+			SpiffeServerCerts: false,
+			SpiffeCerts:       true,
+			Expected:          true,
+		},
+		{
+			IsSSLService:      false,
+			SpiffeServerCerts: true,
+			SpiffeCerts:       false,
+			Expected:          false,
+		},
+		{
+			IsSSLService:      true,
+			SpiffeServerCerts: true,
+			SpiffeCerts:       true,
+			Expected:          true,
+		},
+		{
+			IsSSLService:      true,
+			SpiffeServerCerts: false,
+			SpiffeCerts:       true,
+			Expected:          true,
+		},
+		{
+			IsSSLService:      true,
+			SpiffeServerCerts: true,
+			SpiffeCerts:       false,
+			Expected:          true,
+		},
+		{
+			IsSSLService:      true,
+			SpiffeServerCerts: false,
+			SpiffeCerts:       false,
+			Expected:          true,
+		},
+	}
+	for i, tc := range testCases {
+		actual := isSSLEnabled(tc.IsSSLService, ConfigParams{SpiffeServerCerts: tc.SpiffeServerCerts}, &StaticConfigParams{SpiffeCerts: tc.SpiffeCerts})
+		if actual != tc.Expected {
+			t.Errorf("isSSLEnabled returned %v but expected %v for the case %v", actual, tc.Expected, i)
+		}
 	}
 }

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -2,11 +2,11 @@ package version1
 
 // IngressNginxConfig describes an NGINX configuration.
 type IngressNginxConfig struct {
-	Upstreams   []Upstream
-	Servers     []Server
-	Keepalive   string
-	Ingress     Ingress
-	SpiffeCerts bool
+	Upstreams         []Upstream
+	Servers           []Server
+	Keepalive         string
+	Ingress           Ingress
+	SpiffeClientCerts bool
 }
 
 // Ingress holds information about an Ingress resource.
@@ -90,6 +90,8 @@ type Server struct {
 	AppProtectPolicy    string
 	AppProtectLogConf   string
 	AppProtectLogEnable string
+
+	SpiffeCerts bool
 }
 
 // JWTRedirectLocation describes a location for redirecting client requests to a login URL for JWT Authentication.
@@ -179,6 +181,8 @@ type MainConfig struct {
 	AppProtectCookieSeed               string
 	AppProtectCPUThresholds            string
 	AppProtectPhysicalMemoryThresholds string
+	InternalRouteServer                bool
+	InternalRouteServerName            string
 }
 
 // NewUpstreamWithDefaultServer creates an upstream with the default server.

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -20,6 +20,11 @@ upstream {{$upstream.Name}} {
 
 {{range $server := .Servers}}
 server {
+	{{if $server.SpiffeCerts}}
+	listen 443 ssl;
+	ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
+	ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
+	{{else}}
 	{{if not $server.GRPCOnly}}
 	{{range $port := $server.Ports}}
 	listen {{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
@@ -40,6 +45,7 @@ server {
 	ssl_certificate_key {{$server.SSLCertificateKey}};
 	{{if $server.SSLCiphers}}
 	ssl_ciphers {{$server.SSLCiphers}};
+	{{end}}
 	{{end}}
 	{{end}}
 
@@ -180,7 +186,7 @@ server {
 		{{- if $location.ProxyBufferSize}}
 		grpc_buffer_size {{$location.ProxyBufferSize}};
 		{{- end}}
-		{{if $.SpiffeCerts}}
+		{{if $.SpiffeClientCerts}}
 		grpc_ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
 		grpc_ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
 		grpc_ssl_trusted_certificate /etc/nginx/secrets/spiffe_rootca.pem;
@@ -236,7 +242,7 @@ server {
 		{{- if $location.ProxyMaxTempFileSize}}
 		proxy_max_temp_file_size {{$location.ProxyMaxTempFileSize}};
 		{{- end}}
-		{{if $.SpiffeCerts}}
+		{{if $.SpiffeClientCerts}}
 		proxy_ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
 		proxy_ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
 		proxy_ssl_trusted_certificate /etc/nginx/secrets/spiffe_rootca.pem;

--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -197,6 +197,17 @@ http {
 
         return 418;
     }
+    {{if .InternalRouteServer}}
+    server {
+        listen 443 ssl;
+        server_name {{.InternalRouteServerName}};
+        ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
+        ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
+        ssl_client_certificate /etc/nginx/secrets/spiffe_rootca.pem;
+        ssl_verify_client on;
+        ssl_verify_depth 25;
+    }
+    {{end}}
 }
 
 stream {

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -123,15 +123,6 @@ server {
 		{{- if $location.ProxyBufferSize}}
 		grpc_buffer_size {{$location.ProxyBufferSize}};
 		{{- end}}
-		{{if $.SpiffeCerts}}
-		grpc_ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
-		grpc_ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
-		grpc_ssl_trusted_certificate /etc/nginx/secrets/spiffe_rootca.pem;
-		grpc_ssl_server_name on;
-		grpc_ssl_verify on;
-		grpc_ssl_verify_depth 25;
-		grpc_ssl_name {{$location.ProxySSLName}};
-		{{end}}
 		{{if $location.SSL}}
 		grpc_pass grpcs://{{$location.Upstream.Name}}{{$location.Rewrite}};
 		{{else}}
@@ -172,15 +163,6 @@ server {
 		{{- if $location.ProxyMaxTempFileSize}}
 		proxy_max_temp_file_size {{$location.ProxyMaxTempFileSize}};
 		{{- end}}
-		{{if $.SpiffeCerts}}
-		proxy_ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
-		proxy_ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
-		proxy_ssl_trusted_certificate /etc/nginx/secrets/spiffe_rootca.pem;
-		proxy_ssl_server_name on;
-		proxy_ssl_verify on;
-		proxy_ssl_verify_depth 25;
-		proxy_ssl_name {{$location.ProxySSLName}};
-		{{end}}
 		{{if $location.SSL}}
 		proxy_pass https://{{$location.Upstream.Name}}{{$location.Rewrite}};
 		{{else}}

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -210,15 +210,6 @@ server {
             {{ range $h := $l.AddHeaders }}
         add_header {{ $h.Name }} "{{ $h.Value }}" {{ if $h.Always }}always{{ end }};
             {{ end }}
-            {{ if $.SpiffeCerts }}
-        proxy_ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
-        proxy_ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
-        proxy_ssl_trusted_certificate /etc/nginx/secrets/spiffe_rootca.pem;
-        proxy_ssl_server_name on;
-        proxy_ssl_verify on;
-        proxy_ssl_verify_depth 25;
-        proxy_ssl_name {{ $l.ProxySSLName }};
-            {{ end }}
         proxy_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
         proxy_next_upstream {{ $l.ProxyNextUpstream }};
         proxy_next_upstream_timeout {{ $l.ProxyNextUpstreamTimeout }};

--- a/internal/k8s/spiffe.go
+++ b/internal/k8s/spiffe.go
@@ -32,8 +32,8 @@ func NewSpiffeController(sync func(*workload.X509SVIDs), spireAgentAddr string) 
 
 // Start starts the Spiffe Workload API Client and waits for the Spiffe certs to be written to disk.
 // If the certs are not available after 30 seconds an error is returned.
-// On success, start kicks off the Spiffe Controller's run loop.
-func (sc *spiffeController) Start(stopCh <-chan struct{}) error {
+// On success, calls onStart function and kicks off the Spiffe Controller's run loop.
+func (sc *spiffeController) Start(stopCh <-chan struct{}, onStart func()) error {
 	glog.V(3).Info("Starting SPIFFE Workload API Client")
 	err := sc.client.Start()
 	if err != nil {
@@ -56,6 +56,7 @@ func (sc *spiffeController) Start(stopCh <-chan struct{}) error {
 		}
 		time.Sleep(duration)
 	}
+	onStart()
 	go sc.Run(stopCh)
 	return nil
 }


### PR DESCRIPTION
### Proposed changes
Add support for NGINX Service Mesh internal routes.

- Adds command line flag `-enable-internal-routes` which requires `-spire-agent-address` and `-nginx-plus`. 
If internal routes are enabled an internal route server block is generated to terminate tls connections using the Spiffe certs fetched from the Spire agent. Internal routes are created for Ingress resources that are annotated with `nsm.nginx.com/internal-route: "true"` and can only be accessed by services in NGINX Service Mesh.

- Changes `-spire-agent-address` to require `-nginx-plus` and removes SpiffeCerts config option from the oss templates. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
