### PR TITLE
Fix installation of ingressclass resource via helm chart on certain kubernetes versions

### DIFF
--- a/deployments/helm-chart/templates/controller-ingress-class.yaml
+++ b/deployments/helm-chart/templates/controller-ingress-class.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">=1.18.0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.18.0-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
 kind: IngressClass
 metadata:


### PR DESCRIPTION
### Bug
Helm will fail to install the ingressclass resource when the patch value of the semver contains some non-numerical suffix.

For example:
* v1.18.8-rc.1
* v1.18.10-gke.601

### Proposed changes
On kubernetes versions `v1.18.*-*`(see examples above) the ingressclass resource is installed successfully:

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
