### PR TITLE
Fix TransportServers in debian AppProtect image

### DIFF
--- a/build/appprotect/DockerfileWithAppProtectForPlus
+++ b/build/appprotect/DockerfileWithAppProtectForPlus
@@ -76,6 +76,7 @@ RUN ln -sf /proc/1/fd/1 /var/log/nginx/access.log \
 	&& ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 RUN  mkdir -p /var/lib/nginx \
+	&& mkdir -p /etc/nginx/stream-conf.d \
 	&& mkdir -p /etc/nginx/secrets \
 	&& mkdir -p /etc/nginx/waf \
 	&& mkdir -p /etc/nginx/waf/nac-policies \


### PR DESCRIPTION
### Proposed changes
Previously, the DockerfileWithAppProtectForPlus didn't create the folder /etc/nginx/stream-conf.d. As a result, the IC wasn't able to write generated config for TransportServers, because the directory didn't exist.

 The PR fixes the Dockerfile to create that folder.