### PR TITLE
Fix helm chart kubeVersion detection

### DIFF
--- a/deployments/helm-chart/Chart.yaml
+++ b/deployments/helm-chart/Chart.yaml
@@ -2,7 +2,7 @@ name: nginx-ingress
 version: edge
 appVersion: edge
 apiVersion: v1
-kubeVersion: ">= 1.14.0"
+kubeVersion: ">= 1.14.0-0"
 description: NGINX Ingress Controller
 icon: https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/master/deployments/helm-chart/chart-icon.png
 sources:


### PR DESCRIPTION
### Proposed changes
Previously the helm chart would reject installs on kubernetes version that contained a `-*` suffix on the tag. Such as `v1.16.6-beta.0` or `v1.18.8-eks`

Bug first appeared in: https://github.com/nginxinc/kubernetes-ingress/commit/d893dd093ea3582be48c03ed79c92bbf5ddd73d3


#### Before changes
```
$ helm install dev deployments/helm-chart
Error: chart requires kubeVersion: >= 1.14.0 which is incompatible with Kubernetes v1.16.6-beta.0
```

#### After changes
```
$ helm install dev deployments/helm-chart
NAME: dev
LAST DEPLOYED: Mon Oct 19 15:29:48 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
The NGINX Ingress Controller has been installed
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
