### PR TITLE
Add validation to ingress annotations and config map keys

### DIFF
--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -162,15 +162,27 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 	}
 
 	if proxyConnectTimeout, exists := ingEx.Ingress.Annotations["nginx.org/proxy-connect-timeout"]; exists {
-		cfgParams.ProxyConnectTimeout = proxyConnectTimeout
+		if parsedProxyConnectTimeout, err := ParseTime(proxyConnectTimeout); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/proxy-connect-timeout: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), proxyConnectTimeout, err)
+		} else {
+			cfgParams.ProxyConnectTimeout = parsedProxyConnectTimeout
+		}
 	}
 
 	if proxyReadTimeout, exists := ingEx.Ingress.Annotations["nginx.org/proxy-read-timeout"]; exists {
-		cfgParams.ProxyReadTimeout = proxyReadTimeout
+		if parsedProxyReadTimeout, err := ParseTime(proxyReadTimeout); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/proxy-read-timeout: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), proxyReadTimeout, err)
+		} else {
+			cfgParams.ProxyReadTimeout = parsedProxyReadTimeout
+		}
 	}
 
 	if proxySendTimeout, exists := ingEx.Ingress.Annotations["nginx.org/proxy-send-timeout"]; exists {
-		cfgParams.ProxySendTimeout = proxySendTimeout
+		if parsedProxySendTimeout, err := ParseTime(proxySendTimeout); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/proxy-send-timeout: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), proxySendTimeout, err)
+		} else {
+			cfgParams.ProxySendTimeout = parsedProxySendTimeout
+		}
 	}
 
 	if proxyHideHeaders, exists, err := GetMapKeyAsStringSlice(ingEx.Ingress.Annotations, "nginx.org/proxy-hide-headers", ingEx.Ingress, ","); exists {
@@ -190,7 +202,11 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 	}
 
 	if clientMaxBodySize, exists := ingEx.Ingress.Annotations["nginx.org/client-max-body-size"]; exists {
-		cfgParams.ClientMaxBodySize = clientMaxBodySize
+		if parsedClientMaxBodySize, err := ParseOffset(clientMaxBodySize); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/client-max-body-size: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), clientMaxBodySize, err)
+		} else {
+			cfgParams.ClientMaxBodySize = parsedClientMaxBodySize
+		}
 	}
 
 	if redirectToHTTPS, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, "nginx.org/redirect-to-https", ingEx.Ingress); exists {
@@ -257,19 +273,35 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 	}
 
 	if proxyBuffers, exists := ingEx.Ingress.Annotations["nginx.org/proxy-buffers"]; exists {
-		cfgParams.ProxyBuffers = proxyBuffers
+		if parsedProxyBuffers, err := ParseProxyBuffers(proxyBuffers); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/proxy-buffers: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), proxyBuffers, err)
+		} else {
+			cfgParams.ProxyBuffers = parsedProxyBuffers
+		}
 	}
 
 	if proxyBufferSize, exists := ingEx.Ingress.Annotations["nginx.org/proxy-buffer-size"]; exists {
-		cfgParams.ProxyBufferSize = proxyBufferSize
+		if parsedProxyBufferSize, err := ParseSize(proxyBufferSize); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/proxy-buffer-size: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), proxyBufferSize, err)
+		} else {
+			cfgParams.ProxyBufferSize = parsedProxyBufferSize
+		}
 	}
 
 	if upstreamZoneSize, exists := ingEx.Ingress.Annotations["nginx.org/upstream-zone-size"]; exists {
-		cfgParams.UpstreamZoneSize = upstreamZoneSize
+		if parsedUpstreamZoneSize, err := ParseSize(upstreamZoneSize); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/upstream-zone-size: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), upstreamZoneSize, err)
+		} else {
+			cfgParams.UpstreamZoneSize = parsedUpstreamZoneSize
+		}
 	}
 
 	if proxyMaxTempFileSize, exists := ingEx.Ingress.Annotations["nginx.org/proxy-max-temp-file-size"]; exists {
-		cfgParams.ProxyMaxTempFileSize = proxyMaxTempFileSize
+		if parsedProxyMaxTempFileSize, err := ParseSize(proxyMaxTempFileSize); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/proxy-max-temp-file-size: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), proxyMaxTempFileSize, err)
+		} else {
+			cfgParams.ProxyMaxTempFileSize = parsedProxyMaxTempFileSize
+		}
 	}
 
 	if isPlus {
@@ -304,24 +336,28 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 		}
 	}
 
-	if maxFails, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/max-fails", ingEx.Ingress); exists {
-		if err != nil {
-			glog.Error(err)
+	if maxFails, exists := ingEx.Ingress.Annotations["nginx.org/max-fails"]; exists {
+		if parsedMaxFails, err := ParseNonNegativeInt(maxFails); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/max-fails: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), maxFails, err)
 		} else {
-			cfgParams.MaxFails = maxFails
+			cfgParams.MaxFails = parsedMaxFails
 		}
 	}
 
-	if maxConns, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/max-conns", ingEx.Ingress); exists {
-		if err != nil {
-			glog.Error(err)
+	if maxConns, exists := ingEx.Ingress.Annotations["nginx.org/max-conns"]; exists {
+		if parsedMaxConns, err := ParseNonNegativeInt(maxConns); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/max-conns: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), maxConns, err)
 		} else {
-			cfgParams.MaxConns = maxConns
+			cfgParams.MaxConns = parsedMaxConns
 		}
 	}
 
 	if failTimeout, exists := ingEx.Ingress.Annotations["nginx.org/fail-timeout"]; exists {
-		cfgParams.FailTimeout = failTimeout
+		if parsedFailTimeout, err := ParseTime(failTimeout); err != nil {
+			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/fail-timeout: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), failTimeout, err)
+		} else {
+			cfgParams.FailTimeout = parsedFailTimeout
+		}
 	}
 
 	if hasAppProtect {

--- a/internal/configs/annotations_test.go
+++ b/internal/configs/annotations_test.go
@@ -4,6 +4,9 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	networking "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestParseRewrites(t *testing.T) {
@@ -149,5 +152,691 @@ func TestMergeMasterAnnotationsIntoMinion(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expectedMergedAnnotations, minionAnnotations) {
 		t.Errorf("mergeMasterAnnotationsIntoMinion returned %v, but expected %v", minionAnnotations, expectedMergedAnnotations)
+	}
+}
+
+func TestParseProxyConnectTimeoutAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultTimeout := baseCfg.ProxyConnectTimeout
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected string
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-connect-timeout", "30s"),
+			baseCfg:  baseCfg,
+			expected: "30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-connect-timeout", "1m 30s"),
+			baseCfg:  baseCfg,
+			expected: "1m 30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-connect-timeout", "1m30s"),
+			baseCfg:  baseCfg,
+			expected: "1m30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-connect-timeout", "30s 2m"),
+			baseCfg:  baseCfg,
+			expected: "30s 2m",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-connect-timeout", "10s"),
+			baseCfg:  baseCfg,
+			expected: "10s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-connect-timeout", "60secs"),
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-connect-timeout", "invalid_time_string"),
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.ProxyConnectTimeout {
+			t.Errorf("parseAnnotations() returned cfg.ProxyConnectTimeout with %v, but expected %v", cfg.ProxyConnectTimeout, test.expected)
+		}
+	}
+}
+
+func TestParseProxyReadTimeoutAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultTimeout := baseCfg.ProxyReadTimeout
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected string
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-read-timeout", "30s"),
+			baseCfg:  baseCfg,
+			expected: "30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-read-timeout", "1m 30s"),
+			baseCfg:  baseCfg,
+			expected: "1m 30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-read-timeout", "1m30s"),
+			baseCfg:  baseCfg,
+			expected: "1m30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-read-timeout", "30s 2m"),
+			baseCfg:  baseCfg,
+			expected: "30s 2m",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-read-timeout", "10s"),
+			baseCfg:  baseCfg,
+			expected: "10s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-read-timeout", "60secs"),
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-read-timeout", "invalid_time_string"),
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.ProxyReadTimeout {
+			t.Errorf("parseAnnotations() returned cfg.ProxyReadTimeout with %v, but expected %v", cfg.ProxyReadTimeout, test.expected)
+		}
+	}
+}
+
+func TestParseProxySendTimeoutAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultTimeout := baseCfg.ProxySendTimeout
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected string
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-send-timeout", "30s"),
+			baseCfg:  baseCfg,
+			expected: "30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-send-timeout", "1m 30s"),
+			baseCfg:  baseCfg,
+			expected: "1m 30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-send-timeout", "1m30s"),
+			baseCfg:  baseCfg,
+			expected: "1m30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-send-timeout", "30s 2m"),
+			baseCfg:  baseCfg,
+			expected: "30s 2m",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-send-timeout", "10s"),
+			baseCfg:  baseCfg,
+			expected: "10s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-send-timeout", "60secs"),
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-send-timeout", "invalid_time_string"),
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.ProxySendTimeout {
+			t.Errorf("parseAnnotations() returned cfg.ProxySendTimeout with %v, but expected %v", cfg.ProxySendTimeout, test.expected)
+		}
+	}
+}
+
+func TestParseFailTimeoutAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultTimeout := baseCfg.FailTimeout
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected string
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+		{
+			ing:      createTestIngress("nginx.org/fail-timeout", "30s"),
+			baseCfg:  baseCfg,
+			expected: "30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/fail-timeout", "1m 30s"),
+			baseCfg:  baseCfg,
+			expected: "1m 30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/fail-timeout", "1m30s"),
+			baseCfg:  baseCfg,
+			expected: "1m30s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/fail-timeout", "30s 2m"),
+			baseCfg:  baseCfg,
+			expected: "30s 2m",
+		},
+		{
+			ing:      createTestIngress("nginx.org/fail-timeout", "10s"),
+			baseCfg:  baseCfg,
+			expected: "10s",
+		},
+		{
+			ing:      createTestIngress("nginx.org/fail-timeout", "60secs"),
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+		{
+			ing:      createTestIngress("nginx.org/fail-timeout", "invalid_time_string"),
+			baseCfg:  baseCfg,
+			expected: defaultTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.FailTimeout {
+			t.Errorf("parseAnnotations() returned cfg.FailTimeout with %v, but expected %v", cfg.FailTimeout, test.expected)
+		}
+	}
+}
+
+func TestParseClientMaxBodySizeAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultSize := baseCfg.ClientMaxBodySize
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected string
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/client-max-body-size", "2k"),
+			baseCfg:  baseCfg,
+			expected: "2k",
+		},
+		{
+			ing:      createTestIngress("nginx.org/client-max-body-size", "16M"),
+			baseCfg:  baseCfg,
+			expected: "16M",
+		},
+		{
+			ing:      createTestIngress("nginx.org/client-max-body-size", "1g"),
+			baseCfg:  baseCfg,
+			expected: "1g",
+		},
+		{
+			ing:      createTestIngress("nginx.org/client-max-body-size", "12M"),
+			baseCfg:  baseCfg,
+			expected: "12M",
+		},
+		{
+			ing:      createTestIngress("nginx.org/client-max-body-size", "32Megabytes"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/client-max-body-size", "invalid_offset_string"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.ClientMaxBodySize {
+			t.Errorf("parseAnnotations() returned cfg.ClientMaxBodySize with %v, but expected %v", cfg.ClientMaxBodySize, test.expected)
+		}
+	}
+}
+
+func TestParseProxyBufferSizeAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultSize := baseCfg.ProxyBufferSize
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected string
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffer-size", "2k"),
+			baseCfg:  baseCfg,
+			expected: "2k",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffer-size", "16M"),
+			baseCfg:  baseCfg,
+			expected: "16M",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffer-size", "12M"),
+			baseCfg:  baseCfg,
+			expected: "12M",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffer-size", "1g"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffer-size", "32Megabytes"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffer-size", "invalid_size_string"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.ProxyBufferSize {
+			t.Errorf("parseAnnotations() returned cfg.ProxyBufferSize with %v, but expected %v", cfg.ProxyBufferSize, test.expected)
+		}
+	}
+}
+
+func TestParseProxyMaxTempFileSizeAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultSize := baseCfg.ProxyMaxTempFileSize
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected string
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-max-temp-file-size", "2k"),
+			baseCfg:  baseCfg,
+			expected: "2k",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-max-temp-file-size", "16M"),
+			baseCfg:  baseCfg,
+			expected: "16M",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-max-temp-file-size", "12M"),
+			baseCfg:  baseCfg,
+			expected: "12M",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-max-temp-file-size", "1g"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-max-temp-file-size", "32Megabytes"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-max-temp-file-size", "invalid_size_string"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.ProxyMaxTempFileSize {
+			t.Errorf("parseAnnotations() returned cfg.ProxyMaxTempFileSize with %v, but expected %v", cfg.ProxyMaxTempFileSize, test.expected)
+		}
+	}
+}
+
+func TestParseUpstreamZoneSizeAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultSize := baseCfg.UpstreamZoneSize
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected string
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/upstream-zone-size", "2k"),
+			baseCfg:  baseCfg,
+			expected: "2k",
+		},
+		{
+			ing:      createTestIngress("nginx.org/upstream-zone-size", "16M"),
+			baseCfg:  baseCfg,
+			expected: "16M",
+		},
+		{
+			ing:      createTestIngress("nginx.org/upstream-zone-size", "12M"),
+			baseCfg:  baseCfg,
+			expected: "12M",
+		},
+		{
+			ing:      createTestIngress("nginx.org/upstream-zone-size", "1g"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/upstream-zone-size", "32Megabytes"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+		{
+			ing:      createTestIngress("nginx.org/upstream-zone-size", "invalid_size_string"),
+			baseCfg:  baseCfg,
+			expected: defaultSize,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.UpstreamZoneSize {
+			t.Errorf("parseAnnotations() returned cfg.UpstreamZoneSize with %v, but expected %v", cfg.UpstreamZoneSize, test.expected)
+		}
+	}
+}
+
+func TestParseMaxFailsAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultNum := baseCfg.MaxFails
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected int
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultNum,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-fails", "0"),
+			baseCfg:  baseCfg,
+			expected: 0,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-fails", "1"),
+			baseCfg:  baseCfg,
+			expected: 1,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-fails", "100"),
+			baseCfg:  baseCfg,
+			expected: 100,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-fails", "-1"),
+			baseCfg:  baseCfg,
+			expected: defaultNum,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-fails", "-100"),
+			baseCfg:  baseCfg,
+			expected: defaultNum,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-fails", "invalid_non_negative_int"),
+			baseCfg:  baseCfg,
+			expected: defaultNum,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.MaxFails {
+			t.Errorf("parseAnnotations() returned cfg.MaxFails with %v, but expected %v", cfg.MaxFails, test.expected)
+		}
+	}
+}
+
+func TestParseMaxConnsAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultNum := baseCfg.MaxConns
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected int
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultNum,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-conns", "0"),
+			baseCfg:  baseCfg,
+			expected: 0,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-conns", "1"),
+			baseCfg:  baseCfg,
+			expected: 1,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-conns", "100"),
+			baseCfg:  baseCfg,
+			expected: 100,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-conns", "-1"),
+			baseCfg:  baseCfg,
+			expected: defaultNum,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-conns", "-100"),
+			baseCfg:  baseCfg,
+			expected: defaultNum,
+		},
+		{
+			ing:      createTestIngress("nginx.org/max-conns", "invalid_non_negative_int"),
+			baseCfg:  baseCfg,
+			expected: defaultNum,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.MaxConns {
+			t.Errorf("parseAnnotations() returned cfg.MaxConns with %v, but expected %v", cfg.MaxConns, test.expected)
+		}
+	}
+}
+
+func TestParseProxyBuffersAnnotation(t *testing.T) {
+	baseCfg := NewDefaultConfigParams()
+	defaultSetting := baseCfg.ProxyBuffers
+	tests := []struct {
+		ing      *IngressEx
+		baseCfg  *ConfigParams
+		expected string
+	}{
+		{
+			ing: &IngressEx{
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			baseCfg:  baseCfg,
+			expected: defaultSetting,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffers", "8 2k"),
+			baseCfg:  baseCfg,
+			expected: "8 2k",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffers", "4 16M"),
+			baseCfg:  baseCfg,
+			expected: "4 16M",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffers", "1 12M"),
+			baseCfg:  baseCfg,
+			expected: "1 12M",
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffers", "2k"),
+			baseCfg:  baseCfg,
+			expected: defaultSetting,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffers", "8 1g"),
+			baseCfg:  baseCfg,
+			expected: defaultSetting,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffers", "6 32Megabytes"),
+			baseCfg:  baseCfg,
+			expected: defaultSetting,
+		},
+		{
+			ing:      createTestIngress("nginx.org/proxy-buffers", "invalid_proxy_buffers_string"),
+			baseCfg:  baseCfg,
+			expected: defaultSetting,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := parseAnnotations(test.ing, test.baseCfg, true, false, false)
+		if test.expected != cfg.ProxyBuffers {
+			t.Errorf("parseAnnotations() returned cfg.ProxyBuffers with %v, but expected %v", cfg.ProxyBuffers, test.expected)
+		}
+	}
+}
+
+func createTestIngress(name string, value string) *IngressEx {
+	return &IngressEx{
+		Ingress: &networking.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					name: value,
+				},
+			},
+		},
 	}
 }

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -45,15 +45,27 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool, hasAppProtect bool) *Con
 	}
 
 	if proxyConnectTimeout, exists := cfgm.Data["proxy-connect-timeout"]; exists {
-		cfgParams.ProxyConnectTimeout = proxyConnectTimeout
+		if parsedProxyConnectTimeout, err := ParseTime(proxyConnectTimeout); err != nil {
+			glog.Errorf("Configmap %s/%s: Invalid value for the proxy-connect-timeout key: got %q: %v", cfgm.GetNamespace(), cfgm.GetName(), proxyConnectTimeout, err)
+		} else {
+			cfgParams.ProxyConnectTimeout = parsedProxyConnectTimeout
+		}
 	}
 
 	if proxyReadTimeout, exists := cfgm.Data["proxy-read-timeout"]; exists {
-		cfgParams.ProxyReadTimeout = proxyReadTimeout
+		if parsedProxyReadTimeout, err := ParseTime(proxyReadTimeout); err != nil {
+			glog.Errorf("Configmap %s/%s: Invalid value for the proxy-read-timeout key: got %q: %v", cfgm.GetNamespace(), cfgm.GetName(), proxyReadTimeout, err)
+		} else {
+			cfgParams.ProxyReadTimeout = parsedProxyReadTimeout
+		}
 	}
 
 	if proxySendTimeout, exists := cfgm.Data["proxy-send-timeout"]; exists {
-		cfgParams.ProxySendTimeout = proxySendTimeout
+		if parsedProxySendTimeout, err := ParseTime(proxySendTimeout); err != nil {
+			glog.Errorf("Configmap %s/%s: Invalid value for the proxy-send-timeout key: got %q: %v", cfgm.GetNamespace(), cfgm.GetName(), proxySendTimeout, err)
+		} else {
+			cfgParams.ProxySendTimeout = parsedProxySendTimeout
+		}
 	}
 
 	if proxyHideHeaders, exists, err := GetMapKeyAsStringSlice(cfgm.Data, "proxy-hide-headers", cfgm, ","); exists {
@@ -73,7 +85,11 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool, hasAppProtect bool) *Con
 	}
 
 	if clientMaxBodySize, exists := cfgm.Data["client-max-body-size"]; exists {
-		cfgParams.ClientMaxBodySize = clientMaxBodySize
+		if parsedClientMaxBodySize, err := ParseOffset(clientMaxBodySize); err != nil {
+			glog.Errorf("Configmap %s/%s: Invalid value for the client-max-body-size key: got %q: %v", cfgm.GetNamespace(), cfgm.GetName(), clientMaxBodySize, err)
+		} else {
+			cfgParams.ClientMaxBodySize = parsedClientMaxBodySize
+		}
 	}
 
 	if serverNamesHashBucketSize, exists := cfgm.Data["server-names-hash-bucket-size"]; exists {
@@ -255,15 +271,27 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool, hasAppProtect bool) *Con
 	}
 
 	if proxyBuffers, exists := cfgm.Data["proxy-buffers"]; exists {
-		cfgParams.ProxyBuffers = proxyBuffers
+		if parsedProxyBuffers, err := ParseProxyBuffers(proxyBuffers); err != nil {
+			glog.Errorf("Configmap %s/%s: Invalid value for the proxy-buffers key: got %q: %v", cfgm.GetNamespace(), cfgm.GetName(), proxyBuffers, err)
+		} else {
+			cfgParams.ProxyBuffers = parsedProxyBuffers
+		}
 	}
 
 	if proxyBufferSize, exists := cfgm.Data["proxy-buffer-size"]; exists {
-		cfgParams.ProxyBufferSize = proxyBufferSize
+		if parsedProxyBufferSize, err := ParseSize(proxyBufferSize); err != nil {
+			glog.Errorf("Configmap %s/%s: Invalid value for the proxy-buffer-size key: got %q: %v", cfgm.GetNamespace(), cfgm.GetName(), proxyBufferSize, err)
+		} else {
+			cfgParams.ProxyBufferSize = parsedProxyBufferSize
+		}
 	}
 
 	if proxyMaxTempFileSize, exists := cfgm.Data["proxy-max-temp-file-size"]; exists {
-		cfgParams.ProxyMaxTempFileSize = proxyMaxTempFileSize
+		if parsedProxyMaxTempFileSize, err := ParseSize(proxyMaxTempFileSize); err != nil {
+			glog.Errorf("Configmap %s/%s: Invalid value for the proxy-max-temp-file-size key: got %q: %v", cfgm.GetNamespace(), cfgm.GetName(), proxyMaxTempFileSize, err)
+		} else {
+			cfgParams.ProxyMaxTempFileSize = parsedProxyMaxTempFileSize
+		}
 	}
 
 	if mainMainSnippets, exists, err := GetMapKeyAsStringSlice(cfgm.Data, "main-snippets", cfgm, "\n"); exists {
@@ -330,20 +358,28 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool, hasAppProtect bool) *Con
 		}
 	}
 
-	if maxFails, exists, err := GetMapKeyAsInt(cfgm.Data, "max-fails", cfgm); exists {
-		if err != nil {
-			glog.Error(err)
+	if maxFails, exists := cfgm.Data["max-fails"]; exists {
+		if parsedMaxFails, err := ParseNonNegativeInt(maxFails); err != nil {
+			glog.Errorf("Configmap %s/%s: Invalid value for the max-fails key: got %q: %v", cfgm.GetNamespace(), cfgm.GetName(), parsedMaxFails, err)
 		} else {
-			cfgParams.MaxFails = maxFails
+			cfgParams.MaxFails = parsedMaxFails
 		}
 	}
 
 	if upstreamZoneSize, exists := cfgm.Data["upstream-zone-size"]; exists {
-		cfgParams.UpstreamZoneSize = upstreamZoneSize
+		if parsedUpstreamZoneSize, err := ParseSize(upstreamZoneSize); err != nil {
+			glog.Errorf("Configmap %s/%s: Invalid value for the upstream-zone-size key: got %q: %v", cfgm.GetNamespace(), cfgm.GetName(), upstreamZoneSize, err)
+		} else {
+			cfgParams.UpstreamZoneSize = parsedUpstreamZoneSize
+		}
 	}
 
 	if failTimeout, exists := cfgm.Data["fail-timeout"]; exists {
-		cfgParams.FailTimeout = failTimeout
+		if parsedFailTimeout, err := ParseTime(failTimeout); err != nil {
+			glog.Errorf("Configmap %s/%s: Invalid value for the fail-timeout key: got %q: %v", cfgm.GetNamespace(), cfgm.GetName(), failTimeout, err)
+		} else {
+			cfgParams.FailTimeout = parsedFailTimeout
+		}
 	}
 
 	if mainTemplate, exists := cfgm.Data["main-template"]; exists {

--- a/internal/configs/configmaps_test.go
+++ b/internal/configs/configmaps_test.go
@@ -1,0 +1,479 @@
+package configs
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestParseProxyConnectTimeoutKey(t *testing.T) {
+	defaultTimeout := NewDefaultConfigParams().ProxyConnectTimeout
+	tests := []struct {
+		cfgMap   *v1.ConfigMap
+		expected string
+	}{
+		{
+			cfgMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: defaultTimeout,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-connect-timeout", "60s"),
+			expected: "60s",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-connect-timeout", "1m 30s"),
+			expected: "1m 30s",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-connect-timeout", "1m30s"),
+			expected: "1m30s",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-connect-timeout", "30s 2m"),
+			expected: "30s 2m",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-connect-timeout", "60secs"),
+			expected: defaultTimeout,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-connect-timeout", "invalid_time_string"),
+			expected: defaultTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := ParseConfigMap(test.cfgMap, true, false)
+		if test.expected != cfg.ProxyConnectTimeout {
+			t.Errorf("ParseConfigMap() returned cfg.ProxyConnectTimeout with %v, but expected %v", cfg.ProxyConnectTimeout, test.expected)
+		}
+	}
+}
+
+func TestParseProxyReadTimeoutKey(t *testing.T) {
+	defaultTimeout := NewDefaultConfigParams().ProxyReadTimeout
+	tests := []struct {
+		cfgMap   *v1.ConfigMap
+		expected string
+	}{
+		{
+			cfgMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: defaultTimeout,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-read-timeout", "60s"),
+			expected: "60s",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-read-timeout", "1m 30s"),
+			expected: "1m 30s",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-read-timeout", "1m30s"),
+			expected: "1m30s",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-read-timeout", "30s 2m"),
+			expected: "30s 2m",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-read-timeout", "60secs"),
+			expected: defaultTimeout,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-read-timeout", "invalid_time_string"),
+			expected: defaultTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := ParseConfigMap(test.cfgMap, true, false)
+		if test.expected != cfg.ProxyReadTimeout {
+			t.Errorf("ParseConfigMap() returned cfg.ProxyReadTimeout with %v, but expected %v", cfg.ProxyReadTimeout, test.expected)
+		}
+	}
+}
+
+func TestParseProxySendTimeoutKey(t *testing.T) {
+	defaultTimeout := NewDefaultConfigParams().ProxySendTimeout
+	tests := []struct {
+		cfgMap   *v1.ConfigMap
+		expected string
+	}{
+		{
+			cfgMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: defaultTimeout,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-send-timeout", "60s"),
+			expected: "60s",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-send-timeout", "1m 30s"),
+			expected: "1m 30s",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-send-timeout", "1m30s"),
+			expected: "1m30s",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-send-timeout", "30s 2m"),
+			expected: "30s 2m",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-send-timeout", "60secs"),
+			expected: defaultTimeout,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-send-timeout", "invalid_time_string"),
+			expected: defaultTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := ParseConfigMap(test.cfgMap, true, false)
+		if test.expected != cfg.ProxySendTimeout {
+			t.Errorf("ParseConfigMap() returned cfg.ProxySendTimeout with %v, but expected %v", cfg.ProxySendTimeout, test.expected)
+		}
+	}
+}
+
+func TestParseFailTimeoutKey(t *testing.T) {
+	defaultTimeout := NewDefaultConfigParams().FailTimeout
+	tests := []struct {
+		cfgMap   *v1.ConfigMap
+		expected string
+	}{
+		{
+			cfgMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: defaultTimeout,
+		},
+		{
+			cfgMap:   createTestConfigMap("fail-timeout", "60s"),
+			expected: "60s",
+		},
+		{
+			cfgMap:   createTestConfigMap("fail-timeout", "1m 30s"),
+			expected: "1m 30s",
+		},
+		{
+			cfgMap:   createTestConfigMap("fail-timeout", "1m30s"),
+			expected: "1m30s",
+		},
+		{
+			cfgMap:   createTestConfigMap("fail-timeout", "30s 2m"),
+			expected: "30s 2m",
+		},
+		{
+			cfgMap:   createTestConfigMap("fail-timeout", "60secs"),
+			expected: defaultTimeout,
+		},
+		{
+			cfgMap:   createTestConfigMap("fail-timeout", "invalid_time_string"),
+			expected: defaultTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := ParseConfigMap(test.cfgMap, true, false)
+		if test.expected != cfg.FailTimeout {
+			t.Errorf("ParseConfigMap() returned cfg.FailTimeout with %v, but expected %v", cfg.FailTimeout, test.expected)
+		}
+	}
+}
+
+func TestParseClientMaxBodySizeKey(t *testing.T) {
+	defaultSize := NewDefaultConfigParams().ClientMaxBodySize
+	tests := []struct {
+		cfgMap   *v1.ConfigMap
+		expected string
+	}{
+		{
+			cfgMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("client-max-body-size", "2k"),
+			expected: "2k",
+		},
+		{
+			cfgMap:   createTestConfigMap("client-max-body-size", "16M"),
+			expected: "16M",
+		},
+		{
+			cfgMap:   createTestConfigMap("client-max-body-size", "1g"),
+			expected: "1g",
+		},
+		{
+			cfgMap:   createTestConfigMap("client-max-body-size", "12M"),
+			expected: "12M",
+		},
+		{
+			cfgMap:   createTestConfigMap("client-max-body-size", "32Megabytes"),
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("client-max-body-size", "invalid_offset_string"),
+			expected: defaultSize,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := ParseConfigMap(test.cfgMap, true, false)
+		if test.expected != cfg.ClientMaxBodySize {
+			t.Errorf("ParseConfigMap() returned cfg.ClientMaxBodySize with %v, but expected %v", cfg.ClientMaxBodySize, test.expected)
+		}
+	}
+}
+
+func TestParseProxyBufferSizeKey(t *testing.T) {
+	defaultSize := NewDefaultConfigParams().ProxyBufferSize
+	tests := []struct {
+		cfgMap   *v1.ConfigMap
+		expected string
+	}{
+		{
+			cfgMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffer-size", "2k"),
+			expected: "2k",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffer-size", "16M"),
+			expected: "16M",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffer-size", "12M"),
+			expected: "12M",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffer-size", "1g"),
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffer-size", "32Megabytes"),
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffer-size", "invalid_size_string"),
+			expected: defaultSize,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := ParseConfigMap(test.cfgMap, true, false)
+		if test.expected != cfg.ProxyBufferSize {
+			t.Errorf("ParseConfigMap() returned cfg.ProxyBufferSize with %v, but expected %v", cfg.ProxyBufferSize, test.expected)
+		}
+	}
+}
+
+func TestParseProxyMaxTempFileSizeKey(t *testing.T) {
+	defaultSize := NewDefaultConfigParams().ProxyMaxTempFileSize
+	tests := []struct {
+		cfgMap   *v1.ConfigMap
+		expected string
+	}{
+		{
+			cfgMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-max-temp-file-size", "2k"),
+			expected: "2k",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-max-temp-file-size", "16M"),
+			expected: "16M",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-max-temp-file-size", "12M"),
+			expected: "12M",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-max-temp-file-size", "1g"),
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-max-temp-file-size", "32Megabytes"),
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-max-temp-file-size", "invalid_size_string"),
+			expected: defaultSize,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := ParseConfigMap(test.cfgMap, true, false)
+		if test.expected != cfg.ProxyMaxTempFileSize {
+			t.Errorf("ParseConfigMap() returned cfg.ProxyMaxTempFileSize with %v, but expected %v", cfg.ProxyMaxTempFileSize, test.expected)
+		}
+	}
+}
+
+func TestParseUpstreamZoneSizeKey(t *testing.T) {
+	defaultSize := NewDefaultConfigParams().UpstreamZoneSize
+	tests := []struct {
+		cfgMap   *v1.ConfigMap
+		expected string
+	}{
+		{
+			cfgMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("upstream-zone-size", "2k"),
+			expected: "2k",
+		},
+		{
+			cfgMap:   createTestConfigMap("upstream-zone-size", "16M"),
+			expected: "16M",
+		},
+		{
+			cfgMap:   createTestConfigMap("upstream-zone-size", "12M"),
+			expected: "12M",
+		},
+		{
+			cfgMap:   createTestConfigMap("upstream-zone-size", "1g"),
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("upstream-zone-size", "32Megabytes"),
+			expected: defaultSize,
+		},
+		{
+			cfgMap:   createTestConfigMap("upstream-zone-size", "invalid_size_string"),
+			expected: defaultSize,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := ParseConfigMap(test.cfgMap, true, false)
+		if test.expected != cfg.UpstreamZoneSize {
+			t.Errorf("ParseConfigMap() returned cfg.UpstreamZoneSize with %v, but expected %v", cfg.UpstreamZoneSize, test.expected)
+		}
+	}
+}
+
+func TestParseMaxFailsKey(t *testing.T) {
+	defaultNum := NewDefaultConfigParams().MaxFails
+	tests := []struct {
+		cfgMap   *v1.ConfigMap
+		expected int
+	}{
+		{
+			cfgMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: defaultNum,
+		},
+		{
+			cfgMap:   createTestConfigMap("max-fails", "0"),
+			expected: 0,
+		},
+		{
+			cfgMap:   createTestConfigMap("max-fails", "1"),
+			expected: 1,
+		},
+		{
+			cfgMap:   createTestConfigMap("max-fails", "100"),
+			expected: 100,
+		},
+		{
+			cfgMap:   createTestConfigMap("max-fails", "-1"),
+			expected: defaultNum,
+		},
+		{
+			cfgMap:   createTestConfigMap("max-fails", "-100"),
+			expected: defaultNum,
+		},
+		{
+			cfgMap:   createTestConfigMap("max-fails", "invalid_non_negative_int"),
+			expected: defaultNum,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := ParseConfigMap(test.cfgMap, true, false)
+		if test.expected != cfg.MaxFails {
+			t.Errorf("ParseConfigMap() returned cfg.MaxFails with %v, but expected %v", cfg.MaxFails, test.expected)
+		}
+	}
+}
+
+func TestParseProxyBuffersKey(t *testing.T) {
+	defaultSetting := NewDefaultConfigParams().ProxyBuffers
+	tests := []struct {
+		cfgMap   *v1.ConfigMap
+		expected string
+	}{
+		{
+			cfgMap: &v1.ConfigMap{
+				Data: map[string]string{},
+			},
+			expected: defaultSetting,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffers", "8 2k"),
+			expected: "8 2k",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffers", "4 16M"),
+			expected: "4 16M",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffers", "1 12M"),
+			expected: "1 12M",
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffers", "2k"),
+			expected: defaultSetting,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffers", "8 1g"),
+			expected: defaultSetting,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffers", "6 32Megabytes"),
+			expected: defaultSetting,
+		},
+		{
+			cfgMap:   createTestConfigMap("proxy-buffers", "invalid_proxy_buffers_string"),
+			expected: defaultSetting,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := ParseConfigMap(test.cfgMap, true, false)
+		if test.expected != cfg.ProxyBuffers {
+			t.Errorf("ParseConfigMap() returned cfg.ProxyBuffers with %v, but expected %v", cfg.ProxyBuffers, test.expected)
+		}
+	}
+}
+
+func createTestConfigMap(name string, value string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		Data: map[string]string{
+			name: value,
+		},
+	}
+}

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -162,6 +162,14 @@ func validateHashLBMethod(method string) (string, error) {
 	return "", fmt.Errorf("Invalid load balancing method: %q", method)
 }
 
+func ParseNonNegativeInt(s string) (int, error) {
+	i, err := strconv.Atoi(s)
+	if err != nil || i < 0 {
+		return 0, errors.New("Invalid non-negative int")
+	}
+	return i, nil
+}
+
 // http://nginx.org/en/docs/syntax.html
 var validTimeSuffixes = []string{
 	"ms",
@@ -185,6 +193,45 @@ func ParseTime(s string) (string, error) {
 		return s, nil
 	}
 	return "", errors.New("Invalid time string")
+}
+
+// http://nginx.org/en/docs/syntax.html
+const OffsetFmt = `\d+[kKmMgG]?`
+
+var offsetRegexp = regexp.MustCompile("^" + OffsetFmt + "$")
+
+func ParseOffset(s string) (string, error) {
+	s = strings.TrimSpace(s)
+
+	if offsetRegexp.MatchString(s) {
+		return s, nil
+	}
+	return "", errors.New("Invalid offset string")
+}
+
+// http://nginx.org/en/docs/syntax.html
+const SizeFmt = `\d+[kKmM]?`
+
+var sizeRegexp = regexp.MustCompile("^" + SizeFmt + "$")
+
+func ParseSize(s string) (string, error) {
+	s = strings.TrimSpace(s)
+
+	if sizeRegexp.MatchString(s) {
+		return s, nil
+	}
+	return "", errors.New("Invalid size string")
+}
+
+var proxyBuffersRegexp = regexp.MustCompile(`^\d+ \d+[kKmM]?$`)
+
+func ParseProxyBuffers(s string) (string, error) {
+	s = strings.TrimSpace(s)
+
+	if proxyBuffersRegexp.MatchString(s) {
+		return s, nil
+	}
+	return "", errors.New("Invalid proxy buffers string")
 }
 
 var threshEx = regexp.MustCompile(`high=([1-9]|[1-9][0-9]|100) low=([1-9]|[1-9][0-9]|100)\b`)

--- a/internal/configs/parsing_helpers_test.go
+++ b/internal/configs/parsing_helpers_test.go
@@ -383,6 +383,46 @@ func TestParseTime(t *testing.T) {
 	}
 }
 
+func TestParseOffset(t *testing.T) {
+	var testsWithValidInput = []string{"1", "2k", "2K", "3m", "3M", "4g", "4G"}
+	var invalidInput = []string{"-1", "", "blah"}
+	for _, test := range testsWithValidInput {
+		result, err := ParseOffset(test)
+		if err != nil {
+			t.Errorf("TestParseOffset(%q) returned an error for valid input", test)
+		}
+		if test != result {
+			t.Errorf("TestParseOffset(%q) returned %q expected %q", test, result, test)
+		}
+	}
+	for _, test := range invalidInput {
+		result, err := ParseOffset(test)
+		if err == nil {
+			t.Errorf("TestParseOffset(%q) didn't return error. Returned: %q", test, result)
+		}
+	}
+}
+
+func TestParseSize(t *testing.T) {
+	var testsWithValidInput = []string{"1", "2k", "2K", "3m", "3M"}
+	var invalidInput = []string{"-1", "", "blah", "4g", "4G"}
+	for _, test := range testsWithValidInput {
+		result, err := ParseSize(test)
+		if err != nil {
+			t.Errorf("TestParseSize(%q) returned an error for valid input", test)
+		}
+		if test != result {
+			t.Errorf("TestParseSize(%q) returned %q expected %q", test, result, test)
+		}
+	}
+	for _, test := range invalidInput {
+		result, err := ParseSize(test)
+		if err == nil {
+			t.Errorf("TestParseSize(%q) didn't return error. Returned: %q", test, result)
+		}
+	}
+}
+
 func TestVerifyThresholds(t *testing.T) {
 	validInput := []string{
 		"high=3 low=1",
@@ -413,6 +453,43 @@ func TestVerifyThresholds(t *testing.T) {
 	for _, input := range invalidInput {
 		if VerifyAppProtectThresholds(input) {
 			t.Errorf("VerifyAppProtectThresholds(%s) returned true,expected false", input)
+		}
+	}
+}
+
+func TestParseNonNegativeInt(t *testing.T) {
+	var testsWithValidInput = []struct {
+		input    string
+		expected int
+	}{
+		{"0", 0},
+		{"1", 1},
+		{"2", 2},
+		{"100", 100},
+	}
+
+	var invalidInput = []string{
+		"",
+		"blablah",
+		"-100",
+		"-1",
+	}
+
+	for _, test := range testsWithValidInput {
+		result, err := ParseNonNegativeInt(test.input)
+		if err != nil {
+			t.Errorf("TestParseNonNegativeInt(%q) returned an error for valid input", test.input)
+		}
+
+		if result != test.expected {
+			t.Errorf("TestParseNonNegativeInt(%q) returned %q expected %q", test.input, result, test.expected)
+		}
+	}
+
+	for _, input := range invalidInput {
+		_, err := ParseNonNegativeInt(input)
+		if err == nil {
+			t.Errorf("TestParseNonNegativeInt(%q) does not return an error for invalid input", input)
 		}
 	}
 }

--- a/pkg/apis/configuration/validation/common_test.go
+++ b/pkg/apis/configuration/validation/common_test.go
@@ -287,3 +287,39 @@ func TestValidateSize(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateTime(t *testing.T) {
+	time := "1h 2s"
+	allErrs := validateTime(time, field.NewPath("time-field"))
+
+	if len(allErrs) != 0 {
+		t.Errorf("validateTime returned errors %v valid input %v", allErrs, time)
+	}
+}
+
+func TestValidateTimeFails(t *testing.T) {
+	time := "invalid"
+	allErrs := validateTime(time, field.NewPath("time-field"))
+
+	if len(allErrs) == 0 {
+		t.Errorf("validateTime returned no errors for invalid input %v", time)
+	}
+}
+
+func TestValidateOffset(t *testing.T) {
+	var validInput = []string{"", "1", "10k", "11m", "1K", "100M", "5G"}
+	for _, test := range validInput {
+		allErrs := validateOffset(test, field.NewPath("offset-field"))
+		if len(allErrs) != 0 {
+			t.Errorf("validateOffset(%q) returned an error for valid input", test)
+		}
+	}
+
+	var invalidInput = []string{"55mm", "2mG", "6kb", "-5k", "1L", "5Gb"}
+	for _, test := range invalidInput {
+		allErrs := validateOffset(test, field.NewPath("offset-field"))
+		if len(allErrs) == 0 {
+			t.Errorf("validateOffset(%q) didn't return error for invalid input.", test)
+		}
+	}
+}

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -172,41 +172,6 @@ func validatePositiveIntOrZeroFromPointer(n *int, fieldPath *field.Path) field.E
 	return allErrs
 }
 
-func validateTime(time string, fieldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if time == "" {
-		return allErrs
-	}
-
-	if _, err := configs.ParseTime(time); err != nil {
-		return append(allErrs, field.Invalid(fieldPath, time, err.Error()))
-	}
-
-	return allErrs
-}
-
-// http://nginx.org/en/docs/syntax.html
-const offsetFmt = `\d+[kKmMgG]?`
-const offsetErrMsg = "must consist of numeric characters followed by a valid size suffix. 'k|K|m|M|g|G"
-
-var offsetRegexp = regexp.MustCompile("^" + offsetFmt + "$")
-
-func validateOffset(offset string, fieldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if offset == "" {
-		return allErrs
-	}
-
-	if !offsetRegexp.MatchString(offset) {
-		msg := validation.RegexError(offsetErrMsg, offsetFmt, "16", "32k", "64M")
-		return append(allErrs, field.Invalid(fieldPath, offset, msg))
-	}
-
-	return allErrs
-}
-
 func validateBuffer(buff *v1.UpstreamBuffers, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -2252,33 +2252,6 @@ func TestValidatePositiveIntOrZeroFails(t *testing.T) {
 	}
 }
 
-func TestValidateTime(t *testing.T) {
-	time := "1h 2s"
-	allErrs := validateTime(time, field.NewPath("time-field"))
-
-	if len(allErrs) != 0 {
-		t.Errorf("validateTime returned errors %v valid input %v", allErrs, time)
-	}
-}
-
-func TestValidateOffset(t *testing.T) {
-	var validInput = []string{"", "1", "10k", "11m", "1K", "100M", "5G"}
-	for _, test := range validInput {
-		allErrs := validateOffset(test, field.NewPath("offset-field"))
-		if len(allErrs) != 0 {
-			t.Errorf("validateOffset(%q) returned an error for valid input", test)
-		}
-	}
-
-	var invalidInput = []string{"55mm", "2mG", "6kb", "-5k", "1L", "5Gb"}
-	for _, test := range invalidInput {
-		allErrs := validateOffset(test, field.NewPath("offset-field"))
-		if len(allErrs) == 0 {
-			t.Errorf("validateOffset(%q) didn't return error for invalid input.", test)
-		}
-	}
-}
-
 func TestValidateBuffer(t *testing.T) {
 	validbuff := &v1.UpstreamBuffers{Number: 8, Size: "8k"}
 	allErrs := validateBuffer(validbuff, field.NewPath("buffers-field"))
@@ -2306,15 +2279,6 @@ func TestValidateBuffer(t *testing.T) {
 		if len(allErrs) == 0 {
 			t.Errorf("validateBuffer didn't return error for invalid input %v.", test)
 		}
-	}
-}
-
-func TestValidateTimeFails(t *testing.T) {
-	time := "invalid"
-	allErrs := validateTime(time, field.NewPath("time-field"))
-
-	if len(allErrs) == 0 {
-		t.Errorf("validateTime returned no errors for invalid input %v", time)
 	}
 }
 


### PR DESCRIPTION
Validation of some annotations was not checking for valid times, sizes etc.
resulting in the user being able to specify settings which would cause Nginx
to fail to apply the changes.

### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
