### PR TITLE
add option to specify other log destinations in AP

### DIFF
--- a/internal/k8s/app_protect_resources.go
+++ b/internal/k8s/app_protect_resources.go
@@ -55,13 +55,21 @@ func ValidateAppProtectLogConf(logConf *unstructured.Unstructured) error {
 	return nil
 }
 
-var logDstEx = regexp.MustCompile(`syslog:server=((?:\d{1,3}\.){3}\d{1,3}|localhost):\d{1,5}`)
+var logDstEx = regexp.MustCompile(`(?:syslog:server=((?:\d{1,3}\.){3}\d{1,3}|localhost):\d{1,5})|stderr|(?:\/[\S]+)+`)
+var logDstFileEx = regexp.MustCompile(`(?:\/[\S]+)+`)
 
 // ValidateAppProtectLogDestinationAnnotation validates annotation for log destination configuration
 func ValidateAppProtectLogDestinationAnnotation(dstAntn string) error {
-	errormsg := "Error parsing App Protect Log config: Destination Annotation must follow format: syslog:server=<ip-address | localhost>:<port>"
+	errormsg := "Error parsing App Protect Log config: Destination Annotation must follow format: syslog:server=<ip-address | localhost>:<port> or stderr or absolute path to file"
 	if !logDstEx.MatchString(dstAntn) {
 		return fmt.Errorf("%s Log Destination did not follow format", errormsg)
+	}
+	if dstAntn == "stderr" {
+		return nil
+	}
+	
+	if logDstFileEx.MatchString(dstAntn) {
+		return nil
 	}
 
 	dstchunks := strings.Split(dstAntn, ":")

--- a/internal/k8s/app_protect_resources.go
+++ b/internal/k8s/app_protect_resources.go
@@ -74,10 +74,8 @@ func ValidateAppProtectLogDestinationAnnotation(dstAntn string) error {
 
 	dstchunks := strings.Split(dstAntn, ":")
 
-	port, err := strconv.Atoi(dstchunks[2])
-	if err != nil {
-		return fmt.Errorf("Error parsing port: %v", err)
-	}
+	// This error can be ingored since the regex check ensures this string will be parsable
+	port, _ := strconv.Atoi(dstchunks[2])
 
 	if port > 65535 || port < 1 {
 		return fmt.Errorf("Error parsing port: %v not a valid port number", port)

--- a/internal/k8s/app_protect_resources_test.go
+++ b/internal/k8s/app_protect_resources_test.go
@@ -1,0 +1,32 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+)
+// Positive test cases
+var posDstAntns = []string{"stderr", "syslog:server=localhost:9000", "syslog:server=10.1.1.2:9000", "/var/log/ap.log"}
+
+// Negative test cases item, expected error message
+var negDstAntns = [][]string{{"stdout", "Log Destination did not follow format"},
+	{"syslog:server=localhost:99999", "not a valid port number"},
+	{"syslog:server=999.99.99.99:5678", "is not a valid ip address"}}
+
+func TestValidateAppProtectLogDestinationAnnotation(t *testing.T) {
+	for _, tCase := range posDstAntns {
+		err := ValidateAppProtectLogDestinationAnnotation(tCase)
+		if err != nil {
+			t.Errorf("got %v expected nil", err)
+		}
+	}
+	for _, nTCase := range negDstAntns {
+		err := ValidateAppProtectLogDestinationAnnotation(nTCase[0])
+		if err == nil {
+			t.Errorf("got no error expected error containing %s", nTCase[1])
+		} else {
+			if !strings.Contains(err.Error(), nTCase[1]) {
+				t.Errorf("got %v expected to contain: %s", err, nTCase[1])
+			}
+		}
+	}
+}

--- a/internal/k8s/app_protect_resources_test.go
+++ b/internal/k8s/app_protect_resources_test.go
@@ -4,15 +4,16 @@ import (
 	"strings"
 	"testing"
 )
-// Positive test cases
-var posDstAntns = []string{"stderr", "syslog:server=localhost:9000", "syslog:server=10.1.1.2:9000", "/var/log/ap.log"}
 
-// Negative test cases item, expected error message
-var negDstAntns = [][]string{{"stdout", "Log Destination did not follow format"},
+func TestValidateAppProtectLogDestinationAnnotation(t *testing.T) {	
+	// Positive test cases
+	var posDstAntns = []string{"stderr", "syslog:server=localhost:9000", "syslog:server=10.1.1.2:9000", "/var/log/ap.log"}
+
+	// Negative test cases item, expected error message
+	var negDstAntns = [][]string{{"stdout", "Log Destination did not follow format"},
 	{"syslog:server=localhost:99999", "not a valid port number"},
 	{"syslog:server=999.99.99.99:5678", "is not a valid ip address"}}
 
-func TestValidateAppProtectLogDestinationAnnotation(t *testing.T) {
 	for _, tCase := range posDstAntns {
 		err := ValidateAppProtectLogDestinationAnnotation(tCase)
 		if err != nil {


### PR DESCRIPTION
### Proposed changes
This change allows for configuring additional values as log destinations, when setting remote logging via apLogConf

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
