### PR TITLE
Update supported k8s versions

### DIFF
--- a/docs-web/installation/installation-with-helm.md
+++ b/docs-web/installation/installation-with-helm.md
@@ -37,11 +37,6 @@ $ helm repo update
 
 ### Installing the CRDs
 
-**Note**: If you're using Kubernetes 1.14, make sure to add `--validate=false` to the `kubectl create` command below. Otherwise, you will get an error validating data:
-```
-ValidationError(CustomResourceDefinition.spec): unknown field "preserveUnknownFields" in io.k8s.apiextensions-apiserver.pkg.apis.api extensions.v1beta1.CustomResourceDefinitionSpec
-```
-
 By default, the Ingress Controller requires a number of custom resource definitions (CRDs) installed in the cluster. Helm 3.x client will install those CRDs. If you're using a Helm 2.x client, you need to install the CRDs via `kubectl`:
 
 ```console
@@ -115,8 +110,6 @@ To install the chart with the release name my-release (my-release is the name th
 ## Upgrading the Chart
 
 ### Upgrading the CRDs
-
-**Note**: If you're using Kubernetes 1.14, make sure to add `--validate=false` to the `kubectl apply` command below.
 
 Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a release, run the following command to upgrade the CRDs:
 

--- a/docs-web/installation/installation-with-manifests.md
+++ b/docs-web/installation/installation-with-manifests.md
@@ -57,11 +57,6 @@ In this section, we create resources common for most of the Ingress Controller i
 
 ### Create Custom Resources
 
-**Note**: If you're using Kubernetes 1.14, make sure to add `--validate=false` to the `kubectl apply` commands below. Otherwise, you will get an error validating data:
-```
-ValidationError(CustomResourceDefinition.spec): unknown field "preserveUnknownFields" in io.k8s.apiextensions-apiserver.pkg.apis.api extensions.v1beta1.CustomResourceDefinitionSpec
-```
-
 **Note**: There are two different sets of custom resource definitions: one for Kubernetes <= v1.15 and one for Kubernetes >= v1.16. For Kubernetes <= v1.15 substitute `crds` with `crds-v1beta1` in the following commands.
 
 1. Create custom resource definitions for [VirtualServer and VirtualServerRoute](/nginx-ingress-controller/configuration/virtualserver-and-virtualserverroute-resources), [TransportServer](/nginx-ingress-controller/configuration/transportserver-resource) and [Policy](/nginx-ingress-controller/configuration/policy-resource) resources:
@@ -86,8 +81,6 @@ If you would like to use the TCP and UDP load balancing features of the Ingress 
 > **Feature Status**: The TransportServer, GlobalConfiguration and Policy resources are available as a preview feature: it is suitable for experimenting and testing; however, it must be used with caution in production environments. Additionally, while the feature is in preview, we might introduce some backward-incompatible changes to the resources specification in the next releases.
 
 ### Resources for NGINX App Protect
-
-**Note**: If you're using Kubernetes 1.14, make sure to add `--validate=false` to the `kubectl apply` commands below.
 
 If you would like to use the App Protect module, create the following additional resources:
 

--- a/docs-web/technical-specifications.md
+++ b/docs-web/technical-specifications.md
@@ -3,7 +3,7 @@
 ## Supported Kubernetes Versions
 
 The NGINX Ingress Controller has been verified to run on the following Kubernetes versions:
-* Kubernetes 1.14-1.18
+* Kubernetes 1.15-1.19
 
 ## Supported Docker Images
 


### PR DESCRIPTION
### Proposed changes
* Update supported k8s versions
* Remove notes for k8 1.14 as it is no longer supported.

Note: This change was already done for stable release:
* https://github.com/nginxinc/kubernetes-ingress/pull/1210
* https://docs.nginx.com/nginx-ingress-controller/technical-specifications/

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
