### PR TITLE
Add missing sslName to policy crd for helm

### DIFF
--- a/deployments/helm-chart/crds/policy.yaml
+++ b/deployments/helm-chart/crds/policy.yaml
@@ -67,6 +67,8 @@ spec:
                   type: boolean
                 sessionReuse:
                   type: boolean
+                sslName:
+                  type: string
                 tlsSecret:
                   type: string
                 trustedCertSecret:


### PR DESCRIPTION
Small fix for missing `sslName`