### PR TITLE
Fix path to UBI based AppProtect Dockerfile in docs

### DIFF
--- a/docs-web/installation/building-ingress-controller-image.md
+++ b/docs-web/installation/building-ingress-controller-image.md
@@ -73,13 +73,13 @@ The **Makefile** contains the following main variables for you to customize (eit
   1. `DockerfileWithOpentracingForPlus`, for building a debian-based image with NGINX Plus, [opentracing](https://github.com/opentracing-contrib/nginx-opentracing) module and the [Jaeger](https://www.jaegertracing.io/) tracer.
   1. `openshift/Dockerfile`, for building an ubi-based image with NGINX for [Openshift](https://www.openshift.com/) clusters.
   1. `openshift/DockerfileForPlus`, for building an ubi-based image with NGINX Plus for [Openshift](https://www.openshift.com/) clusters.
-  1. `openshift/DockerfileWithAppProtectForPlus `, for building an ubi-based image with NGINX Plus and the [appprotect](/nginx-app-protect/) module for [Openshift](https://www.openshift.com/) clusters.  
+  1. `appprotect/DockerfileWithAppProtectForPlusForOpenShift`, for building an ubi-based image with NGINX Plus and the [appprotect](/nginx-app-protect/) module for [Openshift](https://www.openshift.com/) clusters.
       Note: You need to place a file named `rhel_license` containing Your Organization and Activation key in the project root. Example: 
       ```bash 
       RHEL_ORGANIZATION=1111111
       RHEL_ACTIVATION_KEY=your-key
       ```
-  1. `appprotect/DockerfileWithAppProtectForPlus `, for building a debian-based image with NGINX Plus and the [appprotect](/nginx-app-protect/) module.
+  1. `appprotect/DockerfileWithAppProtectForPlus`, for building a debian-based image with NGINX Plus and the [appprotect](/nginx-app-protect/) module.
 * **GENERATE_DEFAULT_CERT_AND_KEY** - The Ingress controller requires a certificate and a key for the default HTTP/HTTPS server. You can reference them in a TLS Secret in a command-line argument to the Ingress controller. As an alternative, you can add a file in the PEM format with your certificate and key to the image as `/etc/nginx/secrets/default`. Optionally, you can generate a self-signed certificate and a key during the build process. Set `GENERATE_DEFAULT_CERT_AND_KEY` to `1` to generate a certificate and a key in the `default.pem` file. Note that you must add the `ADD` instruction in the Dockerfile to copy the cert and the key to the image. The default value of `GENERATE_DEFAULT_CERT_AND_KEY` is `0`.
 * **DOCKER_BUILD_OPTIONS** -- the [options](https://docs.docker.com/engine/reference/commandline/build/#options) for the `docker build` command. For example, `--pull`.
 * **BUILD_IN_CONTAINER** -- By default, to compile the controller we use the [golang](https://hub.docker.com/_/golang/) container that we run as part of the building process. If you want to compile the controller using your local golang environment:


### PR DESCRIPTION
### Proposed changes
Fixes: https://github.com/nginxinc/kubernetes-ingress/issues/1090

In https://github.com/nginxinc/kubernetes-ingress/pull/1046 we added a UBI based Dockerfile for use in Openshift but the path to the Dockerfile in docs was incorrect.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
