### PR TITLE
Fix GlobalConfiguration support in helm chart

### DIFF
--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -143,7 +143,7 @@ spec:
           - -enable-tls-passthrough={{ .Values.controller.enableTLSPassthrough }}
           - -enable-snippets={{ .Values.controller.enableSnippets }}
 {{- if .Values.controller.globalConfiguration.create }}
-          - -global-configuration=$(POD_NAMESPACE)/{{ .Release.Name }}
+          - -global-configuration=$(POD_NAMESPACE)/{{ include "nginx-ingress.name" . }}
 {{- end }}
 {{- end }}
           - -ready-status={{ .Values.controller.readyStatus.enable }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -141,7 +141,7 @@ spec:
           - -enable-tls-passthrough={{ .Values.controller.enableTLSPassthrough }}
           - -enable-snippets={{ .Values.controller.enableSnippets }}
 {{- if .Values.controller.globalConfiguration.create }}
-          - -global-configuration=$(POD_NAMESPACE)/{{ .Release.Name }}
+          - -global-configuration=$(POD_NAMESPACE)/{{ include "nginx-ingress.name" . }}
 {{- end }}
 {{- end }}
           - -ready-status={{ .Values.controller.readyStatus.enable }}


### PR DESCRIPTION
### Proposed changes
Fixes: https://github.com/nginxinc/kubernetes-ingress/issues/1103

* Add autogenerated `nginx-ingress` suffix via `{{ include "nginx-ingress.name" . }}` to match https://github.com/nginxinc/kubernetes-ingress/blob/aa6e36e414d7d7926763e387f31712530334d935/deployments/helm-chart/templates/controller-globalconfiguration.yaml#L5

Bug introduced in: https://github.com/nginxinc/kubernetes-ingress/pull/1034

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
