### PR TITLE
Validate TLS and CA secrets

### DIFF
--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -1364,7 +1364,7 @@ func TestGetIngressMTLSSecret(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: SecretTypeCA,
-		Data: map[string][]byte{"ca.crt": nil},
+		Data: map[string][]byte{"ca.crt": validCACert},
 	}
 
 	invalidSecret := &v1.Secret{
@@ -1497,15 +1497,15 @@ func TestAddEgressMTLSSecrets(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: api_v1.SecretTypeTLS,
-		Data: map[string][]byte{"tls.key": nil, "tls.crt": nil},
+		Data: map[string][]byte{"tls.crt": validCert, "tls.key": validKey},
 	}
-	validSecret2 := &v1.Secret{
+	validCASecret := &v1.Secret{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "valid-egress-trusted-secret",
 			Namespace: "default",
 		},
 		Type: SecretTypeCA,
-		Data: map[string][]byte{"ca.crt": nil},
+		Data: map[string][]byte{"ca.crt": validCACert},
 	}
 
 	invalidSecret := &v1.Secret{
@@ -1557,7 +1557,7 @@ func TestAddEgressMTLSSecrets(t *testing.T) {
 				},
 			},
 			expectedEgressMTLSSecrets: map[string]*v1.Secret{
-				"default/valid-egress-trusted-secret": validSecret2,
+				"default/valid-egress-trusted-secret": validCASecret,
 			},
 			wantErr: false,
 			msg:     "test getting valid TrustedCA secret",
@@ -1579,7 +1579,7 @@ func TestAddEgressMTLSSecrets(t *testing.T) {
 			},
 			expectedEgressMTLSSecrets: map[string]*v1.Secret{
 				"default/valid-egress-mtls-secret":    validSecret,
-				"default/valid-egress-trusted-secret": validSecret2,
+				"default/valid-egress-trusted-secret": validCASecret,
 			},
 			wantErr: false,
 			msg:     "test getting valid secrets",
@@ -1655,7 +1655,7 @@ func TestAddEgressMTLSSecrets(t *testing.T) {
 						case "default/valid-egress-mtls-secret":
 							return validSecret, true, nil
 						case "default/valid-egress-trusted-secret":
-							return validSecret2, true, nil
+							return validCASecret, true, nil
 						case "default/invalid-egress-mtls-secret":
 							return invalidSecret, true, errors.New("secret is missing egress-mtls key in data")
 						default:

--- a/internal/k8s/secret_test.go
+++ b/internal/k8s/secret_test.go
@@ -71,7 +71,7 @@ func TestValidateCASecret(t *testing.T) {
 		},
 		Type: SecretTypeCA,
 		Data: map[string][]byte{
-			"ca.crt": nil,
+			"ca.crt": validCert,
 		},
 	}
 
@@ -94,7 +94,7 @@ func TestValidateCASecretFails(t *testing.T) {
 				},
 				Type: "some-type",
 				Data: map[string][]byte{
-					"ca.crt": nil,
+					"ca.crt": validCert,
 				},
 			},
 			msg: "Incorrect type for CA secret",
@@ -108,6 +108,45 @@ func TestValidateCASecretFails(t *testing.T) {
 				Type: SecretTypeCA,
 			},
 			msg: "Missing ca.crt for CA secret",
+		},
+		{
+			secret: &v1.Secret{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "ingress-mtls-secret",
+					Namespace: "default",
+				},
+				Type: SecretTypeCA,
+				Data: map[string][]byte{
+					"ca.crt": invalidCACertWithNoPEMBlock,
+				},
+			},
+			msg: "Invalid cert with no PEM block",
+		},
+		{
+			secret: &v1.Secret{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "ingress-mtls-secret",
+					Namespace: "default",
+				},
+				Type: SecretTypeCA,
+				Data: map[string][]byte{
+					"ca.crt": invalidCACertWithWrongPEMBlock,
+				},
+			},
+			msg: "Invalid cert with wrong PEM block",
+		},
+		{
+			secret: &v1.Secret{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "ingress-mtls-secret",
+					Namespace: "default",
+				},
+				Type: SecretTypeCA,
+				Data: map[string][]byte{
+					"ca.crt": invalidCACert,
+				},
+			},
+			msg: "Invalid cert",
 		},
 	}
 
@@ -126,6 +165,10 @@ func TestValidateTLSSecret(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: v1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": validCert,
+			"tls.key": validKey,
+		},
 	}
 
 	err := ValidateTLSSecret(secret)
@@ -135,17 +178,55 @@ func TestValidateTLSSecret(t *testing.T) {
 }
 
 func TestValidateTLSSecretFails(t *testing.T) {
-	secret := &v1.Secret{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      "tls-secret",
-			Namespace: "default",
+	tests := []struct {
+		secret *v1.Secret
+		msg    string
+	}{
+		{
+			secret: &v1.Secret{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "tls-secret",
+					Namespace: "default",
+				},
+				Type: "some type",
+			},
+			msg: "Wrong type",
 		},
-		Type: "some type",
+		{
+			secret: &v1.Secret{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "tls-secret",
+					Namespace: "default",
+				},
+				Type: v1.SecretTypeTLS,
+				Data: map[string][]byte{
+					"tls.crt": invalidCert,
+					"tls.key": validKey,
+				},
+			},
+			msg: "Invalid cert",
+		},
+		{
+			secret: &v1.Secret{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "tls-secret",
+					Namespace: "default",
+				},
+				Type: v1.SecretTypeTLS,
+				Data: map[string][]byte{
+					"tls.crt": validCert,
+					"tls.key": invalidKey,
+				},
+			},
+			msg: "Invalid key",
+		},
 	}
 
-	err := ValidateTLSSecret(secret)
-	if err == nil {
-		t.Errorf("ValidateTLSSecret() returned no error")
+	for _, test := range tests {
+		err := ValidateTLSSecret(test.secret)
+		if err == nil {
+			t.Errorf("ValidateTLSSecret() returned no error for the case of %s", test.msg)
+		}
 	}
 }
 
@@ -161,6 +242,10 @@ func TestValidateSecret(t *testing.T) {
 					Namespace: "default",
 				},
 				Type: v1.SecretTypeTLS,
+				Data: map[string][]byte{
+					"tls.crt": validCert,
+					"tls.key": validKey,
+				},
 			},
 			msg: "Valid TLS secret",
 		},
@@ -172,7 +257,7 @@ func TestValidateSecret(t *testing.T) {
 				},
 				Type: SecretTypeCA,
 				Data: map[string][]byte{
-					"ca.crt": nil,
+					"ca.crt": validCACert,
 				},
 			},
 			msg: "Valid CA secret",
@@ -209,6 +294,10 @@ func TestValidateSecretFails(t *testing.T) {
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "tls-secret",
 					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"tls.crt": validCert,
+					"tls.key": validKey,
 				},
 			},
 			msg: "Missing type for TLS secret",
@@ -272,3 +361,70 @@ func TestHasCorrectSecretType(t *testing.T) {
 		}
 	}
 }
+
+var (
+	validCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDLjCCAhYCCQDAOF9tLsaXWjANBgkqhkiG9w0BAQsFADBaMQswCQYDVQQGEwJV
+UzELMAkGA1UECAwCQ0ExITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0
+ZDEbMBkGA1UEAwwSY2FmZS5leGFtcGxlLmNvbSAgMB4XDTE4MDkxMjE2MTUzNVoX
+DTIzMDkxMTE2MTUzNVowWDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMSEwHwYD
+VQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxGTAXBgNVBAMMEGNhZmUuZXhh
+bXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCp6Kn7sy81
+p0juJ/cyk+vCAmlsfjtFM2muZNK0KtecqG2fjWQb55xQ1YFA2XOSwHAYvSdwI2jZ
+ruW8qXXCL2rb4CZCFxwpVECrcxdjm3teViRXVsYImmJHPPSyQgpiobs9x7DlLc6I
+BA0ZjUOyl0PqG9SJexMV73WIIa5rDVSF2r4kSkbAj4Dcj7LXeFlVXH2I5XwXCptC
+n67JCg42f+k8wgzcRVp8XZkZWZVjwq9RUKDXmFB2YyN1XEWdZ0ewRuKYUJlsm692
+skOrKQj0vkoPn41EE/+TaVEpqLTRoUY3rzg7DkdzfdBizFO2dsPNFx2CW0jXkNLv
+Ko25CZrOhXAHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAKHFCcyOjZvoHswUBMdL
+RdHIb383pWFynZq/LuUovsVA58B0Cg7BEfy5vWVVrq5RIkv4lZ81N29x21d1JH6r
+jSnQx+DXCO/TJEV5lSCUpIGzEUYaUPgRyjsM/NUdCJ8uHVhZJ+S6FA+CnOD9rn2i
+ZBePCI5rHwEXwnnl8ywij3vvQ5zHIuyBglWr/Qyui9fjPpwWUvUm4nv5SMG9zCV7
+PpuwvuatqjO1208BjfE/cZHIg8Hw9mvW9x9C+IQMIMDE7b/g6OcK7LGTLwlFxvA8
+7WjEequnayIphMhKRXVf1N349eN98Ez38fOTHTPbdJjFA/PcC+Gyme+iGt5OQdFh
+yRE=
+-----END CERTIFICATE-----`)
+
+	validKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAqeip+7MvNadI7if3MpPrwgJpbH47RTNprmTStCrXnKhtn41k
+G+ecUNWBQNlzksBwGL0ncCNo2a7lvKl1wi9q2+AmQhccKVRAq3MXY5t7XlYkV1bG
+CJpiRzz0skIKYqG7Pcew5S3OiAQNGY1DspdD6hvUiXsTFe91iCGuaw1Uhdq+JEpG
+wI+A3I+y13hZVVx9iOV8FwqbQp+uyQoONn/pPMIM3EVafF2ZGVmVY8KvUVCg15hQ
+dmMjdVxFnWdHsEbimFCZbJuvdrJDqykI9L5KD5+NRBP/k2lRKai00aFGN684Ow5H
+c33QYsxTtnbDzRcdgltI15DS7yqNuQmazoVwBwIDAQABAoIBAQCPSdSYnQtSPyql
+FfVFpTOsoOYRhf8sI+ibFxIOuRauWehhJxdm5RORpAzmCLyL5VhjtJme223gLrw2
+N99EjUKb/VOmZuDsBc6oCF6QNR58dz8cnORTewcotsJR1pn1hhlnR5HqJJBJask1
+ZEnUQfcXZrL94lo9JH3E+Uqjo1FFs8xxE8woPBqjZsV7pRUZgC3LhxnwLSExyFo4
+cxb9SOG5OmAJozStFoQ2GJOes8rJ5qfdvytgg9xbLaQL/x0kpQ62BoFMBDdqOePW
+KfP5zZ6/07/vpj48yA1Q32PzobubsBLd3Kcn32jfm1E7prtWl+JeOFiOznBQFJbN
+4qPVRz5hAoGBANtWyxhNCSLu4P+XgKyckljJ6F5668fNj5CzgFRqJ09zn0TlsNro
+FTLZcxDqnR3HPYM42JERh2J/qDFZynRQo3cg3oeivUdBVGY8+FI1W0qdub/L9+yu
+edOZTQ5XmGGp6r6jexymcJim/OsB3ZnYOpOrlD7SPmBvzNLk4MF6gxbXAoGBAMZO
+0p6HbBmcP0tjFXfcKE77ImLm0sAG4uHoUx0ePj/2qrnTnOBBNE4MvgDuTJzy+caU
+k8RqmdHCbHzTe6fzYq/9it8sZ77KVN1qkbIcuc+RTxA9nNh1TjsRne74Z0j1FCLk
+hHcqH0ri7PYSKHTE8FvFCxZYdbuB84CmZihvxbpRAoGAIbjqaMYPTYuklCda5S79
+YSFJ1JzZe1Kja//tDw1zFcgVCKa31jAwciz0f/lSRq3HS1GGGmezhPVTiqLfeZqc
+R0iKbhgbOcVVkJJ3K0yAyKwPTumxKHZ6zImZS0c0am+RY9YGq5T7YrzpzcfvpiOU
+ffe3RyFT7cfCmfoOhDCtzukCgYB30oLC1RLFOrqn43vCS51zc5zoY44uBzspwwYN
+TwvP/ExWMf3VJrDjBCH+T/6sysePbJEImlzM+IwytFpANfiIXEt/48Xf60Nx8gWM
+uHyxZZx/NKtDw0V8vX1POnq2A5eiKa+8jRARYKJLYNdfDuwolxvG6bZhkPi/4EtT
+3Y18sQKBgHtKbk+7lNJVeswXE5cUG6EDUsDe/2Ua7fXp7FcjqBEoap1LSw+6TXp0
+ZgrmKE8ARzM47+EJHUviiq/nupE15g0kJW3syhpU9zZLO7ltB0KIkO9ZRcmUjo8Q
+cpLlHMAqbLJ8WYGJCkhiWxyal6hYTyWY4cVkC0xtTl/hUE9IeNKo
+-----END RSA PRIVATE KEY-----`)
+
+	invalidCert = []byte(`-----BEGIN CERTIFICATE-----
+-----END CERTIFICATE-----`)
+
+	invalidKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+-----END RSA PRIVATE KEY-----`)
+
+	validCACert = validCert
+
+	invalidCACertWithNoPEMBlock []byte
+
+	invalidCACertWithWrongPEMBlock = []byte(`-----BEGIN PRIVATE KEY-----
+-----END PRIVATE KEY-----`)
+
+	invalidCACert = []byte(`-----BEGIN CERTIFICATE-----
+-----END CERTIFICATE-----`)
+)


### PR DESCRIPTION
### Proposed changes

Previously, the contents of the TLS and CA secrets wasn't validated. As a result, NGINX could be configured to use an invalid TLS cert and/or key. In that case, NGINX would fail to reload. More over, NGINX would keep failing to reload until that secret was fixed/removed or a resource referencing that secret was removed.

This PR brings validation of the contents of secrets:
* cert and key of TLS secret
* cert of CA secret

If a secret is invalid, NGINX will not be configured to use it. 