### PR TITLE
Adjust K8S control plane version to match worker nodes for tests

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -253,16 +253,13 @@ jobs:
           nodes:
             - role: control-plane
             - role: worker
-              image: kindest/node:v${{ env.K8S_VERSION }}
             - role: worker
-              image: kindest/node:v${{ env.K8S_VERSION }}
             - role: worker
-              image: kindest/node:v${{ env.K8S_VERSION }}
           EOF
       - name: Deploy Kubernetes
         id: k8s
         run: |
-          kind create cluster --name ${{ github.run_id }} --config kind-config.yaml --kubeconfig kube-${{ github.run_id }} --wait ${{ env.K8S_TIMEOUT }}
+          kind create cluster --name ${{ github.run_id }} --image=kindest/node:v${{ env.K8S_VERSION }} --config kind-config.yaml --kubeconfig kube-${{ github.run_id }} --wait ${{ env.K8S_TIMEOUT }}
           kind load docker-image ${{ matrix.image }}:${{ matrix.tag }} --name ${{ github.run_id }}
           echo ::set-output name=cluster_ip::$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${{ github.run_id }}-control-plane)
           echo ::set-output name=cluster::$(echo 'nginx-${{ matrix.type }}-${{ matrix.marker }}')

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -296,16 +296,13 @@ jobs:
           nodes:
             - role: control-plane
             - role: worker
-              image: kindest/node:v${{ matrix.k8s }}
             - role: worker
-              image: kindest/node:v${{ matrix.k8s }}
             - role: worker
-              image: kindest/node:v${{ matrix.k8s }}
           EOF
       - name: Deploy Kubernetes
         id: k8s
         run: |
-          kind create cluster --name ${{ github.run_id }} --config kind-config.yaml --kubeconfig kube-${{ github.run_id }} --wait ${{ env.K8S_TIMEOUT }}
+          kind create cluster --name ${{ github.run_id }} --image=kindest/node:v${{ matrix.k8s }} --config kind-config.yaml --kubeconfig kube-${{ github.run_id }} --wait ${{ env.K8S_TIMEOUT }}
           kind load docker-image ${{ matrix.image }}:${{ matrix.tag }} --name ${{ github.run_id }}
           echo ::set-output name=cluster_ip::$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${{ github.run_id }}-control-plane)
           echo ::set-output name=cluster::$(echo 'nginx-${{ matrix.type }}')


### PR DESCRIPTION
### Proposed changes
Make control-plane in K8S use the same version as the workers for smoke tests.
