### PR TITLE
add gRPC support for VirtualServer

### DIFF
--- a/deployments/common/crds-v1beta1/k8s.nginx.org_virtualserverroutes.yaml
+++ b/deployments/common/crds-v1beta1/k8s.nginx.org_virtualserverroutes.yaml
@@ -66,8 +66,6 @@ spec:
                     description: Action defines an action.
                     type: object
                     properties:
-                      grpc:
-                        type: boolean
                       pass:
                         type: string
                       proxy:
@@ -190,8 +188,6 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
-                            grpc:
-                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -290,8 +286,6 @@ spec:
                                 description: Action defines an action.
                                 type: object
                                 properties:
-                                  grpc:
-                                    type: boolean
                                   pass:
                                     type: string
                                   proxy:
@@ -390,8 +384,6 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
-                            grpc:
-                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -490,6 +482,8 @@ spec:
                     type: string
                   fail-timeout:
                     type: string
+                  grpc:
+                    type: boolean
                   healthCheck:
                     description: HealthCheck defines the parameters for active Upstream HealthChecks.
                     type: object

--- a/deployments/common/crds-v1beta1/k8s.nginx.org_virtualserverroutes.yaml
+++ b/deployments/common/crds-v1beta1/k8s.nginx.org_virtualserverroutes.yaml
@@ -66,6 +66,8 @@ spec:
                     description: Action defines an action.
                     type: object
                     properties:
+                      grpc:
+                        type: boolean
                       pass:
                         type: string
                       proxy:
@@ -188,6 +190,8 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
+                            grpc:
+                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -286,6 +290,8 @@ spec:
                                 description: Action defines an action.
                                 type: object
                                 properties:
+                                  grpc:
+                                    type: boolean
                                   pass:
                                     type: string
                                   proxy:
@@ -384,6 +390,8 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
+                            grpc:
+                              type: boolean
                             pass:
                               type: string
                             proxy:

--- a/deployments/common/crds-v1beta1/k8s.nginx.org_virtualservers.yaml
+++ b/deployments/common/crds-v1beta1/k8s.nginx.org_virtualservers.yaml
@@ -78,6 +78,8 @@ spec:
                     description: Action defines an action.
                     type: object
                     properties:
+                      grpc:
+                        type: boolean
                       pass:
                         type: string
                       proxy:
@@ -200,6 +202,8 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
+                            grpc:
+                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -298,6 +302,8 @@ spec:
                                 description: Action defines an action.
                                 type: object
                                 properties:
+                                  grpc:
+                                    type: boolean
                                   pass:
                                     type: string
                                   proxy:
@@ -396,6 +402,8 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
+                            grpc:
+                              type: boolean
                             pass:
                               type: string
                             proxy:

--- a/deployments/common/crds-v1beta1/k8s.nginx.org_virtualservers.yaml
+++ b/deployments/common/crds-v1beta1/k8s.nginx.org_virtualservers.yaml
@@ -78,8 +78,6 @@ spec:
                     description: Action defines an action.
                     type: object
                     properties:
-                      grpc:
-                        type: boolean
                       pass:
                         type: string
                       proxy:
@@ -202,8 +200,6 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
-                            grpc:
-                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -302,8 +298,6 @@ spec:
                                 description: Action defines an action.
                                 type: object
                                 properties:
-                                  grpc:
-                                    type: boolean
                                   pass:
                                     type: string
                                   proxy:
@@ -402,8 +396,6 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
-                            grpc:
-                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -520,6 +512,8 @@ spec:
                     type: string
                   fail-timeout:
                     type: string
+                  grpc:
+                    type: boolean
                   healthCheck:
                     description: HealthCheck defines the parameters for active Upstream HealthChecks.
                     type: object

--- a/deployments/common/crds/k8s.nginx.org_virtualserverroutes.yaml
+++ b/deployments/common/crds/k8s.nginx.org_virtualserverroutes.yaml
@@ -65,8 +65,6 @@ spec:
                         description: Action defines an action.
                         type: object
                         properties:
-                          grpc:
-                            type: boolean
                           pass:
                             type: string
                           proxy:
@@ -189,8 +187,6 @@ spec:
                               description: Action defines an action.
                               type: object
                               properties:
-                                grpc:
-                                  type: boolean
                                 pass:
                                   type: string
                                 proxy:
@@ -289,8 +285,6 @@ spec:
                                     description: Action defines an action.
                                     type: object
                                     properties:
-                                      grpc:
-                                        type: boolean
                                       pass:
                                         type: string
                                       proxy:
@@ -389,8 +383,6 @@ spec:
                               description: Action defines an action.
                               type: object
                               properties:
-                                grpc:
-                                  type: boolean
                                 pass:
                                   type: string
                                 proxy:
@@ -489,6 +481,8 @@ spec:
                         type: string
                       fail-timeout:
                         type: string
+                      grpc:
+                        type: boolean
                       healthCheck:
                         description: HealthCheck defines the parameters for active Upstream HealthChecks.
                         type: object

--- a/deployments/common/crds/k8s.nginx.org_virtualserverroutes.yaml
+++ b/deployments/common/crds/k8s.nginx.org_virtualserverroutes.yaml
@@ -65,6 +65,8 @@ spec:
                         description: Action defines an action.
                         type: object
                         properties:
+                          grpc:
+                            type: boolean
                           pass:
                             type: string
                           proxy:
@@ -187,6 +189,8 @@ spec:
                               description: Action defines an action.
                               type: object
                               properties:
+                                grpc:
+                                  type: boolean
                                 pass:
                                   type: string
                                 proxy:
@@ -285,6 +289,8 @@ spec:
                                     description: Action defines an action.
                                     type: object
                                     properties:
+                                      grpc:
+                                        type: boolean
                                       pass:
                                         type: string
                                       proxy:
@@ -383,6 +389,8 @@ spec:
                               description: Action defines an action.
                               type: object
                               properties:
+                                grpc:
+                                  type: boolean
                                 pass:
                                   type: string
                                 proxy:

--- a/deployments/common/crds/k8s.nginx.org_virtualservers.yaml
+++ b/deployments/common/crds/k8s.nginx.org_virtualservers.yaml
@@ -77,6 +77,8 @@ spec:
                         description: Action defines an action.
                         type: object
                         properties:
+                          grpc:
+                            type: boolean
                           pass:
                             type: string
                           proxy:
@@ -199,6 +201,8 @@ spec:
                               description: Action defines an action.
                               type: object
                               properties:
+                                grpc:
+                                  type: boolean
                                 pass:
                                   type: string
                                 proxy:
@@ -297,6 +301,8 @@ spec:
                                     description: Action defines an action.
                                     type: object
                                     properties:
+                                      grpc:
+                                        type: boolean
                                       pass:
                                         type: string
                                       proxy:
@@ -395,6 +401,8 @@ spec:
                               description: Action defines an action.
                               type: object
                               properties:
+                                grpc:
+                                  type: boolean
                                 pass:
                                   type: string
                                 proxy:

--- a/deployments/common/crds/k8s.nginx.org_virtualservers.yaml
+++ b/deployments/common/crds/k8s.nginx.org_virtualservers.yaml
@@ -77,8 +77,6 @@ spec:
                         description: Action defines an action.
                         type: object
                         properties:
-                          grpc:
-                            type: boolean
                           pass:
                             type: string
                           proxy:
@@ -201,8 +199,6 @@ spec:
                               description: Action defines an action.
                               type: object
                               properties:
-                                grpc:
-                                  type: boolean
                                 pass:
                                   type: string
                                 proxy:
@@ -301,8 +297,6 @@ spec:
                                     description: Action defines an action.
                                     type: object
                                     properties:
-                                      grpc:
-                                        type: boolean
                                       pass:
                                         type: string
                                       proxy:
@@ -401,8 +395,6 @@ spec:
                               description: Action defines an action.
                               type: object
                               properties:
-                                grpc:
-                                  type: boolean
                                 pass:
                                   type: string
                                 proxy:
@@ -519,6 +511,8 @@ spec:
                         type: string
                       fail-timeout:
                         type: string
+                      grpc:
+                        type: boolean
                       healthCheck:
                         description: HealthCheck defines the parameters for active Upstream HealthChecks.
                         type: object

--- a/deployments/helm-chart/crds/k8s.nginx.org_virtualserverroutes.yaml
+++ b/deployments/helm-chart/crds/k8s.nginx.org_virtualserverroutes.yaml
@@ -66,8 +66,6 @@ spec:
                     description: Action defines an action.
                     type: object
                     properties:
-                      grpc:
-                        type: boolean
                       pass:
                         type: string
                       proxy:
@@ -190,8 +188,6 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
-                            grpc:
-                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -290,8 +286,6 @@ spec:
                                 description: Action defines an action.
                                 type: object
                                 properties:
-                                  grpc:
-                                    type: boolean
                                   pass:
                                     type: string
                                   proxy:
@@ -390,8 +384,6 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
-                            grpc:
-                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -490,6 +482,8 @@ spec:
                     type: string
                   fail-timeout:
                     type: string
+                  grpc:
+                    type: boolean
                   healthCheck:
                     description: HealthCheck defines the parameters for active Upstream HealthChecks.
                     type: object

--- a/deployments/helm-chart/crds/k8s.nginx.org_virtualserverroutes.yaml
+++ b/deployments/helm-chart/crds/k8s.nginx.org_virtualserverroutes.yaml
@@ -66,6 +66,8 @@ spec:
                     description: Action defines an action.
                     type: object
                     properties:
+                      grpc:
+                        type: boolean
                       pass:
                         type: string
                       proxy:
@@ -188,6 +190,8 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
+                            grpc:
+                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -286,6 +290,8 @@ spec:
                                 description: Action defines an action.
                                 type: object
                                 properties:
+                                  grpc:
+                                    type: boolean
                                   pass:
                                     type: string
                                   proxy:
@@ -384,6 +390,8 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
+                            grpc:
+                              type: boolean
                             pass:
                               type: string
                             proxy:

--- a/deployments/helm-chart/crds/k8s.nginx.org_virtualservers.yaml
+++ b/deployments/helm-chart/crds/k8s.nginx.org_virtualservers.yaml
@@ -78,6 +78,8 @@ spec:
                     description: Action defines an action.
                     type: object
                     properties:
+                      grpc:
+                        type: boolean
                       pass:
                         type: string
                       proxy:
@@ -200,6 +202,8 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
+                            grpc:
+                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -298,6 +302,8 @@ spec:
                                 description: Action defines an action.
                                 type: object
                                 properties:
+                                  grpc:
+                                    type: boolean
                                   pass:
                                     type: string
                                   proxy:
@@ -396,6 +402,8 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
+                            grpc:
+                              type: boolean
                             pass:
                               type: string
                             proxy:

--- a/deployments/helm-chart/crds/k8s.nginx.org_virtualservers.yaml
+++ b/deployments/helm-chart/crds/k8s.nginx.org_virtualservers.yaml
@@ -78,8 +78,6 @@ spec:
                     description: Action defines an action.
                     type: object
                     properties:
-                      grpc:
-                        type: boolean
                       pass:
                         type: string
                       proxy:
@@ -202,8 +200,6 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
-                            grpc:
-                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -302,8 +298,6 @@ spec:
                                 description: Action defines an action.
                                 type: object
                                 properties:
-                                  grpc:
-                                    type: boolean
                                   pass:
                                     type: string
                                   proxy:
@@ -402,8 +396,6 @@ spec:
                           description: Action defines an action.
                           type: object
                           properties:
-                            grpc:
-                              type: boolean
                             pass:
                               type: string
                             proxy:
@@ -520,6 +512,8 @@ spec:
                     type: string
                   fail-timeout:
                     type: string
+                  grpc:
+                    type: boolean
                   healthCheck:
                     description: HealthCheck defines the parameters for active Upstream HealthChecks.
                     type: object

--- a/docs-web/configuration/virtualserver-and-virtualserverroute-resources.md
+++ b/docs-web/configuration/virtualserver-and-virtualserverroute-resources.md
@@ -780,6 +780,10 @@ In the example below, client requests are passed to an upstream `coffee`:
      - Passes requests to an upstream. The upstream with that name must be defined in the resource.
      - ``string``
      - No*
+   * - ``grpc``
+     - Enables gRPC for the upstream. The default is ``False`` (the HTTP protocol is used). It is necessary to enable HTTP/2 in the `ConfigMap </nginx-ingress-controller/configuration/global-configuration/configmap-resource/#listeners)>`_ and configure TLS termination in the VirtualServer. Otherwise, the HTTP protocol will be used.
+     - ``boolean``
+     - No*
    * - ``redirect``
      - Redirects requests to a provided URL.
      - `action.redirect <#action-redirect>`_

--- a/docs-web/configuration/virtualserver-and-virtualserverroute-resources.md
+++ b/docs-web/configuration/virtualserver-and-virtualserverroute-resources.md
@@ -403,6 +403,7 @@ next-upstream-tries: 10
 client-max-body-size: 2m
 tls:
   enable: true
+grpc: true
 ```
 
 **Note**: The WebSocket protocol is supported without any additional configuration.
@@ -507,6 +508,10 @@ tls:
      - Sets the size of the buffer used for reading the first part of a response received from the upstream server. See the `proxy_buffer_size <https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size>`_ directive. The default is set in the ``proxy-buffer-size`` ConfigMap key.
      - ``string``
      - No
+   * - ``grpc``
+     - Enables gRPC for the upstream. The default is ``False`` (the HTTP protocol is used). It is necessary to enable HTTP/2 in the `ConfigMap </nginx-ingress-controller/configuration/global-configuration/configmap-resource/#listeners)>`_ and configure TLS termination in the VirtualServer. Otherwise, the HTTP protocol will be used.
+     - ``boolean``
+     - No*
 ```
 
 ### Upstream.Buffers
@@ -779,10 +784,6 @@ In the example below, client requests are passed to an upstream `coffee`:
    * - ``pass``
      - Passes requests to an upstream. The upstream with that name must be defined in the resource.
      - ``string``
-     - No*
-   * - ``grpc``
-     - Enables gRPC for the upstream. The default is ``False`` (the HTTP protocol is used). It is necessary to enable HTTP/2 in the `ConfigMap </nginx-ingress-controller/configuration/global-configuration/configmap-resource/#listeners)>`_ and configure TLS termination in the VirtualServer. Otherwise, the HTTP protocol will be used.
-     - ``boolean``
      - No*
    * - ``redirect``
      - Redirects requests to a provided URL.

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -144,7 +144,7 @@ type Location struct {
 	IsVSR                    bool
 	VSRName                  string
 	VSRNamespace             string
-	GRPC                     bool
+	GRPCPass                 string
 }
 
 // ReturnLocation defines a location for returning a fixed response.

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -37,6 +37,7 @@ type Upstream struct {
 	Queue            *Queue
 	SessionCookie    *SessionCookie
 	UpstreamLabels   UpstreamLabels
+	GRPC             bool
 }
 
 // UpstreamServer defines an upstream server.
@@ -144,7 +145,6 @@ type Location struct {
 	IsVSR                    bool
 	VSRName                  string
 	VSRNamespace             string
-	GRPCPass                 string
 }
 
 // ReturnLocation defines a location for returning a fixed response.

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -144,6 +144,7 @@ type Location struct {
 	IsVSR                    bool
 	VSRName                  string
 	VSRNamespace             string
+	GRPCPass                 string
 }
 
 // ReturnLocation defines a location for returning a fixed response.

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -37,7 +37,6 @@ type Upstream struct {
 	Queue            *Queue
 	SessionCookie    *SessionCookie
 	UpstreamLabels   UpstreamLabels
-	GRPC             bool
 }
 
 // UpstreamServer defines an upstream server.
@@ -145,6 +144,7 @@ type Location struct {
 	IsVSR                    bool
 	VSRName                  string
 	VSRNamespace             string
+	GRPC                     bool
 }
 
 // ReturnLocation defines a location for returning a fixed response.

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -297,7 +297,7 @@ server {
 
         {{ if $l.ProxyPass }}
         {{ $proxyOrGRPC := "proxy" }}
-            {{ if $l.GRPCProxy }}
+            {{ if $l.GRPCPass }}
         {{ $proxyOrGRPC = "grpc" }}
             {{ end }}
 
@@ -362,7 +362,7 @@ server {
         proxy_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
 
-            {{if $l.GRPCProxy}}
+            {{if $l.GRPCPass}}
         error_page 400 @grpcerror400;
         error_page 401 @grpcerror401;
         error_page 403 @grpcerror403;

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -295,45 +295,20 @@ server {
         proxy_pass {{ $l.InternalProxyPass }};
         {{ end }}
 
-        {{if $l.GrpcPass}}
-        grpc_connect_timeout {{$l.ProxyConnectTimeout}};
-        grpc_read_timeout {{$l.ProxyReadTimeout}};
-        grpc_send_timeout {{$l.ProxySendTimeout}};
-        grpc_set_header Host $host;
-        grpc_set_header X-Real-IP $remote_addr;
-        grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        grpc_set_header X-Forwarded-Host $host;
-        grpc_set_header X-Forwarded-Port $server_port;
-        grpc_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
+        {{ if $l.ProxyPass }}
+        {{ $proxyOrGRPC := "proxy" }}
+            {{ if $l.GRPC }}
+        {{ $proxyOrGRPC = "grpc" }}
+            {{ end }}
 
-            {{ if $l.ProxyBufferSize}}
-        grpc_buffer_size {{$l.ProxyBufferSize}};
-            {{ end}}
-        grpc_pass {{ $l.GrpcPass }}{{ $l.ProxyPassRewrite }};
-
-        error_page 400 @grpcerror400;
-        error_page 401 @grpcerror401;
-        error_page 403 @grpcerror403;
-        error_page 404 @grpcerror404;
-        error_page 405 @grpcerror405;
-        error_page 408 @grpcerror408;
-        error_page 414 @grpcerror414;
-        error_page 426 @grpcerror426;
-        error_page 500 @grpcerror500;
-        error_page 501 @grpcerror501;
-        error_page 502 @grpcerror502;
-        error_page 503 @grpcerror503;
-        error_page 504 @grpcerror504;
-
-        {{ else if $l.ProxyPass }}
         set $default_connection_header {{ if $l.HasKeepalive }}""{{ else }}close{{ end }};
 
             {{ range $r := $l.Rewrites }}
         rewrite {{ $r }};
             {{ end }}
-        proxy_connect_timeout {{ $l.ProxyConnectTimeout }};
-        proxy_read_timeout {{ $l.ProxyReadTimeout }};
-        proxy_send_timeout {{ $l.ProxySendTimeout }};
+        {{ $proxyOrGRPC }}_connect_timeout {{ $l.ProxyConnectTimeout }};
+        {{ $proxyOrGRPC }}_read_timeout {{ $l.ProxyReadTimeout }};
+        {{ $proxyOrGRPC }}_send_timeout {{ $l.ProxySendTimeout }};
         client_max_body_size {{ $l.ClientMaxBodySize }};
 
             {{ if $l.ProxyMaxTempFileSize }}
@@ -345,18 +320,18 @@ server {
         proxy_buffers {{ $l.ProxyBuffers }};
             {{ end }}
             {{ if $l.ProxyBufferSize }}
-        proxy_buffer_size {{ $l.ProxyBufferSize }};
+        {{ $proxyOrGRPC }}_buffer_size {{ $l.ProxyBufferSize }};
             {{ end }}
         proxy_http_version 1.1;
 
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $vs_connection_header;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Port $server_port;
-        proxy_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
+        {{ $proxyOrGRPC }}_set_header Host $host;
+        {{ $proxyOrGRPC }}_set_header X-Real-IP $remote_addr;
+        {{ $proxyOrGRPC }}_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        {{ $proxyOrGRPC }}_set_header X-Forwarded-Host $host;
+        {{ $proxyOrGRPC }}_set_header X-Forwarded-Port $server_port;
+        {{ $proxyOrGRPC }}_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
             {{ range $h := $l.ProxySetHeaders }}
         proxy_set_header {{ $h.Name }} "{{ $h.Value }}";
             {{ end }}
@@ -381,11 +356,27 @@ server {
         proxy_ssl_verify_depth 25;
         proxy_ssl_name {{ $l.ProxySSLName }};
             {{ end }}
-        proxy_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
+        {{ $proxyOrGRPC }}_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
         proxy_next_upstream {{ $l.ProxyNextUpstream }};
         proxy_next_upstream_timeout {{ $l.ProxyNextUpstreamTimeout }};
         proxy_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
+
+            {{if $l.GRPC}}
+        error_page 400 @grpcerror400;
+        error_page 401 @grpcerror401;
+        error_page 403 @grpcerror403;
+        error_page 404 @grpcerror404;
+        error_page 405 @grpcerror405;
+        error_page 408 @grpcerror408;
+        error_page 414 @grpcerror414;
+        error_page 426 @grpcerror426;
+        error_page 500 @grpcerror500;
+        error_page 501 @grpcerror501;
+        error_page 502 @grpcerror502;
+        error_page 503 @grpcerror503;
+        error_page 504 @grpcerror504;
+            {{ end }}
         {{ end }}
     }
     {{ end }}

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -295,7 +295,37 @@ server {
         proxy_pass {{ $l.InternalProxyPass }};
         {{ end }}
 
-        {{ if $l.ProxyPass }}
+        {{if $l.GrpcPass}}
+        grpc_connect_timeout {{$l.ProxyConnectTimeout}};
+        grpc_read_timeout {{$l.ProxyReadTimeout}};
+        grpc_send_timeout {{$l.ProxySendTimeout}};
+        grpc_set_header Host $host;
+        grpc_set_header X-Real-IP $remote_addr;
+        grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        grpc_set_header X-Forwarded-Host $host;
+        grpc_set_header X-Forwarded-Port $server_port;
+        grpc_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
+
+            {{ if $l.ProxyBufferSize}}
+        grpc_buffer_size {{$l.ProxyBufferSize}};
+            {{ end}}
+        grpc_pass {{ $l.GrpcPass }}{{ $l.ProxyPassRewrite }};
+
+        error_page 400 @grpcerror400;
+        error_page 401 @grpcerror401;
+        error_page 403 @grpcerror403;
+        error_page 404 @grpcerror404;
+        error_page 405 @grpcerror405;
+        error_page 408 @grpcerror408;
+        error_page 414 @grpcerror414;
+        error_page 426 @grpcerror426;
+        error_page 500 @grpcerror500;
+        error_page 501 @grpcerror501;
+        error_page 502 @grpcerror502;
+        error_page 503 @grpcerror503;
+        error_page 504 @grpcerror504;
+
+        {{ else if $l.ProxyPass }}
         set $default_connection_header {{ if $l.HasKeepalive }}""{{ else }}close{{ end }};
 
             {{ range $r := $l.Rewrites }}
@@ -358,5 +388,23 @@ server {
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
         {{ end }}
     }
+    {{ end }}
+
+    {{ with $ssl := $s.SSL }}
+    {{ if $ssl.HTTP2 }}
+    location @grpcerror400 { default_type application/grpc; return 400 "\n"; }
+    location @grpcerror401 { default_type application/grpc; return 401 "\n"; }
+    location @grpcerror403 { default_type application/grpc; return 403 "\n"; }
+    location @grpcerror404 { default_type application/grpc; return 404 "\n"; }
+    location @grpcerror405 { default_type application/grpc; return 405 "\n"; }
+    location @grpcerror408 { default_type application/grpc; return 408 "\n"; }
+    location @grpcerror414 { default_type application/grpc; return 414 "\n"; }
+    location @grpcerror426 { default_type application/grpc; return 426 "\n"; }
+    location @grpcerror500 { default_type application/grpc; return 500 "\n"; }
+    location @grpcerror501 { default_type application/grpc; return 501 "\n"; }
+    location @grpcerror502 { default_type application/grpc; return 502 "\n"; }
+    location @grpcerror503 { default_type application/grpc; return 503 "\n"; }
+    location @grpcerror504 { default_type application/grpc; return 504 "\n"; }
+    {{ end }}
     {{ end }}
 }

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -297,7 +297,7 @@ server {
 
         {{ if $l.ProxyPass }}
         {{ $proxyOrGRPC := "proxy" }}
-            {{ if $l.GRPC }}
+            {{ if $l.GRPCProxy }}
         {{ $proxyOrGRPC = "grpc" }}
             {{ end }}
 
@@ -362,7 +362,7 @@ server {
         proxy_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
 
-            {{if $l.GRPC}}
+            {{if $l.GRPCProxy}}
         error_page 400 @grpcerror400;
         error_page 401 @grpcerror401;
         error_page 403 @grpcerror403;

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -295,7 +295,7 @@ server {
         proxy_pass {{ $l.InternalProxyPass }};
         {{ end }}
 
-        {{ if $l.ProxyPass }}
+        {{ if or $l.ProxyPass $l.GRPCPass}}
         {{ $proxyOrGRPC := "proxy" }}
             {{ if $l.GRPCPass }}
         {{ $proxyOrGRPC = "grpc" }}
@@ -356,7 +356,11 @@ server {
         proxy_ssl_verify_depth 25;
         proxy_ssl_name {{ $l.ProxySSLName }};
             {{ end }}
-        {{ $proxyOrGRPC }}_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
+            {{if $l.GRPCPass}}
+        grpc_pass {{ $l.GRPCPass }};
+            {{ else }}
+        proxy_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
+            {{ end }}
         proxy_next_upstream {{ $l.ProxyNextUpstream }};
         proxy_next_upstream_timeout {{ $l.ProxyNextUpstreamTimeout }};
         proxy_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -365,41 +365,7 @@ server {
         proxy_next_upstream_timeout {{ $l.ProxyNextUpstreamTimeout }};
         proxy_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
-
-            {{if $l.GRPCPass}}
-        error_page 400 @grpcerror400;
-        error_page 401 @grpcerror401;
-        error_page 403 @grpcerror403;
-        error_page 404 @grpcerror404;
-        error_page 405 @grpcerror405;
-        error_page 408 @grpcerror408;
-        error_page 414 @grpcerror414;
-        error_page 426 @grpcerror426;
-        error_page 500 @grpcerror500;
-        error_page 501 @grpcerror501;
-        error_page 502 @grpcerror502;
-        error_page 503 @grpcerror503;
-        error_page 504 @grpcerror504;
-            {{ end }}
         {{ end }}
     }
-    {{ end }}
-
-    {{ with $ssl := $s.SSL }}
-    {{ if $ssl.HTTP2 }}
-    location @grpcerror400 { default_type application/grpc; return 400 "\n"; }
-    location @grpcerror401 { default_type application/grpc; return 401 "\n"; }
-    location @grpcerror403 { default_type application/grpc; return 403 "\n"; }
-    location @grpcerror404 { default_type application/grpc; return 404 "\n"; }
-    location @grpcerror405 { default_type application/grpc; return 405 "\n"; }
-    location @grpcerror408 { default_type application/grpc; return 408 "\n"; }
-    location @grpcerror414 { default_type application/grpc; return 414 "\n"; }
-    location @grpcerror426 { default_type application/grpc; return 426 "\n"; }
-    location @grpcerror500 { default_type application/grpc; return 500 "\n"; }
-    location @grpcerror501 { default_type application/grpc; return 501 "\n"; }
-    location @grpcerror502 { default_type application/grpc; return 502 "\n"; }
-    location @grpcerror503 { default_type application/grpc; return 503 "\n"; }
-    location @grpcerror504 { default_type application/grpc; return 504 "\n"; }
-    {{ end }}
     {{ end }}
 }

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -254,7 +254,7 @@ server {
         proxy_pass {{ $l.InternalProxyPass }};
         {{ end }}
 
-        {{ if $l.ProxyPass }}
+        {{ if or $l.ProxyPass $l.GRPCPass}}
         {{ $proxyOrGRPC := "proxy" }}
             {{ if $l.GRPCPass }}
         {{ $proxyOrGRPC = "grpc" }}
@@ -306,7 +306,11 @@ server {
             {{ range $h := $l.AddHeaders }}
         add_header {{ $h.Name }} "{{ $h.Value }}" {{ if $h.Always }}always{{ end }};
             {{ end }}
-        {{ $proxyOrGRPC }}_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
+            {{if $l.GRPCPass}}
+        grpc_pass {{ $l.GRPCPass }};
+            {{ else }}
+        proxy_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
+            {{ end }}
         proxy_next_upstream {{ $l.ProxyNextUpstream }};
         proxy_next_upstream_timeout {{ $l.ProxyNextUpstreamTimeout }};
         proxy_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -256,7 +256,7 @@ server {
 
         {{ if $l.ProxyPass }}
         {{ $proxyOrGRPC := "proxy" }}
-            {{ if $l.GRPC }}
+            {{ if $l.GRPCProxy }}
         {{ $proxyOrGRPC = "grpc" }}
             {{ end }}
 
@@ -312,7 +312,7 @@ server {
         proxy_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
 
-            {{if $l.GRPC}}
+            {{if $l.GRPCProxy}}
         error_page 400 @grpcerror400;
         error_page 401 @grpcerror401;
         error_page 403 @grpcerror403;

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -254,45 +254,20 @@ server {
         proxy_pass {{ $l.InternalProxyPass }};
         {{ end }}
 
-        {{if $l.GrpcPass}}
-        grpc_connect_timeout {{$l.ProxyConnectTimeout}};
-        grpc_read_timeout {{$l.ProxyReadTimeout}};
-        grpc_send_timeout {{$l.ProxySendTimeout}};
-        grpc_set_header Host $host;
-        grpc_set_header X-Real-IP $remote_addr;
-        grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        grpc_set_header X-Forwarded-Host $host;
-        grpc_set_header X-Forwarded-Port $server_port;
-        grpc_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
+        {{ if $l.ProxyPass }}
+        {{ $proxyOrGRPC := "proxy" }}
+            {{ if $l.GRPC }}
+        {{ $proxyOrGRPC = "grpc" }}
+            {{ end }}
 
-            {{ if $l.ProxyBufferSize}}
-        grpc_buffer_size {{$l.ProxyBufferSize}};
-            {{ end}}
-        grpc_pass {{ $l.GrpcPass }}{{ $l.ProxyPassRewrite }};
-
-        error_page 400 @grpcerror400;
-        error_page 401 @grpcerror401;
-        error_page 403 @grpcerror403;
-        error_page 404 @grpcerror404;
-        error_page 405 @grpcerror405;
-        error_page 408 @grpcerror408;
-        error_page 414 @grpcerror414;
-        error_page 426 @grpcerror426;
-        error_page 500 @grpcerror500;
-        error_page 501 @grpcerror501;
-        error_page 502 @grpcerror502;
-        error_page 503 @grpcerror503;
-        error_page 504 @grpcerror504;
-
-        {{ else if $l.ProxyPass }}
         set $default_connection_header {{ if $l.HasKeepalive }}""{{ else }}close{{ end }};
 
             {{ range $r := $l.Rewrites }}
         rewrite {{ $r }};
             {{ end }}
-        proxy_connect_timeout {{ $l.ProxyConnectTimeout }};
-        proxy_read_timeout {{ $l.ProxyReadTimeout }};
-        proxy_send_timeout {{ $l.ProxySendTimeout }};
+        {{ $proxyOrGRPC }}_connect_timeout {{ $l.ProxyConnectTimeout }};
+        {{ $proxyOrGRPC }}_read_timeout {{ $l.ProxyReadTimeout }};
+        {{ $proxyOrGRPC }}_send_timeout {{ $l.ProxySendTimeout }};
         client_max_body_size {{ $l.ClientMaxBodySize }};
 
             {{ if $l.ProxyMaxTempFileSize }}
@@ -304,18 +279,18 @@ server {
         proxy_buffers {{ $l.ProxyBuffers }};
             {{ end }}
             {{ if $l.ProxyBufferSize }}
-        proxy_buffer_size {{ $l.ProxyBufferSize }};
+        {{ $proxyOrGRPC }}_buffer_size {{ $l.ProxyBufferSize }};
             {{ end }}
         proxy_http_version 1.1;
 
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $vs_connection_header;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Port $server_port;
-        proxy_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
+        {{ $proxyOrGRPC }}_set_header Host $host;
+        {{ $proxyOrGRPC }}_set_header X-Real-IP $remote_addr;
+        {{ $proxyOrGRPC }}_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        {{ $proxyOrGRPC }}_set_header X-Forwarded-Host $host;
+        {{ $proxyOrGRPC }}_set_header X-Forwarded-Port $server_port;
+        {{ $proxyOrGRPC }}_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
             {{ range $h := $l.ProxySetHeaders }}
         proxy_set_header {{ $h.Name }} "{{ $h.Value }}";
             {{ end }}
@@ -331,11 +306,27 @@ server {
             {{ range $h := $l.AddHeaders }}
         add_header {{ $h.Name }} "{{ $h.Value }}" {{ if $h.Always }}always{{ end }};
             {{ end }}
-        proxy_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
+        {{ $proxyOrGRPC }}_pass {{ $l.ProxyPass }}{{ $l.ProxyPassRewrite }};
         proxy_next_upstream {{ $l.ProxyNextUpstream }};
         proxy_next_upstream_timeout {{ $l.ProxyNextUpstreamTimeout }};
         proxy_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
+
+            {{if $l.GRPC}}
+        error_page 400 @grpcerror400;
+        error_page 401 @grpcerror401;
+        error_page 403 @grpcerror403;
+        error_page 404 @grpcerror404;
+        error_page 405 @grpcerror405;
+        error_page 408 @grpcerror408;
+        error_page 414 @grpcerror414;
+        error_page 426 @grpcerror426;
+        error_page 500 @grpcerror500;
+        error_page 501 @grpcerror501;
+        error_page 502 @grpcerror502;
+        error_page 503 @grpcerror503;
+        error_page 504 @grpcerror504;
+            {{ end }}
         {{ end }}
     }
     {{ end }}

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -256,7 +256,7 @@ server {
 
         {{ if $l.ProxyPass }}
         {{ $proxyOrGRPC := "proxy" }}
-            {{ if $l.GRPCProxy }}
+            {{ if $l.GRPCPass }}
         {{ $proxyOrGRPC = "grpc" }}
             {{ end }}
 
@@ -312,7 +312,7 @@ server {
         proxy_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
 
-            {{if $l.GRPCProxy}}
+            {{if $l.GRPCPass}}
         error_page 400 @grpcerror400;
         error_page 401 @grpcerror401;
         error_page 403 @grpcerror403;

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -315,41 +315,7 @@ server {
         proxy_next_upstream_timeout {{ $l.ProxyNextUpstreamTimeout }};
         proxy_next_upstream_tries {{ $l.ProxyNextUpstreamTries }};
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
-
-            {{if $l.GRPCPass}}
-        error_page 400 @grpcerror400;
-        error_page 401 @grpcerror401;
-        error_page 403 @grpcerror403;
-        error_page 404 @grpcerror404;
-        error_page 405 @grpcerror405;
-        error_page 408 @grpcerror408;
-        error_page 414 @grpcerror414;
-        error_page 426 @grpcerror426;
-        error_page 500 @grpcerror500;
-        error_page 501 @grpcerror501;
-        error_page 502 @grpcerror502;
-        error_page 503 @grpcerror503;
-        error_page 504 @grpcerror504;
-            {{ end }}
         {{ end }}
     }
-    {{ end }}
-
-    {{ with $ssl := $s.SSL }}
-    {{ if $ssl.HTTP2 }}
-    location @grpcerror400 { default_type application/grpc; return 400 "\n"; }
-    location @grpcerror401 { default_type application/grpc; return 401 "\n"; }
-    location @grpcerror403 { default_type application/grpc; return 403 "\n"; }
-    location @grpcerror404 { default_type application/grpc; return 404 "\n"; }
-    location @grpcerror405 { default_type application/grpc; return 405 "\n"; }
-    location @grpcerror408 { default_type application/grpc; return 408 "\n"; }
-    location @grpcerror414 { default_type application/grpc; return 414 "\n"; }
-    location @grpcerror426 { default_type application/grpc; return 426 "\n"; }
-    location @grpcerror500 { default_type application/grpc; return 500 "\n"; }
-    location @grpcerror501 { default_type application/grpc; return 501 "\n"; }
-    location @grpcerror502 { default_type application/grpc; return 502 "\n"; }
-    location @grpcerror503 { default_type application/grpc; return 503 "\n"; }
-    location @grpcerror504 { default_type application/grpc; return 504 "\n"; }
-    {{ end }}
     {{ end }}
 }

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -254,7 +254,37 @@ server {
         proxy_pass {{ $l.InternalProxyPass }};
         {{ end }}
 
-        {{ if $l.ProxyPass }}
+        {{if $l.GrpcPass}}
+        grpc_connect_timeout {{$l.ProxyConnectTimeout}};
+        grpc_read_timeout {{$l.ProxyReadTimeout}};
+        grpc_send_timeout {{$l.ProxySendTimeout}};
+        grpc_set_header Host $host;
+        grpc_set_header X-Real-IP $remote_addr;
+        grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        grpc_set_header X-Forwarded-Host $host;
+        grpc_set_header X-Forwarded-Port $server_port;
+        grpc_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
+
+            {{ if $l.ProxyBufferSize}}
+        grpc_buffer_size {{$l.ProxyBufferSize}};
+            {{ end}}
+        grpc_pass {{ $l.GrpcPass }}{{ $l.ProxyPassRewrite }};
+
+        error_page 400 @grpcerror400;
+        error_page 401 @grpcerror401;
+        error_page 403 @grpcerror403;
+        error_page 404 @grpcerror404;
+        error_page 405 @grpcerror405;
+        error_page 408 @grpcerror408;
+        error_page 414 @grpcerror414;
+        error_page 426 @grpcerror426;
+        error_page 500 @grpcerror500;
+        error_page 501 @grpcerror501;
+        error_page 502 @grpcerror502;
+        error_page 503 @grpcerror503;
+        error_page 504 @grpcerror504;
+
+        {{ else if $l.ProxyPass }}
         set $default_connection_header {{ if $l.HasKeepalive }}""{{ else }}close{{ end }};
 
             {{ range $r := $l.Rewrites }}
@@ -308,5 +338,23 @@ server {
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
         {{ end }}
     }
+    {{ end }}
+
+    {{ with $ssl := $s.SSL }}
+    {{ if $ssl.HTTP2 }}
+    location @grpcerror400 { default_type application/grpc; return 400 "\n"; }
+    location @grpcerror401 { default_type application/grpc; return 401 "\n"; }
+    location @grpcerror403 { default_type application/grpc; return 403 "\n"; }
+    location @grpcerror404 { default_type application/grpc; return 404 "\n"; }
+    location @grpcerror405 { default_type application/grpc; return 405 "\n"; }
+    location @grpcerror408 { default_type application/grpc; return 408 "\n"; }
+    location @grpcerror414 { default_type application/grpc; return 414 "\n"; }
+    location @grpcerror426 { default_type application/grpc; return 426 "\n"; }
+    location @grpcerror500 { default_type application/grpc; return 500 "\n"; }
+    location @grpcerror501 { default_type application/grpc; return 501 "\n"; }
+    location @grpcerror502 { default_type application/grpc; return 502 "\n"; }
+    location @grpcerror503 { default_type application/grpc; return 503 "\n"; }
+    location @grpcerror504 { default_type application/grpc; return 504 "\n"; }
+    {{ end }}
     {{ end }}
 }

--- a/internal/configs/version2/template_executor.go
+++ b/internal/configs/version2/template_executor.go
@@ -12,11 +12,6 @@ const tlsPassthroughHostsTemplateString = `# mapping between TLS Passthrough hos
 {{ end }}
 `
 
-var funcMap = template.FuncMap{
-	// The name "title" is what the function will be called in the template text.
-	"isGRPCUpstream": isGRPCUpstream,
-}
-
 // TemplateExecutor executes NGINX configuration templates.
 type TemplateExecutor struct {
 	virtualServerTemplate       *template.Template
@@ -24,20 +19,11 @@ type TemplateExecutor struct {
 	tlsPassthroughHostsTemplate *template.Template
 }
 
-func isGRPCUpstream(upstreams []Upstream, upstreamName string) bool {
-	for _, upstream := range upstreams {
-		if upstream.Name == upstreamName {
-			return upstream.GRPC
-		}
-	}
-	return false
-}
-
 // NewTemplateExecutor creates a TemplateExecutor.
 func NewTemplateExecutor(virtualServerTemplatePath string, transportServerTemplatePath string) (*TemplateExecutor, error) {
 	// template names  must be the base name of the template file https://golang.org/pkg/text/template/#Template.ParseFiles
 
-	vsTemplate, err := template.New(path.Base(virtualServerTemplatePath)).Funcs(funcMap).ParseFiles(virtualServerTemplatePath)
+	vsTemplate, err := template.New(path.Base(virtualServerTemplatePath)).ParseFiles(virtualServerTemplatePath)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +47,7 @@ func NewTemplateExecutor(virtualServerTemplatePath string, transportServerTempla
 
 // UpdateVirtualServerTemplate updates the VirtualServer template.
 func (te *TemplateExecutor) UpdateVirtualServerTemplate(templateString *string) error {
-	newTemplate, err := template.New("virtualServerTemplate").Funcs(funcMap).Parse(*templateString)
+	newTemplate, err := template.New("virtualServerTemplate").Parse(*templateString)
 	if err != nil {
 		return err
 	}

--- a/internal/configs/version2/templates_test.go
+++ b/internal/configs/version2/templates_test.go
@@ -245,6 +245,7 @@ var virtualServerCfg = VirtualServerConfig{
 				ProxyReadTimeout:    "31s",
 				ProxySendTimeout:    "32s",
 				ClientMaxBodySize:   "1m",
+				ProxyPass:           "http://coffee-v2",
 				GRPCPass:            "grpc://coffee-v3",
 			},
 			{

--- a/internal/configs/version2/templates_test.go
+++ b/internal/configs/version2/templates_test.go
@@ -240,6 +240,14 @@ var virtualServerCfg = VirtualServerConfig{
 				ProxyNextUpstreamTimeout: "5s",
 			},
 			{
+				Path:                "@loc2",
+				ProxyConnectTimeout: "30s",
+				ProxyReadTimeout:    "31s",
+				ProxySendTimeout:    "32s",
+				ClientMaxBodySize:   "1m",
+				GRPCPass:            "grpc://coffee-v3",
+			},
+			{
 				Path:                     "@match_loc_0",
 				ProxyConnectTimeout:      "30s",
 				ProxyReadTimeout:         "31s",

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -1393,6 +1393,7 @@ func generateLocationForProxying(path string, upstreamName string, upstream conf
 		IsVSR:                    isVSR,
 		VSRName:                  vsrName,
 		VSRNamespace:             vsrNamespace,
+		GRPC:                     upstream.GRPC,
 	}
 }
 

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -1216,6 +1216,23 @@ func generateProxyPassProtocol(enableTLS bool) string {
 	return "http"
 }
 
+func generateGRPCPass(grpcEnabled bool, tlsEnabled bool, upstreamName string) string {
+	grpcPass := fmt.Sprintf("%v://%v", generateGRPCPassProtocol(tlsEnabled), upstreamName)
+
+	if !grpcEnabled {
+		return ""
+	}
+
+	return grpcPass
+}
+
+func generateGRPCPassProtocol(enableTLS bool) string {
+	if enableTLS {
+		return "grpcs"
+	}
+	return "grpc"
+}
+
 func generateString(s string, defaultS string) string {
 	if s == "" {
 		return defaultS
@@ -1393,7 +1410,7 @@ func generateLocationForProxying(path string, upstreamName string, upstream conf
 		IsVSR:                    isVSR,
 		VSRName:                  vsrName,
 		VSRNamespace:             vsrNamespace,
-		GRPC:                     upstream.GRPC,
+		GRPCPass:                 generateGRPCPass(upstream.GRPC, upstream.TLS.Enable, upstreamName),
 	}
 }
 

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -3198,25 +3198,25 @@ func TestGenerateProxyPassProtocol(t *testing.T) {
 
 func TestGenerateGRPCPass(t *testing.T) {
 	tests := []struct {
-		grpcEnabled bool
+		grpcEnabled  bool
 		tlsEnabled   bool
 		upstreamName string
 		expected     string
 	}{
 		{
-			grpcEnabled: false,
+			grpcEnabled:  false,
 			tlsEnabled:   false,
 			upstreamName: "test-upstream",
 			expected:     "",
 		},
 		{
-			grpcEnabled: true,
+			grpcEnabled:  true,
 			tlsEnabled:   false,
 			upstreamName: "test-upstream",
 			expected:     "grpc://test-upstream",
 		},
 		{
-			grpcEnabled: true,
+			grpcEnabled:  true,
 			tlsEnabled:   true,
 			upstreamName: "test-upstream",
 			expected:     "grpcs://test-upstream",
@@ -3226,7 +3226,7 @@ func TestGenerateGRPCPass(t *testing.T) {
 	for _, test := range tests {
 		result := generateGRPCPass(test.grpcEnabled, test.tlsEnabled, test.upstreamName)
 		if result != test.expected {
-			t.Errorf("generateGRPCPass(%v, %v, %v) returned %v but expected %v", test.grpcEnabled,test.tlsEnabled, test.upstreamName, result, test.expected)
+			t.Errorf("generateGRPCPass(%v, %v, %v) returned %v but expected %v", test.grpcEnabled, test.tlsEnabled, test.upstreamName, result, test.expected)
 		}
 	}
 }

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -3199,24 +3199,35 @@ func TestGenerateProxyPassProtocol(t *testing.T) {
 func TestGenerateGRPCPass(t *testing.T) {
 	tests := []struct {
 		grpcEnabled  bool
+		http2Enabled bool
 		tlsEnabled   bool
 		upstreamName string
 		expected     string
 	}{
 		{
 			grpcEnabled:  false,
+			http2Enabled: true,
 			tlsEnabled:   false,
 			upstreamName: "test-upstream",
 			expected:     "",
 		},
 		{
 			grpcEnabled:  true,
+			http2Enabled: false,
+			tlsEnabled:   false,
+			upstreamName: "test-upstream",
+			expected:     "",
+		},
+		{
+			grpcEnabled:  true,
+			http2Enabled: true,
 			tlsEnabled:   false,
 			upstreamName: "test-upstream",
 			expected:     "grpc://test-upstream",
 		},
 		{
 			grpcEnabled:  true,
+			http2Enabled: true,
 			tlsEnabled:   true,
 			upstreamName: "test-upstream",
 			expected:     "grpcs://test-upstream",
@@ -3224,7 +3235,7 @@ func TestGenerateGRPCPass(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := generateGRPCPass(test.grpcEnabled, test.tlsEnabled, test.upstreamName)
+		result := generateGRPCPass(test.grpcEnabled, test.http2Enabled, test.tlsEnabled, test.upstreamName)
 		if result != test.expected {
 			t.Errorf("generateGRPCPass(%v, %v, %v) returned %v but expected %v", test.grpcEnabled, test.tlsEnabled, test.upstreamName, result, test.expected)
 		}
@@ -3399,6 +3410,7 @@ func TestGenerateLocationForGrpcProxying(t *testing.T) {
 		ProxyBuffers:         "8 4k",
 		ProxyBufferSize:      "4k",
 		LocationSnippets:     []string{"# location snippet"},
+		HTTP2:                true,
 	}
 	path := "/"
 	upstreamName := "test-upstream"

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -77,6 +77,7 @@ type Upstream struct {
 	SlowStart                string            `json:"slow-start"`
 	Queue                    *UpstreamQueue    `json:"queue"`
 	SessionCookie            *SessionCookie    `json:"sessionCookie"`
+	GRPC                     bool              `json:"grpc"`
 }
 
 // UpstreamBuffers defines Buffer Configuration for an Upstream.
@@ -138,7 +139,6 @@ type Route struct {
 
 // Action defines an action.
 type Action struct {
-	Grpc     bool            `json:"grpc"`
 	Pass     string          `json:"pass"`
 	Redirect *ActionRedirect `json:"redirect"`
 	Return   *ActionReturn   `json:"return"`

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -138,6 +138,7 @@ type Route struct {
 
 // Action defines an action.
 type Action struct {
+	Grpc     bool            `json:"grpc"`
 	Pass     string          `json:"pass"`
 	Redirect *ActionRedirect `json:"redirect"`
 	Return   *ActionReturn   `json:"return"`


### PR DESCRIPTION
### Proposed changes

Add gRPC support for VirtualServer CRD. For example, grpc proxy traffic for specific route,

```
apiVersion: k8s.nginx.org/v1
kind: VirtualServer
metadata:
  name: grpc-example
spec:
  host: grpc.example.com
  tls:
    secret: grpc-secret
    redirect:
      enable: true
  upstreams:
  - name: grpc-app 
    service: grpc-svc
    port: 50051
  routes:
  - path: /
    action:
      pass: grpc-app
      grpc: true # enables gRPC for the upstream
```

Fix https://github.com/nginxinc/kubernetes-ingress/issues/908

Note I'm not an expert in Go/Nginx/Kubernetes, so feel free to suggest changes so we can have a solid implementation for VirtualServer gRPC support.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
