### PR TITLE
Add health-status-uri to cli argument doc

### DIFF
--- a/docs-web/configuration/global-configuration/command-line-arguments.md
+++ b/docs-web/configuration/global-configuration/command-line-arguments.md
@@ -64,6 +64,10 @@ Below we describe the available command-line arguments:
 	Adds a location "/nginx-health" to the default server. The location responds with the 200 status code for any request.
 	Useful for external health-checking of the Ingress controller.
 
+.. option:: -health-status-uri <string>
+
+	Sets the URI of health status location in the default server. Requires :option:`-health-status`. (default "/nginx-health")
+
 .. option:: -ingress-class <string>
 
 	A class of the Ingress controller.


### PR DESCRIPTION
### Proposed changes
* Re-add `health-status-uri` to cli argument doc. Removed in error in: https://github.com/nginxinc/kubernetes-ingress/commit/36febac1b11e3ab03e9d32a928480522427ae1f5

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
