### PR TITLE
Improve latency metrics documentation

### DIFF
--- a/docs-web/configuration/global-configuration/command-line-arguments.md
+++ b/docs-web/configuration/global-configuration/command-line-arguments.md
@@ -204,6 +204,11 @@ Below we describe the available command-line arguments:
 
     - If the argument is set, but `nginx-plus` is set to false, or the `spire-agent-address` is not provided, the Ingress Controller will fail to start.
 
+.. option:: -enable-latency-metrics
+
+	Enable collection of latency metrics for upstreams.
+    Requires :option:`-enable-prometheus-metrics`.
+
 .. option:: -enable-app-protect
 
 	 Enables support for App Protect.

--- a/docs-web/logging-and-monitoring/prometheus.md
+++ b/docs-web/logging-and-monitoring/prometheus.md
@@ -24,7 +24,7 @@ If you're using *Helm* to install the Ingress Controller, to enable Prometheus m
 The Ingress Controller exports the following metrics:
 
 * NGINX/NGINX Plus metrics:
-  * Exported by NGINX/NGINX Plus. See this [doc](https://github.com/nginxinc/nginx-prometheus-exporter#exported-metrics) to find more information about the exported metrics.
+  * Exported by NGINX/NGINX Plus. Refer to the [NGINX Prometheus Exporter developer docs](https://github.com/nginxinc/nginx-prometheus-exporter#exported-metrics) to find more information about the exported metrics.
   * Calculated by the Ingress Controller:
     *  `controller_upstream_server_response_latency_ms_count`. Bucketed response times from when NGINX establishes a connection to an upstream server to when the last byte of the response body is received by NGINX. **Note**: The metric for the upstream isn't available until traffic is sent to the upstream. The metric isn't enabled by default. To enable the metric, set the `-enable-latency-metrics` command-line argument.
 * Ingress Controller metrics

--- a/docs-web/logging-and-monitoring/prometheus.md
+++ b/docs-web/logging-and-monitoring/prometheus.md
@@ -23,8 +23,10 @@ If you're using *Helm* to install the Ingress Controller, to enable Prometheus m
 ## Available Metrics
 The Ingress Controller exports the following metrics:
 
-* NGINX/NGINX Plus metrics. Please see this [doc](https://github.com/nginxinc/nginx-prometheus-exporter#exported-metrics) to find more information about the exported metrics.
-
+* NGINX/NGINX Plus metrics:
+  * Exported by NGINX/NGINX Plus. See this [doc](https://github.com/nginxinc/nginx-prometheus-exporter#exported-metrics) to find more information about the exported metrics.
+  * Calculated by the Ingress Controller:
+    *  `controller_upstream_server_response_latency_ms_count`. Bucketed response times from when NGINX establishes a connection to an upstream server to when the last byte of the response body is received by NGINX. **Note**: The metric for the upstream isn't available until traffic is sent to the upstream. The metric isn't enabled by default. To enable the metric, set the `-enable-latency-metrics` command-line argument.
 * Ingress Controller metrics
   * `controller_nginx_reloads_total`. Number of successful NGINX reloads. This includes the label `reason` with 2 possible values `endpoints` (the reason for the reload was an endpoints update) and `other` (the reload was caused by something other than an endpoint update like an ingress update).
   * `controller_nginx_reload_errors_total`. Number of unsuccessful NGINX reloads.
@@ -34,7 +36,6 @@ The Ingress Controller exports the following metrics:
   * `controller_ingress_resources_total`. Number of handled Ingress resources. This metric includes the label type, that groups the Ingress resources by their type (regular, [minion or master](/nginx-ingress-controller/configuration/ingress-resources/cross-namespace-configuration)). **Note**: The metric doesn't count minions without a master.
   * `controller_virtualserver_resources_total`. Number of handled VirtualServer resources.
   * `controller_virtualserverroute_resources_total`. Number of handled VirtualServerRoute resources. **Note**: The metric counts only VirtualServerRoutes that have a reference from a VirtualServer.
-  * `controller_upstream_server_response_latency_ms_count`. Bucketed response times from when NGINX establishes a connection to an upstream server to when the last byte of the response body is received by NGINX. **Note** The metric for the upstream isn't available until traffic is sent to the upstream.
 
 **Note**: all metrics have the namespace nginx_ingress. For example, nginx_ingress_controller_nginx_reloads_total.
 


### PR DESCRIPTION
### Proposed changes

* Document -enable-latency-metrics cli arg
* Update the metric doc in the Prometheus doc

(there is some inconsistent whitespace usage in the cli arg table. this PR doesn't fixes it - uses the style of the nearest from above cli argument)