### PR TITLE
Fix ignoring JWK secrets in VS route policies

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -2082,6 +2082,11 @@ func (lbc *LoadBalancerController) createVirtualServerEx(virtualServer *conf_v1.
 			glog.Warningf("Error getting policy for VirtualServer %s/%s: %v", virtualServer.Namespace, virtualServer.Name, err)
 		}
 		policies = append(policies, vsRoutePolicies...)
+
+		err = lbc.addJWTSecrets(vsRoutePolicies, virtualServerEx.JWTKeys)
+		if err != nil {
+			glog.Warningf("Error getting JWT secrets for VirtualServer %v/%v: %v", virtualServer.Namespace, virtualServer.Name, err)
+		}
 	}
 
 	for _, vsr := range virtualServerRoutes {


### PR DESCRIPTION
### Proposed changes

Previously, If a route in a VS referenced a JWT policy, the IC would always mistakenly assume that the JWK secret that the policy referenced didn't exist. As a result, the VS would be configured with a warning about a missing secret and NGINX would return 500 status codes for requests to that VS.

This PR fixes that bug.

The bug was introduced in 253c3e9

