### PR TITLE
Add prometheus latency collector

### DIFF
--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -113,6 +113,7 @@ type StaticConfigParams struct {
 	EnableInternalRoutes           bool
 	MainAppProtectLoadModule       bool
 	PodName                        string
+	EnableLatencyMetrics           bool
 }
 
 // GlobalConfigParams holds global configuration parameters. For now, it only holds listeners.

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -545,6 +545,7 @@ func GenerateNginxMainConfig(staticCfgParams *StaticConfigParams, config *Config
 		AppProtectPhysicalMemoryThresholds: config.MainAppProtectPhysicalMemoryThresholds,
 		InternalRouteServer:                staticCfgParams.EnableInternalRoutes,
 		InternalRouteServerName:            staticCfgParams.PodName,
+		LatencyMetrics:                     staticCfgParams.EnableLatencyMetrics,
 	}
 	return nginxCfg
 }

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -192,6 +192,7 @@ type MainConfig struct {
 	AppProtectPhysicalMemoryThresholds string
 	InternalRouteServer                bool
 	InternalRouteServerName            string
+	LatencyMetrics                     bool
 }
 
 // NewUpstreamWithDefaultServer creates an upstream with the default server.

--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -53,6 +53,11 @@ http {
     access_log  /var/log/nginx/access.log  main;
     {{end}}
 
+    {{if .LatencyMetrics}}
+    log_format response_time '{"upstreamAddress":"$upstream_addr", "upstreamResponseTime":"$upstream_response_time", "proxyHost":"$proxy_host", "upstreamStatus": "$upstream_status"}';
+    access_log syslog:server=unix:/var/lib/nginx/nginx-syslog.sock,nohostname,tag=nginx response_time;
+    {{end}}
+
     {{- if .AppProtectLoadModule}}
     {{if .AppProtectFailureModeAction}}app_protect_failure_mode_action {{.AppProtectFailureModeAction}};{{end}}
     {{if .AppProtectCookieSeed}}app_protect_cookie_seed {{.AppProtectCookieSeed}};{{end}}

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -50,6 +50,11 @@ http {
     access_log  /var/log/nginx/access.log  main;
     {{end}}
 
+    {{if .LatencyMetrics}}
+    log_format response_time '{"upstreamAddress":"$upstream_addr", "upstreamResponseTime":"$upstream_response_time", "proxyHost":"$proxy_host", "upstreamStatus": "$upstream_status"}';
+    access_log syslog:server=unix:/var/lib/nginx/nginx-syslog.sock,nohostname,tag=nginx response_time;
+    {{end}}
+
     sendfile        on;
     #tcp_nopush     on;
 

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -152,6 +152,7 @@ type LoadBalancerController struct {
 	internalRoutesEnabled         bool
 	syncLock                      sync.Mutex
 	isNginxReady                  bool
+	isLatencyMetricsEnabled       bool
 }
 
 var keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
@@ -183,6 +184,7 @@ type NewLoadBalancerControllerInput struct {
 	TransportServerValidator     *validation.TransportServerValidator
 	SpireAgentAddress            string
 	InternalRoutesEnabled        bool
+	IsLatencyMetricsEnabled      bool
 }
 
 // NewLoadBalancerController creates a controller
@@ -209,6 +211,7 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 		globalConfigurationValidator: input.GlobalConfigurationValidator,
 		transportServerValidator:     input.TransportServerValidator,
 		internalRoutesEnabled:        input.InternalRoutesEnabled,
+		isLatencyMetricsEnabled:      input.IsLatencyMetricsEnabled,
 	}
 
 	eventBroadcaster := record.NewBroadcaster()
@@ -2386,7 +2389,7 @@ func (lbc *LoadBalancerController) createIngress(ing *networking.Ingress) (*conf
 			}
 		}
 
-		if lbc.isNginxPlus {
+		if lbc.isNginxPlus || lbc.isLatencyMetricsEnabled {
 			for _, endpoint := range podEndps {
 				ingEx.PodsByIP[endpoint.Address] = endpoint.PodName
 			}
@@ -2433,7 +2436,7 @@ func (lbc *LoadBalancerController) createIngress(ing *networking.Ingress) (*conf
 				}
 			}
 
-			if lbc.isNginxPlus {
+			if lbc.isNginxPlus || lbc.isLatencyMetricsEnabled {
 				for _, endpoint := range podEndps {
 					ingEx.PodsByIP[endpoint.Address] = endpoint.PodName
 				}
@@ -2572,7 +2575,7 @@ func (lbc *LoadBalancerController) createVirtualServer(virtualServer *conf_v1.Vi
 		endps := getIPAddressesFromEndpoints(podEndps)
 		endpoints[endpointsKey] = endps
 
-		if lbc.isNginxPlus {
+		if lbc.isNginxPlus || lbc.isLatencyMetricsEnabled {
 			for _, endpoint := range podEndps {
 				podsByIP[endpoint.Address] = endpoint.PodName
 			}
@@ -2660,7 +2663,7 @@ func (lbc *LoadBalancerController) createVirtualServer(virtualServer *conf_v1.Vi
 			endps := getIPAddressesFromEndpoints(podEndps)
 			endpoints[endpointsKey] = endps
 
-			if lbc.isNginxPlus {
+			if lbc.isNginxPlus || lbc.isLatencyMetricsEnabled {
 				for _, endpoint := range podEndps {
 					podsByIP[endpoint.Address] = endpoint.PodName
 				}

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -742,7 +742,7 @@ func getMergableDefaults() (cafeMaster, coffeeMinion, teaMinion networking.Ingre
 	cafeMasterIngEx, _ := lbc.createIngress(&cafeMaster)
 	ingExMap["default-cafe-master"] = cafeMasterIngEx
 
-	cnf := configs.NewConfigurator(&nginx.LocalManager{}, &configs.StaticConfigParams{}, &configs.ConfigParams{}, &configs.GlobalConfigParams{}, &version1.TemplateExecutor{}, &version2.TemplateExecutor{}, false, false, nil, false)
+	cnf := configs.NewConfigurator(&nginx.LocalManager{}, &configs.StaticConfigParams{}, &configs.ConfigParams{}, &configs.GlobalConfigParams{}, &version1.TemplateExecutor{}, &version2.TemplateExecutor{}, false, false, nil, false, nil, false)
 
 	// edit private field ingresses to use in testing
 	pointerVal := reflect.ValueOf(cnf)
@@ -956,7 +956,7 @@ func TestFindProbeForPods(t *testing.T) {
 
 func TestGetServicePortForIngressPort(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset()
-	cnf := configs.NewConfigurator(&nginx.LocalManager{}, &configs.StaticConfigParams{}, &configs.ConfigParams{}, &configs.GlobalConfigParams{}, &version1.TemplateExecutor{}, &version2.TemplateExecutor{}, false, false, nil, false)
+	cnf := configs.NewConfigurator(&nginx.LocalManager{}, &configs.StaticConfigParams{}, &configs.ConfigParams{}, &configs.GlobalConfigParams{}, &version1.TemplateExecutor{}, &version2.TemplateExecutor{}, false, false, nil, false, nil, false)
 	lbc := LoadBalancerController{
 		client:           fakeClient,
 		ingressClass:     "nginx",
@@ -1113,7 +1113,7 @@ func TestFindIngressesForSecret(t *testing.T) {
 
 			manager := nginx.NewFakeManager("/etc/nginx")
 
-			cnf := configs.NewConfigurator(manager, &configs.StaticConfigParams{}, &configs.ConfigParams{}, &configs.GlobalConfigParams{}, templateExecutor, templateExecutorV2, false, false, nil, false)
+			cnf := configs.NewConfigurator(manager, &configs.StaticConfigParams{}, &configs.ConfigParams{}, &configs.GlobalConfigParams{}, templateExecutor, templateExecutorV2, false, false, nil, false, nil, false)
 			lbc := LoadBalancerController{
 				client:           fakeClient,
 				ingressClass:     "nginx",
@@ -1304,7 +1304,7 @@ func TestFindIngressesForSecretWithMinions(t *testing.T) {
 
 			manager := nginx.NewFakeManager("/etc/nginx")
 
-			cnf := configs.NewConfigurator(manager, &configs.StaticConfigParams{}, &configs.ConfigParams{}, &configs.GlobalConfigParams{}, templateExecutor, templateExecutorV2, false, false, nil, false)
+			cnf := configs.NewConfigurator(manager, &configs.StaticConfigParams{}, &configs.ConfigParams{}, &configs.GlobalConfigParams{}, templateExecutor, templateExecutorV2, false, false, nil, false, nil, false)
 			lbc := LoadBalancerController{
 				client:           fakeClient,
 				ingressClass:     "nginx",

--- a/internal/metrics/collectors/latency.go
+++ b/internal/metrics/collectors/latency.go
@@ -1,0 +1,315 @@
+package collectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const nginxSeparator = "nginx:"
+
+var latencyBucketsMilliSeconds = []float64{
+	1,
+	2,
+	3,
+	4,
+	5,
+	10,
+	20,
+	30,
+	40,
+	50,
+	100,
+	200,
+	300,
+	400,
+	500,
+	1000,
+	2000,
+	3000,
+	4000,
+	5000,
+	10000,
+	20000,
+	30000,
+	40000,
+	50000,
+}
+
+// LatencyCollector is an interface for latency metrics
+type LatencyCollector interface {
+	RecordLatency(string)
+	UpdateUpstreamServerLabels(map[string][]string)
+	DeleteUpstreamServerLabels([]string)
+	UpdateUpstreamServerPeerLabels(map[string][]string)
+	DeleteUpstreamServerPeerLabels([]string)
+	DeleteMetrics([]string)
+	Register(*prometheus.Registry) error
+}
+
+// metricsPublishedMap is a map of upstream server peers (upstream/server) to a metricsSet.
+// This map is used to keep track of all the metrics published for each upstream server peer,
+// so that the metrics can be deleted when the upstream server peers are deleted.
+type metricsPublishedMap map[string]metricsSet
+
+// metricsSet is a set of metrics published.
+// The keys are string representations of the lists of label values for a published metric.
+// The list of label values is joined with the "+" symbol. For example, a metric produced with the label values
+// ["one", "two", "three"] is added to the set with the key "one+two+three".
+type metricsSet map[string]struct{}
+
+// LatencyMetricsCollector implements the LatencyCollector interface and prometheus.Collector interface
+type LatencyMetricsCollector struct {
+	httpLatency                  *prometheus.HistogramVec
+	upstreamServerLabelNames     []string
+	upstreamServerPeerLabelNames []string
+	upstreamServerLabels         map[string][]string
+	upstreamServerPeerLabels     map[string][]string
+	metricsPublishedMap          metricsPublishedMap
+	metricsPublishedMutex        sync.Mutex
+	variableLabelsMutex          sync.RWMutex
+}
+
+// NewLatencyMetricsCollector creates a new LatencyMetricsCollector
+func NewLatencyMetricsCollector(
+	constLabels map[string]string,
+	upstreamServerLabelNames []string,
+	upstreamServerPeerLabelNames []string,
+) *LatencyMetricsCollector {
+	return &LatencyMetricsCollector{
+		httpLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:   metricsNamespace,
+			Name:        "upstream_server_response_latency_ms",
+			Help:        "Bucketed response times from when NGINX establishes a connection to an upstream server to when the last byte of the response body is received by NGINX",
+			ConstLabels: constLabels,
+			Buckets:     latencyBucketsMilliSeconds,
+		},
+			createLatencyLabelNames(upstreamServerLabelNames, upstreamServerPeerLabelNames),
+		),
+		upstreamServerLabels:         make(map[string][]string),
+		upstreamServerPeerLabels:     make(map[string][]string),
+		metricsPublishedMap:          make(metricsPublishedMap),
+		upstreamServerLabelNames:     upstreamServerLabelNames,
+		upstreamServerPeerLabelNames: upstreamServerPeerLabelNames,
+	}
+}
+
+// UpdateUpstreamServerPeerLabels updates the Upstream Server Peer Labels
+func (l *LatencyMetricsCollector) UpdateUpstreamServerPeerLabels(upstreamServerPeerLabels map[string][]string) {
+	l.variableLabelsMutex.Lock()
+	for k, v := range upstreamServerPeerLabels {
+		l.upstreamServerPeerLabels[k] = v
+	}
+	l.variableLabelsMutex.Unlock()
+}
+
+// DeleteUpstreamServerPeerLabels deletes the Upstream Server Peer Labels
+func (l *LatencyMetricsCollector) DeleteUpstreamServerPeerLabels(peers []string) {
+	l.variableLabelsMutex.Lock()
+	for _, k := range peers {
+		delete(l.upstreamServerPeerLabels, k)
+	}
+	l.variableLabelsMutex.Unlock()
+}
+
+// UpdateUpstreamServerLabels updates the upstream server label map
+func (l *LatencyMetricsCollector) UpdateUpstreamServerLabels(newLabelValues map[string][]string) {
+	l.variableLabelsMutex.Lock()
+	for k, v := range newLabelValues {
+		l.upstreamServerLabels[k] = v
+	}
+	l.variableLabelsMutex.Unlock()
+}
+
+// DeleteUpstreamServerLabels deletes upstream server labels
+func (l *LatencyMetricsCollector) DeleteUpstreamServerLabels(upstreamNames []string) {
+	l.variableLabelsMutex.Lock()
+	for _, k := range upstreamNames {
+		delete(l.upstreamServerLabels, k)
+	}
+	l.variableLabelsMutex.Unlock()
+}
+
+// DeleteMetrics deletes all metrics published associated with the given upstream server peer names.
+func (l *LatencyMetricsCollector) DeleteMetrics(upstreamServerPeerNames []string) {
+	for _, name := range upstreamServerPeerNames {
+		for _, labelValues := range l.listAndDeleteMetricsPublished(name) {
+			success := l.httpLatency.DeleteLabelValues(labelValues...)
+			if !success {
+				glog.Warningf("could not delete metric for upstream server peer: %s with values: %v", name, labelValues)
+			}
+		}
+	}
+}
+
+func (l *LatencyMetricsCollector) getUpstreamServerPeerLabelValues(peer string) []string {
+	l.variableLabelsMutex.RLock()
+	defer l.variableLabelsMutex.RUnlock()
+	return l.upstreamServerPeerLabels[peer]
+}
+
+func (l *LatencyMetricsCollector) getUpstreamServerLabels(upstreamName string) []string {
+	l.variableLabelsMutex.RLock()
+	defer l.variableLabelsMutex.RUnlock()
+	return l.upstreamServerLabels[upstreamName]
+}
+
+// Register registers all the metrics of the collector
+func (l *LatencyMetricsCollector) Register(registry *prometheus.Registry) error {
+	return registry.Register(l)
+}
+
+// Describe implements prometheus.Collector interface Describe method
+func (l *LatencyMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	l.httpLatency.Describe(ch)
+}
+
+// Collect implements the prometheus.Collector interface Collect method
+func (l *LatencyMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	l.httpLatency.Collect(ch)
+}
+
+// RecordLatency parses a syslog message and records latency
+func (l *LatencyMetricsCollector) RecordLatency(syslogMsg string) {
+	lm, err := parseMessage(syslogMsg)
+	if err != nil {
+		glog.V(3).Infof("could not parse syslog message: %v", err)
+		return
+	}
+	labelValues, err := l.createLatencyLabelValues(lm)
+	if err != nil {
+		glog.Errorf("cannot record latency for upstream %s and server %s: %v", lm.Upstream, lm.Server, err)
+		return
+	}
+	l.httpLatency.WithLabelValues(labelValues...).Observe(lm.Latency * 1000)
+	l.updateMetricsPublished(lm.Upstream, lm.Server, labelValues)
+}
+
+func (l *LatencyMetricsCollector) updateMetricsPublished(upstreamName, server string, labelValues []string) {
+	l.metricsPublishedMutex.Lock()
+	key := fmt.Sprintf("%s/%s", upstreamName, server)
+	if _, ok := l.metricsPublishedMap[key]; !ok {
+		l.metricsPublishedMap[key] = make(metricsSet)
+	}
+	l.metricsPublishedMap[key][strings.Join(labelValues, "+")] = struct{}{}
+	l.metricsPublishedMutex.Unlock()
+}
+
+func (l *LatencyMetricsCollector) listAndDeleteMetricsPublished(key string) (metricsPublished [][]string) {
+	l.metricsPublishedMutex.Lock()
+	defer l.metricsPublishedMutex.Unlock()
+	for labelValues := range l.metricsPublishedMap[key] {
+		metricsPublished = append(metricsPublished, strings.Split(labelValues, "+"))
+	}
+	delete(l.metricsPublishedMap, key)
+	return metricsPublished
+}
+
+func (l *LatencyMetricsCollector) createLatencyLabelValues(lm latencyMetric) ([]string, error) {
+	labelValues := []string{lm.Upstream, lm.Server, lm.Code}
+	upstreamServerLabelValues := l.getUpstreamServerLabels(lm.Upstream)
+	if len(l.upstreamServerLabelNames) != len(upstreamServerLabelValues) {
+		return nil, fmt.Errorf("wrong number of labels for upstream %v. For labels %v, got values: %v",
+			lm.Upstream, l.upstreamServerLabelNames, upstreamServerLabelValues)
+	}
+	labelValues = append(labelValues, upstreamServerLabelValues...)
+	peerServerLabelValues := l.getUpstreamServerPeerLabelValues(fmt.Sprintf("%v/%v", lm.Upstream, lm.Server))
+	if len(l.upstreamServerPeerLabelNames) != len(peerServerLabelValues) {
+		return nil, fmt.Errorf("wrong number of labels for upstream peer %v. For labels %v, got values: %v",
+			lm.Server, l.upstreamServerPeerLabelNames, peerServerLabelValues)
+	}
+	labelValues = append(labelValues, peerServerLabelValues...)
+	return labelValues, nil
+}
+
+func createLatencyLabelNames(upstreamServerLabelNames, upstreamServerPeerLabelNames []string) []string {
+	return append(append([]string{"upstream", "server", "code"}, upstreamServerLabelNames...), upstreamServerPeerLabelNames...)
+}
+
+type syslogMsg struct {
+	ProxyHost            string `json:"proxyHost"`
+	UpstreamAddr         string `json:"upstreamAddress"`
+	UpstreamStatus       string `json:"upstreamStatus"`
+	UpstreamResponseTime string `json:"upstreamResponseTime"`
+}
+
+type latencyMetric struct {
+	Upstream string
+	Server   string
+	Code     string
+	Latency  float64
+}
+
+func parseMessage(msg string) (latencyMetric, error) {
+	msgParts := strings.Split(msg, nginxSeparator)
+	if len(msgParts) != 2 {
+		return latencyMetric{}, fmt.Errorf("wrong message format: %s, expected message to start with \"%s\"", msg, nginxSeparator)
+	}
+	var sm syslogMsg
+	info := msgParts[1]
+	if err := json.Unmarshal([]byte(info), &sm); err != nil {
+		return latencyMetric{}, fmt.Errorf("could not unmarshal %s: %v", msg, err)
+	}
+	if sm.UpstreamAddr == sm.ProxyHost {
+		// no upstream connected so don't publish a metric
+		return latencyMetric{}, fmt.Errorf("nginx could not connect to upstream")
+	}
+	server := parseMultipartResponse(sm.UpstreamAddr)
+	latency, err := strconv.ParseFloat(parseMultipartResponse(sm.UpstreamResponseTime), 64)
+	if err != nil {
+		return latencyMetric{}, fmt.Errorf("could not parse float from upstream response time %s: %v", sm.UpstreamResponseTime, err)
+	}
+	code := parseMultipartResponse(sm.UpstreamStatus)
+	lm := latencyMetric{
+		Upstream: sm.ProxyHost,
+		Server:   server,
+		Code:     code,
+		Latency:  latency,
+	}
+
+	return lm, nil
+}
+
+// parseMutlipartResponse checks if the input string contains commas.
+// If it does it returns the last item of the list, otherwise it returns input.
+func parseMultipartResponse(input string) string {
+	parts := strings.Split(input, ",")
+	if l := len(parts); l > 1 {
+		return strings.TrimLeft(parts[l-1], " ")
+	}
+	return input
+}
+
+// LatencyFakeCollector is a fake collector that implements the LatencyCollector interface
+type LatencyFakeCollector struct{}
+
+// DeleteMetrics implements a fake DeleteMetrics
+func (l *LatencyFakeCollector) DeleteMetrics([]string) {}
+
+// UpdateUpstreamServerPeerLabels implements a fake UpdateUpstreamServerPeerLabels
+func (l *LatencyFakeCollector) UpdateUpstreamServerPeerLabels(map[string][]string) {}
+
+// DeleteUpstreamServerPeerLabels implements a fake DeleteUpstreamServerPeerLabels
+func (l *LatencyFakeCollector) DeleteUpstreamServerPeerLabels([]string) {}
+
+// UpdateUpstreamServerLabels implements a fake UpdateUpstreamServerLabels
+func (l *LatencyFakeCollector) UpdateUpstreamServerLabels(map[string][]string) {}
+
+// UpdateUpstreamServerLabels implements a fake DeleteUpstreamServerLabels
+func (l *LatencyFakeCollector) DeleteUpstreamServerLabels([]string) {}
+
+// NewControllerFakeCollector creates a fake collector that implements the LatencyCollector interface
+func NewLatencyFakeCollector() *LatencyFakeCollector {
+	return &LatencyFakeCollector{}
+}
+
+// Register implements a fake Register
+func (l *LatencyFakeCollector) Register(_ *prometheus.Registry) error { return nil }
+
+// RecordLatency implements a fake RecordLatency
+func (l *LatencyFakeCollector) RecordLatency(_ string) {}

--- a/internal/metrics/collectors/latency_test.go
+++ b/internal/metrics/collectors/latency_test.go
@@ -1,0 +1,233 @@
+package collectors
+
+import (
+	"reflect"
+	"testing"
+)
+
+func newTestLatencyMetricsCollector() *LatencyMetricsCollector {
+	return &LatencyMetricsCollector{
+		upstreamServerLabels:         make(map[string][]string),
+		upstreamServerPeerLabels:     make(map[string][]string),
+		metricsPublishedMap:          make(metricsPublishedMap),
+		upstreamServerLabelNames:     []string{"service", "resource_type", "resource_name", "resource_namespace"},
+		upstreamServerPeerLabelNames: []string{"pod_name"},
+	}
+}
+func TestParseMessageWithValidInputs(t *testing.T) {
+	tests := []struct {
+		msg         string
+		expectedErr bool
+		expected    latencyMetric
+	}{
+		{
+			msg:         `nginx: {"upstreamAddress":"10.0.0.1", "upstreamResponseTime":"0.003", "proxyHost":"upstream-1", "upstreamStatus": "200"}`,
+			expectedErr: false,
+			expected: latencyMetric{
+				Upstream: "upstream-1",
+				Server:   "10.0.0.1",
+				Latency:  0.003,
+				Code:     "200",
+			},
+		},
+		{
+			msg:         `nginx: {"upstreamAddress":"127.0.0.1:6001, 127.0.0.1:6002, 127.0.0.1:8001", "upstreamResponseTime":"0.9, 0.99, 0.1", "proxyHost":"upstream-1", "upstreamStatus": "500, 500, 200"}`,
+			expectedErr: false,
+			expected: latencyMetric{
+				Upstream: "upstream-1",
+				Server:   "127.0.0.1:8001",
+				Latency:  0.1,
+				Code:     "200",
+			},
+		},
+		{
+			msg:         `nginx: {"upstreamAddress":"upstream-1", "upstreamResponseTime":"0.0", "proxyHost":"upstream-1", "upstreamStatus": "404"}`,
+			expectedErr: true,
+		},
+		{
+			msg:         `nginx: {"upstreamAddress":"-", "upstreamResponseTime":"0.0", "proxyHost":"-", "upstreamStatus": "404"}`,
+			expectedErr: true,
+		},
+		{
+			msg:         `nginx: {"upstreamAddress":"10.0.0.1", "upstreamResponseTime":"not-a-float", "proxyHost":"upstream-1", "upstreamStatus": "404"}`,
+			expectedErr: true,
+		},
+		{
+			msg:         `wrong format`,
+			expectedErr: true,
+		},
+		{
+			msg:         `nginx: {"badJson}`,
+			expectedErr: true,
+		},
+	}
+	for _, test := range tests {
+		actual, err := parseMessage(test.msg)
+		if test.expectedErr {
+			if err == nil {
+				t.Errorf("parseMessage should return an error, got nil")
+			}
+		} else {
+			if err != nil {
+				t.Errorf("parseMessage returned an unexpected error: %v", err)
+			}
+			if actual != test.expected {
+				t.Errorf("parseMessage returned: %+v, expected: %+v", actual, test.expected)
+			}
+		}
+	}
+}
+
+func TestCreateLatencyLabelNames(t *testing.T) {
+	expected := []string{"upstream", "server", "code", "one", "two", "three", "four", "five"}
+	actual := createLatencyLabelNames([]string{"one", "two", "three"}, []string{"four", "five"})
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("createLatencyLabelNames returned: %v, expected: %v", actual, expected)
+	}
+}
+
+func TestCreateLatencyLabelNamesWithNilInputs(t *testing.T) {
+	expected := []string{"upstream", "server", "code"}
+	actual := createLatencyLabelNames(nil, nil)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("createLatencyLabelNames returned: %v, expected: %v", actual, expected)
+	}
+}
+
+func TestCreateLatencyLabelValuesWithCorrectNumberOfLabels(t *testing.T) {
+	collector := newTestLatencyMetricsCollector()
+	collector.upstreamServerLabels["upstream-1"] = []string{"service-1", "ingress", "ingress-1", "default"}
+	collector.upstreamServerPeerLabels["upstream-1/10.0.0.1"] = []string{"pod-1"}
+
+	lm := latencyMetric{
+		Upstream: "upstream-1",
+		Server:   "10.0.0.1",
+		Code:     "200",
+	}
+	expected := []string{"upstream-1", "10.0.0.1", "200", "service-1", "ingress", "ingress-1", "default", "pod-1"}
+	actual, err := collector.createLatencyLabelValues(lm)
+	if err != nil {
+		t.Errorf("createLatencyLabelValues returned unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("createLatencyLabelValues returned: %v, expected: %v", actual, expected)
+	}
+}
+
+func TestCreateLatencyLabelValuesWithNoUpstreamServerLabels(t *testing.T) {
+	collector := newTestLatencyMetricsCollector()
+	collector.upstreamServerPeerLabels["upstream-1/10.0.0.1"] = []string{"pod-1"}
+	lm := latencyMetric{
+		Upstream: "upstream-1",
+		Server:   "10.0.0.1",
+		Code:     "200",
+	}
+	_, err := collector.createLatencyLabelValues(lm)
+	if err == nil {
+		t.Error("createLatencyLabelValues should have returned an error, got nil")
+	}
+}
+
+func TestCreateLatencyLabelValuesWithNoUpstreamPeerServerLabels(t *testing.T) {
+	collector := newTestLatencyMetricsCollector()
+	collector.upstreamServerLabels["upstream-1"] = []string{"service-1", "ingress", "ingress-1", "default"}
+	lm := latencyMetric{
+		Upstream: "upstream-1",
+		Server:   "10.0.0.1",
+		Code:     "200",
+	}
+	_, err := collector.createLatencyLabelValues(lm)
+	if err == nil {
+		t.Error("createLatencyLabelValues should have returned an error, got nil")
+	}
+}
+
+func TestCreateLatencyLabelValuesWithNoLabels(t *testing.T) {
+	collector := newTestLatencyMetricsCollector()
+	lm := latencyMetric{
+		Upstream: "upstream-1",
+		Server:   "10.0.0.1",
+		Code:     "200",
+	}
+	_, err := collector.createLatencyLabelValues(lm)
+	if err == nil {
+		t.Error("createLatencyLabelValues should have returned an error, got nil")
+	}
+}
+
+func TestMetricsPublished(t *testing.T) {
+	collector := newTestLatencyMetricsCollector()
+	labelValueList1 := []string{"label-value-1", "label-value-2", "label-value-3"}
+	labelValueList2 := []string{"new-label-value-1", "new-label-value-2", "new-label-value-3"}
+	// add metric for upstream-1
+	collector.updateMetricsPublished("upstream-1", "10.0.0.0:80", labelValueList1)
+	// add the same metric
+	collector.updateMetricsPublished("upstream-1", "10.0.0.0:80", labelValueList1)
+	// add a new metric for upstream-1
+	collector.updateMetricsPublished("upstream-1", "10.0.0.0:80", labelValueList2)
+	// add metric for upstream-2
+	collector.updateMetricsPublished("upstream-2", "10.0.0.0:80", labelValueList1)
+
+	if l := len(collector.metricsPublishedMap); l != 2 {
+		t.Errorf("updateMetricsPublished did not update metricsPublishedMap map correctly, length is %d expected 2", l)
+	}
+
+	// verify metrics for upstream-1 are correct
+	upstream1Metrics, ok := collector.metricsPublishedMap["upstream-1/10.0.0.0:80"]
+	if !ok {
+		t.Errorf("updateMetricsPublished did not add upstream-1 as key to map")
+	}
+	if l := len(upstream1Metrics); l != 2 {
+		t.Errorf("updateMetricsPublished did not update upstream-1 map correctly, length is %d expected 2", l)
+	}
+
+	// call list and delete
+	labelValuesUpstream1 := collector.listAndDeleteMetricsPublished("upstream-1/10.0.0.0:80")
+	if l := len(labelValuesUpstream1); l != 2 {
+		t.Errorf("listAndDeleteMetricsPublished return a list of length %d for upstream-1, expected 2", l)
+	}
+	if !contains(labelValueList1, labelValuesUpstream1) {
+		t.Errorf("listAndDeleteMetricsPublished did not return metric labels %v in list %v", labelValueList1, labelValuesUpstream1)
+	}
+	if !contains(labelValueList2, labelValuesUpstream1) {
+		t.Errorf("listAndDeleteMetricsPublished did not return metric labels %v in list %v", labelValueList2, labelValuesUpstream1)
+	}
+	if _, ok := collector.metricsPublishedMap["upstream-1/10.0.0.0:80"]; ok {
+		t.Errorf("listAndDeleteMetricsPublished did not delete upstream-1 from map")
+	}
+
+	// verify metrics for upstream-2 are correct
+	upstream2Metrics, ok := collector.metricsPublishedMap["upstream-2/10.0.0.0:80"]
+	if !ok {
+		t.Errorf("updateMetricsPublished did not add upstream-2 as key to map")
+	}
+	if l := len(upstream2Metrics); l != 1 {
+		t.Errorf("updateMetricsPublished did not update upstream-2 map correctly, length is %d expected 1", l)
+	}
+
+	// call list and delete
+	labelValuesUpstream2 := collector.listAndDeleteMetricsPublished("upstream-2/10.0.0.0:80")
+	if l := len(labelValuesUpstream2); l != 1 {
+		t.Errorf("listAndDeleteMetricsPublished return a list of length %d for upstream-2, expected 1", l)
+	}
+	if !reflect.DeepEqual(labelValuesUpstream2[0], labelValueList1) {
+		t.Errorf("listAndDeleteMetricsPublished returned %v for upstream-2, expected: %v", labelValueList1, labelValuesUpstream2[0])
+	}
+	if _, ok := collector.metricsPublishedMap["upstream-2/10.0.0.0:80"]; ok {
+		t.Errorf("listAndDeleteMetricsPublished did not delete upstream-2 from map")
+	}
+
+	// double check map is empty
+	if l := len(collector.metricsPublishedMap); l != 0 {
+		t.Errorf("listAndDeleteMetricsPublished did not delete upstreams from map")
+	}
+}
+
+func contains(x []string, y [][]string) bool {
+	for _, l := range y {
+		if reflect.DeepEqual(x, l) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/metrics/syslog_listener.go
+++ b/internal/metrics/syslog_listener.go
@@ -1,0 +1,83 @@
+package metrics
+
+import (
+	"net"
+
+	"github.com/golang/glog"
+
+	"github.com/nginxinc/kubernetes-ingress/internal/metrics/collectors"
+)
+
+// SyslogListener is an interface for syslog metrics listener
+// that reads syslog metrics logged by nginx
+type SyslogListener interface {
+	Run()
+	Stop()
+}
+
+// LatencyMetricsListener implements the SyslogListener interface
+type LatencyMetricsListener struct {
+	conn      *net.UnixConn
+	addr      string
+	collector collectors.LatencyCollector
+}
+
+// NewLatencyMetricsListener returns a LatencyMetricsListener that listens over a unix socket
+// for syslog messages from nginx.
+func NewLatencyMetricsListener(sockPath string, c collectors.LatencyCollector) SyslogListener {
+	glog.Infof("Starting latency metrics server listening on: %s", sockPath)
+	conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
+		Name: sockPath,
+		Net:  "unixgram",
+	})
+	if err != nil {
+		glog.Errorf("Failed to create latency metrics listener: %v. Latency metrics will not be collected.", err)
+		return NewSyslogFakeServer()
+	}
+	return &LatencyMetricsListener{conn: conn, addr: sockPath, collector: c}
+}
+
+// Run reads from the unix connection until an unrecoverable error occurs or the connection is closed.
+func (l LatencyMetricsListener) Run() {
+	buffer := make([]byte, 1024)
+	for {
+		n, err := l.conn.Read(buffer)
+		if err != nil {
+			if !isErrorRecoverable(err) {
+				glog.Info("Stopping latency metrics listener")
+				return
+			}
+		}
+		go l.collector.RecordLatency(string(buffer[:n]))
+	}
+}
+
+// Stop closes the unix connection of the listener.
+func (l LatencyMetricsListener) Stop() {
+	err := l.conn.Close()
+	if err != nil {
+		glog.Errorf("error closing latency metrics unix connection: %v", err)
+	}
+}
+
+func isErrorRecoverable(err error) bool {
+	if nerr, ok := err.(*net.OpError); ok && nerr.Temporary() {
+		return true
+	} else {
+		return false
+	}
+}
+
+// SyslogFakeListener is a fake implementation of the SyslogListener interface
+type SyslogFakeListener struct{}
+
+// NewFakeSyslogServer returns a SyslogFakeListener
+func NewSyslogFakeServer() *SyslogFakeListener {
+	return &SyslogFakeListener{}
+}
+
+// Run is a fake implementation of SyslogListener Run
+func (s SyslogFakeListener) Run() {}
+
+// Stop is a fake implementation of SyslogListener Stop
+func (s SyslogFakeListener) Stop() {}


### PR DESCRIPTION
### Proposed changes

Adds prometheus latency collector that calculates http upstream server latency in milliseconds using a prometheus histogram vector. 
Latency metrics are published under the names: 
- `nginx_ingress_controller_upstream_server_response_latency_ms_bucket`
- `nginx_ingress_controller_upstream_server_response_latency_ms_sum`
- `nginx_ingress_controller_upstream_server_response_latency_ms_count` 

The metrics have the following labels:  upstream, server, resource_namespace, resource_type, resource_name, service, pod_name, and code. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
