### PR TITLE
Fix trailing blank lines in vs/vsr snippets

### DIFF
--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -41,7 +41,7 @@ map {{ $m.Source }} {{ $m.Variable }} {
 {{ end }}
 
 {{ range $snippet := .HTTPSnippets }}
-{{ $snippet }}
+{{- $snippet }}
 {{ end }}
 
 {{ range $m := .StatusMatches }}
@@ -111,7 +111,7 @@ server {
     {{ end }}
 
     {{ range $snippet := $s.Snippets }}
-    {{ $snippet }}
+    {{- $snippet }}
     {{ end }}
 
     {{ range $l := $s.InternalRedirectLocations }}
@@ -161,7 +161,7 @@ server {
         internal;
         {{ end }}
         {{ range $snippet := $l.Snippets }}
-        {{ $snippet }}
+        {{- $snippet }}
         {{ end }}
 
         {{ with $l.PoliciesErrorReturn }}

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -31,7 +31,7 @@ map {{ $m.Source }} {{ $m.Variable }} {
 {{ end }}
 
 {{ range $snippet := .HTTPSnippets }}
-{{ $snippet }}
+{{- $snippet }}
 {{ end }}
 
 {{ $s := .Server }}
@@ -94,7 +94,7 @@ server {
     {{ end }}
 
     {{ range $snippet := $s.Snippets }}
-    {{ $snippet }}
+    {{- $snippet }}
     {{ end }}
 
     {{ range $l := $s.InternalRedirectLocations }}
@@ -130,7 +130,7 @@ server {
         internal;
         {{ end }}
         {{ range $snippet := $l.Snippets }}
-        {{ $snippet }}
+        {{- $snippet }}
         {{ end }}
 
         {{ with $l.PoliciesErrorReturn }}


### PR DESCRIPTION
### Proposed changes
Fixes: https://github.com/nginxinc/kubernetes-ingress/issues/1074

Remove trailing blank lines in vs/vsr snippets. Applies to all snippets(`http`,`server`,`location`)

#### Example VirtualServer input
```yaml
apiVersion: k8s.nginx.org/v1
kind: VirtualServer
metadata:
  name: cafe
  namespace: default
spec:
  http-snippets: |
    limit_req_zone $binary_remote_addr zone=mylimit:10m rate=1r/s;
    proxy_cache_path /tmp keys_zone=one:10m;
  host: cafe.example.com
  tls:
    secret: cafe-secret
  upstreams:
  - name: tea
    service: tea-svc
    port: 80
  routes:
  - path: /tea
    action:
      pass: tea
```

#### Generated config before change
```nginx
limit_req_zone $binary_remote_addr zone=mylimit:10m rate=1r/s;

proxy_cache_path /tmp keys_zone=one:10m;
```
#### Generated config after change
```nginx
limit_req_zone $binary_remote_addr zone=mylimit:10m rate=1r/s;
proxy_cache_path /tmp keys_zone=one:10m;
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
