### PR TITLE
Add pod_owner label to metrics when -spire-agent-address is set

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -500,7 +500,7 @@ func main() {
 		StubStatusOverUnixSocketForOSS: *enablePrometheusMetrics,
 		TLSPassthrough:                 *enableTLSPassthrough,
 		EnableSnippets:                 *enableSnippets,
-		SpiffeCerts:                    *spireAgentAddress != "",
+		NginxServiceMesh:               *spireAgentAddress != "",
 		MainAppProtectLoadModule:       *appProtect,
 		EnableLatencyMetrics:           *enableLatencyMetrics,
 	}
@@ -548,6 +548,9 @@ func main() {
 	if *enablePrometheusMetrics {
 		upstreamServerVariableLabels := []string{"service", "resource_type", "resource_name", "resource_namespace"}
 		upstreamServerPeerVariableLabelNames := []string{"pod_name"}
+		if staticCfgParams.NginxServiceMesh {
+			upstreamServerPeerVariableLabelNames = append(upstreamServerPeerVariableLabelNames, "pod_owner")
+		}
 		if *nginxPlus {
 			serverZoneVariableLabels := []string{"resource_type", "resource_name", "resource_namespace"}
 			variableLabelNames := nginxCollector.NewVariableLabelNames(upstreamServerVariableLabels, serverZoneVariableLabels, upstreamServerPeerVariableLabelNames)

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -109,7 +109,7 @@ type StaticConfigParams struct {
 	StubStatusOverUnixSocketForOSS bool
 	TLSPassthrough                 bool
 	EnableSnippets                 bool
-	SpiffeCerts                    bool
+	NginxServiceMesh               bool
 	EnableInternalRoutes           bool
 	MainAppProtectLoadModule       bool
 	PodName                        string

--- a/internal/configs/configurator.go
+++ b/internal/configs/configurator.go
@@ -164,9 +164,13 @@ func (cnf *Configurator) updateIngressMetricsLabels(ingEx *IngressEx, upstreams 
 		newUpstreamsNames = append(newUpstreamsNames, u.Name)
 		for _, server := range u.UpstreamServers {
 			s := fmt.Sprintf("%v:%v", server.Address, server.Port)
-			podName := ingEx.PodsByIP[s]
+			podInfo := ingEx.PodsByIP[s]
 			labelKey := fmt.Sprintf("%v/%v", u.Name, s)
-			upstreamServerPeerLabels[labelKey] = []string{podName}
+			upstreamServerPeerLabels[labelKey] = []string{podInfo.Name}
+			if cnf.staticCfgParams.NginxServiceMesh {
+				ownerLabelVal := fmt.Sprintf("%s/%s", podInfo.OwnerType, podInfo.OwnerName)
+				upstreamServerPeerLabels[labelKey] = append(upstreamServerPeerLabels[labelKey], ownerLabelVal)
+			}
 			newPeers[labelKey] = true
 			newPeersIPs = append(newPeersIPs, labelKey)
 		}
@@ -314,9 +318,13 @@ func (cnf *Configurator) updateVirtualServerMetricsLabels(virtualServerEx *Virtu
 		newUpstreams[u.Name] = true
 		newUpstreamsNames = append(newUpstreamsNames, u.Name)
 		for _, server := range u.Servers {
-			podName := virtualServerEx.PodsByIP[server.Address]
+			podInfo := virtualServerEx.PodsByIP[server.Address]
 			labelKey := fmt.Sprintf("%v/%v", u.Name, server.Address)
-			upstreamServerPeerLabels[labelKey] = []string{podName}
+			upstreamServerPeerLabels[labelKey] = []string{podInfo.Name}
+			if cnf.staticCfgParams.NginxServiceMesh {
+				ownerLabelVal := fmt.Sprintf("%s/%s", podInfo.OwnerType, podInfo.OwnerName)
+				upstreamServerPeerLabels[labelKey] = append(upstreamServerPeerLabels[labelKey], ownerLabelVal)
+			}
 			newPeers[labelKey] = true
 			newPeersIPs = append(newPeersIPs, labelKey)
 		}

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -640,9 +640,9 @@ func TestUpdateIngressMetricsLabels(t *testing.T) {
 				},
 			},
 		},
-		PodsByIP: map[string]string{
-			"10.0.0.1:80": "pod-1",
-			"10.0.0.2:80": "pod-2",
+		PodsByIP: map[string]PodInfo{
+			"10.0.0.1:80": {Name: "pod-1"},
+			"10.0.0.2:80": {Name: "pod-2"},
 		},
 	}
 
@@ -800,9 +800,9 @@ func TestUpdateVirtualServerMetricsLabels(t *testing.T) {
 				Host: "example.com",
 			},
 		},
-		PodsByIP: map[string]string{
-			"10.0.0.1:80": "pod-1",
-			"10.0.0.2:80": "pod-2",
+		PodsByIP: map[string]PodInfo{
+			"10.0.0.1:80": {Name: "pod-1"},
+			"10.0.0.2:80": {Name: "pod-2"},
 		},
 	}
 

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -26,7 +26,7 @@ type IngressEx struct {
 	Endpoints         map[string][]string
 	HealthChecks      map[string]*api_v1.Probe
 	ExternalNameSvcs  map[string]bool
-	PodsByIP          map[string]string
+	PodsByIP          map[string]PodInfo
 	AppProtectPolicy  *unstructured.Unstructured
 	AppProtectLogConf *unstructured.Unstructured
 	AppProtectLogDst  string
@@ -250,7 +250,7 @@ func generateNginxCfg(ingEx *IngressEx, pems map[string]string, apResources map[
 			Namespace:   ingEx.Ingress.Namespace,
 			Annotations: ingEx.Ingress.Annotations,
 		},
-		SpiffeClientCerts: staticParams.SpiffeCerts && !cfgParams.SpiffeServerCerts,
+		SpiffeClientCerts: staticParams.NginxServiceMesh && !cfgParams.SpiffeServerCerts,
 	}
 }
 
@@ -478,10 +478,10 @@ func generateNginxCfgForMergeableIngresses(mergeableIngs *MergeableIngresses, ma
 		Upstreams:         upstreams,
 		Keepalive:         keepalive,
 		Ingress:           masterNginxCfg.Ingress,
-		SpiffeClientCerts: staticParams.SpiffeCerts && !baseCfgParams.SpiffeServerCerts,
+		SpiffeClientCerts: staticParams.NginxServiceMesh && !baseCfgParams.SpiffeServerCerts,
 	}
 }
 
 func isSSLEnabled(isSSLService bool, cfgParams ConfigParams, staticCfgParams *StaticConfigParams) bool {
-	return isSSLService || staticCfgParams.SpiffeCerts && !cfgParams.SpiffeServerCerts
+	return isSSLService || staticCfgParams.NginxServiceMesh && !cfgParams.SpiffeServerCerts
 }

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -766,7 +766,7 @@ func TestGenerateNginxCfgForSpiffe(t *testing.T) {
 	}
 
 	apResources := make(map[string]string)
-	result := generateNginxCfg(&cafeIngressEx, pems, apResources, false, configParams, false, false, "", &StaticConfigParams{SpiffeCerts: true})
+	result := generateNginxCfg(&cafeIngressEx, pems, apResources, false, configParams, false, false, "", &StaticConfigParams{NginxServiceMesh: true})
 
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("generateNginxCfg returned \n%v,  but expected \n%v", result, expected)
@@ -788,7 +788,7 @@ func TestGenerateNginxCfgForInternalRoute(t *testing.T) {
 	}
 
 	apResources := make(map[string]string)
-	result := generateNginxCfg(&cafeIngressEx, pems, apResources, false, configParams, false, false, "", &StaticConfigParams{SpiffeCerts: true, EnableInternalRoutes: true})
+	result := generateNginxCfg(&cafeIngressEx, pems, apResources, false, configParams, false, false, "", &StaticConfigParams{NginxServiceMesh: true, EnableInternalRoutes: true})
 
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("generateNginxCfg returned \n%+v,  but expected \n%+v", result, expected)
@@ -799,61 +799,61 @@ func TestIsSSLEnabled(t *testing.T) {
 	type testCase struct {
 		IsSSLService,
 		SpiffeServerCerts,
-		SpiffeCerts,
+		NginxServiceMesh,
 		Expected bool
 	}
 	var testCases = []testCase{
 		{
 			IsSSLService:      false,
 			SpiffeServerCerts: false,
-			SpiffeCerts:       false,
+			NginxServiceMesh:  false,
 			Expected:          false,
 		},
 		{
 			IsSSLService:      false,
 			SpiffeServerCerts: true,
-			SpiffeCerts:       true,
+			NginxServiceMesh:  true,
 			Expected:          false,
 		},
 		{
 			IsSSLService:      false,
 			SpiffeServerCerts: false,
-			SpiffeCerts:       true,
+			NginxServiceMesh:  true,
 			Expected:          true,
 		},
 		{
 			IsSSLService:      false,
 			SpiffeServerCerts: true,
-			SpiffeCerts:       false,
+			NginxServiceMesh:  false,
 			Expected:          false,
 		},
 		{
 			IsSSLService:      true,
 			SpiffeServerCerts: true,
-			SpiffeCerts:       true,
+			NginxServiceMesh:  true,
 			Expected:          true,
 		},
 		{
 			IsSSLService:      true,
 			SpiffeServerCerts: false,
-			SpiffeCerts:       true,
+			NginxServiceMesh:  true,
 			Expected:          true,
 		},
 		{
 			IsSSLService:      true,
 			SpiffeServerCerts: true,
-			SpiffeCerts:       false,
+			NginxServiceMesh:  false,
 			Expected:          true,
 		},
 		{
 			IsSSLService:      true,
 			SpiffeServerCerts: false,
-			SpiffeCerts:       false,
+			NginxServiceMesh:  false,
 			Expected:          true,
 		},
 	}
 	for i, tc := range testCases {
-		actual := isSSLEnabled(tc.IsSSLService, ConfigParams{SpiffeServerCerts: tc.SpiffeServerCerts}, &StaticConfigParams{SpiffeCerts: tc.SpiffeCerts})
+		actual := isSSLEnabled(tc.IsSSLService, ConfigParams{SpiffeServerCerts: tc.SpiffeServerCerts}, &StaticConfigParams{NginxServiceMesh: tc.NginxServiceMesh})
 		if actual != tc.Expected {
 			t.Errorf("isSSLEnabled returned %v but expected %v for the case %v", actual, tc.Expected, i)
 		}

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -29,6 +29,22 @@ var incompatibleLBMethodsForSlowStart = map[string]bool{
 	"random two least_time=last_byte": true,
 }
 
+// MeshPodOwner contains the type and name of the K8s resource that owns the pod.
+// This owner information is needed for NGINX Service Mesh metrics.
+type MeshPodOwner struct {
+	// OwnerType is one of the following: statefulset, daemonset, deployment.
+	OwnerType string
+	// OwnerName is the name of the statefulset, daemonset, or deployment.
+	OwnerName string
+}
+
+// PodInfo contains the name of the Pod and the MeshPodOwner information
+// which is used for NGINX Service Mesh metrics.
+type PodInfo struct {
+	Name string
+	MeshPodOwner
+}
+
 // VirtualServerEx holds a VirtualServer along with the resources that are referenced in this VirtualServer.
 type VirtualServerEx struct {
 	VirtualServer       *conf_v1.VirtualServer
@@ -37,7 +53,7 @@ type VirtualServerEx struct {
 	VirtualServerRoutes []*conf_v1.VirtualServerRoute
 	ExternalNameSvcs    map[string]bool
 	Policies            map[string]*conf_v1alpha1.Policy
-	PodsByIP            map[string]string
+	PodsByIP            map[string]PodInfo
 }
 
 func (vsx *VirtualServerEx) String() string {
@@ -168,7 +184,7 @@ func newVirtualServerConfigurator(cfgParams *ConfigParams, isPlus bool, isResolv
 		isTLSPassthrough:     staticParams.TLSPassthrough,
 		enableSnippets:       staticParams.EnableSnippets,
 		warnings:             make(map[runtime.Object][]string),
-		spiffeCerts:          staticParams.SpiffeCerts,
+		spiffeCerts:          staticParams.NginxServiceMesh,
 	}
 }
 

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -699,7 +699,7 @@ func TestGenerateVirtualServerConfigWithSpiffeCerts(t *testing.T) {
 	isPlus := false
 	isResolverConfigured := false
 	tlsPemFileName := ""
-	staticConfigParams := &StaticConfigParams{TLSPassthrough: true, SpiffeCerts: true}
+	staticConfigParams := &StaticConfigParams{TLSPassthrough: true, NginxServiceMesh: true}
 	vsc := newVirtualServerConfigurator(&baseCfgParams, isPlus, isResolverConfigured, staticConfigParams)
 	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, tlsPemFileName)
 	if !reflect.DeepEqual(result, expected) {


### PR DESCRIPTION
### Proposed changes
NGINX Service Mesh needs to know the owner kind and name of the pod in order to produce metrics according to the smi-spec. This PR adds a `pod_owner` label to metrics when the `-spire-agent-address` is set. The metrics produced by the mesh only support owner types of Deployment, StatefulSet, and DaemonSet. If the owner type is not one of these resources we default to deployment. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
