### PR TITLE
Fix GlobalConfiguration support in helm chart

### DIFF
--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -143,7 +143,7 @@ spec:
           - -enable-tls-passthrough={{ .Values.controller.enableTLSPassthrough }}
           - -enable-snippets={{ .Values.controller.enableSnippets }}
 {{- if .Values.controller.globalConfiguration.create }}
-          - -global-configuration=$(POD_NAMESPACE)/{{ .Release.Name }}
+          - -global-configuration=$(POD_NAMESPACE)/{{ include "nginx-ingress.name" . }}
 {{- end }}
 {{- end }}
           - -ready-status={{ .Values.controller.readyStatus.enable }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -141,7 +141,7 @@ spec:
           - -enable-tls-passthrough={{ .Values.controller.enableTLSPassthrough }}
           - -enable-snippets={{ .Values.controller.enableSnippets }}
 {{- if .Values.controller.globalConfiguration.create }}
-          - -global-configuration=$(POD_NAMESPACE)/{{ .Release.Name }}
+          - -global-configuration=$(POD_NAMESPACE)/{{ include "nginx-ingress.name" . }}
 {{- end }}
 {{- end }}
           - -ready-status={{ .Values.controller.readyStatus.enable }}


### PR DESCRIPTION
### Proposed changes
Fixes: #1103 for stable release of KIC

* Fixes that generated GlobalConfiguration resourceName did not match the generated reference in the deployment/daemonset manifest.

Bug introduced in: https://github.com/nginxinc/kubernetes-ingress/commit/058d596271cb24671e4bddb1722f0cd5cfde29aa

Copy of changes: https://github.com/nginxinc/kubernetes-ingress/pull/1105

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
