### PR TITLE
Update the base ubi images to 8.3

### DIFF
--- a/build/openshift/Dockerfile
+++ b/build/openshift/Dockerfile
@@ -1,6 +1,6 @@
 ARG GOLANG_CONTAINER=golang:latest
 
-FROM registry.access.redhat.com/ubi8/ubi:8.1 AS base
+FROM registry.access.redhat.com/ubi8/ubi:8.3 AS base
 
 LABEL name="NGINX Ingress Controller" \
       description="The Ingress controller is an application that runs in a cluster and configures an HTTP load balancer according to Ingress resources." \

--- a/build/openshift/DockerfileForPlus
+++ b/build/openshift/DockerfileForPlus
@@ -1,6 +1,6 @@
 ARG GOLANG_CONTAINER=golang:latest
 
-FROM registry.access.redhat.com/ubi8/ubi:8.1 AS base
+FROM registry.access.redhat.com/ubi8/ubi:8.3 AS base
 
 LABEL name="NGINX Ingress Controller" \
       description="The Ingress controller is an application that runs in a cluster and configures an HTTP load balancer according to Ingress resources." \

--- a/docs-web/technical-specifications.md
+++ b/docs-web/technical-specifications.md
@@ -40,7 +40,7 @@ The supported architecture is x86-64.
       - 
     * - Ubi-based image
       - ``openshift/Dockerfile``
-      - ``registry.access.redhat.com/ubi8/ubi:8.1``
+      - ``registry.access.redhat.com/ubi8/ubi:8.3``
       - 
       - ``nginx/nginx-ingress:1.9.0-ubi``
 ```
@@ -71,7 +71,7 @@ NGINX Plus images are not available through DockerHub.
       - NGINX Plus OpenTracing module, C++ OpenTracing binding for Jaeger 0.4.2 
     * - Ubi-based image
       - ``openshift/DockerfileForPlus``
-      - ``registry.access.redhat.com/ubi8/ubi:8.1``
+      - ``registry.access.redhat.com/ubi8/ubi:8.3``
       - 
     * - Debian-based image with App Protect
       - ``appprotect/DockerfileWithAppProtectForPlus``


### PR DESCRIPTION
### Proposed changes
Update the base ubi images from 8.1 to 8.3 as the older images cause the health index of Images to marked as lower category in openshift due to lack of security upgrades in older images.

Fixes: #1226 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x]  I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
