### PR TITLE
Add LocalSecretStore

### DIFF
--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -277,7 +277,7 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 			cfgParams.JWTRealm = jwtRealm
 		}
 		if jwtKey, exists := ingEx.Ingress.Annotations[JWTKeyAnnotation]; exists {
-			cfgParams.JWTKey = fmt.Sprintf("%v/%v", ingEx.Ingress.Namespace, jwtKey)
+			cfgParams.JWTKey = jwtKey
 		}
 		if jwtToken, exists := ingEx.Ingress.Annotations["nginx.com/jwt-token"]; exists {
 			cfgParams.JWTToken = jwtToken

--- a/internal/configs/secret.go
+++ b/internal/configs/secret.go
@@ -1,0 +1,20 @@
+package configs
+
+import api_v1 "k8s.io/api/core/v1"
+
+// The constants below are defined because we can't use the same constants from the internal/k8s package
+// because that will lead to import cycles
+// TO-DO: Consider refactoring the internal/k8s package, so that we only define those constants once
+
+// SecretTypeCA contains a certificate authority for TLS certificate verification.
+const SecretTypeCA api_v1.SecretType = "nginx.org/ca"
+
+// SecretTypeJWK contains a JWK (JSON Web Key) for validating JWTs (JSON Web Tokens).
+const SecretTypeJWK api_v1.SecretType = "nginx.org/jwk"
+
+// SecretReference holds a reference to a secret stored on the file system.
+type SecretReference struct {
+	Type  api_v1.SecretType
+	Path  string
+	Error error
+}

--- a/internal/k8s/secret_store.go
+++ b/internal/k8s/secret_store.go
@@ -1,0 +1,101 @@
+package k8s
+
+import (
+	"fmt"
+
+	api_v1 "k8s.io/api/core/v1"
+)
+
+// StoredSecret holds a secret, its validation status and the path on the file system.
+type StoredSecret struct {
+	Secret        *api_v1.Secret
+	Path          string
+	ValidationErr error
+}
+
+// SecretFileManager manages secrets on the file system.
+type SecretFileManager interface {
+	AddOrUpdateSecret(secret *api_v1.Secret) string
+	DeleteSecret(key string)
+}
+
+// SecretStore stores secrets that the Ingress Controller uses.
+type SecretStore interface {
+	AddOrUpdateSecret(secret *api_v1.Secret)
+	DeleteSecret(key string)
+	GetSecret(key string) (api_v1.SecretType, string, error)
+}
+
+// LocalSecretStore implements SecretStore interface.
+// It validates the secrets and manages them on the file system (via SecretFileManager).
+type LocalSecretStore struct {
+	secrets map[string]*StoredSecret
+	manager SecretFileManager
+}
+
+// NewLocalSecretStore creates a new LocalSecretStore.
+func NewLocalSecretStore(manager SecretFileManager) *LocalSecretStore {
+	return &LocalSecretStore{
+		secrets: make(map[string]*StoredSecret),
+		manager: manager,
+	}
+}
+
+// AddOrUpdateSecret adds or updates a secret.
+// The secret will only be updated on the file system if it is valid and if it is already on the file system.
+// If the secret becomes invalid, it will be removed from the filesystem.
+func (s *LocalSecretStore) AddOrUpdateSecret(secret *api_v1.Secret) {
+	storedSecret, exists := s.secrets[getResourceKey(&secret.ObjectMeta)]
+	if !exists {
+		storedSecret = &StoredSecret{
+			Secret: secret,
+		}
+	} else {
+		storedSecret.Secret = secret
+	}
+
+	storedSecret.ValidationErr = ValidateSecret(secret)
+
+	if storedSecret.Path != "" {
+		if storedSecret.ValidationErr != nil {
+			s.manager.DeleteSecret(getResourceKey(&secret.ObjectMeta))
+			storedSecret.Path = ""
+		} else {
+			storedSecret.Path = s.manager.AddOrUpdateSecret(secret)
+		}
+	}
+
+	s.secrets[getResourceKey(&secret.ObjectMeta)] = storedSecret
+}
+
+// DeleteSecret deletes a secret.
+func (s *LocalSecretStore) DeleteSecret(key string) {
+	storedSecret, exists := s.secrets[key]
+	if !exists {
+		return
+	}
+
+	delete(s.secrets, key)
+
+	if storedSecret.Path == "" {
+		return
+	}
+
+	s.manager.DeleteSecret(key)
+}
+
+// GetSecret gets the secretType and the path of a requested secret via its namespace/name key.
+// If the secret doesn't exist, is of an unsupported type, or invalid, GetSecret will return an error.
+// If the secret is valid but isn't present on the file system, the secret will be written to the file system.
+func (s *LocalSecretStore) GetSecret(key string) (api_v1.SecretType, string, error) {
+	storedSecret, exists := s.secrets[key]
+	if !exists {
+		return "", "", fmt.Errorf("secret doesn't exist or of an unsupported type")
+	}
+
+	if storedSecret.ValidationErr == nil && storedSecret.Path == "" {
+		storedSecret.Path = s.manager.AddOrUpdateSecret(storedSecret.Secret)
+	}
+
+	return storedSecret.Secret.Type, storedSecret.Path, storedSecret.ValidationErr
+}

--- a/internal/k8s/secret_store_test.go
+++ b/internal/k8s/secret_store_test.go
@@ -1,0 +1,340 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	api_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type fakeSecretFileManager struct {
+	AddedOrUpdatedSecret *api_v1.Secret
+	DeletedSecret        string
+}
+
+func (m *fakeSecretFileManager) AddOrUpdateSecret(secret *api_v1.Secret) string {
+	m.AddedOrUpdatedSecret = secret
+	return "testpath"
+}
+
+func (m *fakeSecretFileManager) DeleteSecret(key string) {
+	m.DeletedSecret = key
+}
+
+func (m *fakeSecretFileManager) Reset() {
+	m.AddedOrUpdatedSecret = nil
+	m.DeletedSecret = ""
+}
+
+var (
+	validSecret = &api_v1.Secret{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "tls-secret",
+			Namespace: "default",
+		},
+		Type: api_v1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": validCert,
+			"tls.key": validKey,
+		},
+	}
+	invalidSecret = &api_v1.Secret{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "tls-secret",
+			Namespace: "default",
+		},
+		Type: api_v1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": invalidCert,
+			"tls.key": validKey,
+		},
+	}
+)
+
+func TestAddOrUpdateSecret(t *testing.T) {
+	manager := &fakeSecretFileManager{}
+
+	store := NewLocalSecretStore(manager)
+
+	// Add the valid secret
+
+	expectedManager := &fakeSecretFileManager{}
+
+	store.AddOrUpdateSecret(validSecret)
+
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("AddOrUpdateSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Get the secret
+
+	expectedSecretType := api_v1.SecretTypeTLS
+	expectedSecretPath := "testpath"
+	expectedManager = &fakeSecretFileManager{
+		AddedOrUpdatedSecret: validSecret,
+	}
+
+	manager.Reset()
+	secretType, secretPath, err := store.GetSecret("default/tls-secret")
+
+	if secretType != expectedSecretType {
+		t.Errorf("GetSecret() returned %v but expected %v", secretType, expectedSecretType)
+	}
+	if secretPath != expectedSecretPath {
+		t.Errorf("GetSecret() returned %v but expected %v", secretPath, expectedSecretPath)
+	}
+	if err != nil {
+		t.Errorf("GetSecret() returned unexpected error %v", err)
+	}
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("GetSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Make the secret invalid
+
+	expectedManager = &fakeSecretFileManager{
+		DeletedSecret: "default/tls-secret",
+	}
+
+	manager.Reset()
+	store.AddOrUpdateSecret(invalidSecret)
+
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("AddOrUpdateSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Get the secret
+
+	expectedSecretType = api_v1.SecretTypeTLS
+	expectedSecretPath = ""
+	expectedManager = &fakeSecretFileManager{}
+	expectedErrorMsg := "Failed to validate TLS cert and key: asn1: syntax error: sequence truncated"
+
+	manager.Reset()
+	secretType, secretPath, err = store.GetSecret("default/tls-secret")
+
+	if secretType != expectedSecretType {
+		t.Errorf("GetSecret() returned %v but expected %v", secretType, expectedSecretType)
+	}
+	if secretPath != expectedSecretPath {
+		t.Errorf("GetSecret() returned %v but expected %v", secretPath, expectedSecretPath)
+	}
+	if err == nil || err.Error() != expectedErrorMsg {
+		t.Errorf("GetSecret() returned error %v but expected %s", err, expectedErrorMsg)
+	}
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("GetSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Restore the valid secret
+
+	expectedManager = &fakeSecretFileManager{}
+
+	manager.Reset()
+	store.AddOrUpdateSecret(validSecret)
+
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("AddOrUpdateSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Get the secret
+
+	expectedSecretType = api_v1.SecretTypeTLS
+	expectedSecretPath = "testpath"
+	expectedManager = &fakeSecretFileManager{
+		AddedOrUpdatedSecret: validSecret,
+	}
+
+	manager.Reset()
+	secretType, secretPath, err = store.GetSecret("default/tls-secret")
+
+	if secretType != expectedSecretType {
+		t.Errorf("GetSecret() returned %v but expected %v", secretType, expectedSecretType)
+	}
+	if secretPath != expectedSecretPath {
+		t.Errorf("GetSecret() returned %v but expected %v", secretPath, expectedSecretPath)
+	}
+	if err != nil {
+		t.Errorf("GetSecret() returned unexpected error %v", err)
+	}
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("GetSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Update the secret
+
+	expectedManager = &fakeSecretFileManager{
+		AddedOrUpdatedSecret: validSecret,
+	}
+
+	manager.Reset()
+	// for the test, it is ok to use the same version
+	store.AddOrUpdateSecret(validSecret)
+
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("AddOrUpdateSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Get the secret
+
+	expectedSecretType = api_v1.SecretTypeTLS
+	expectedSecretPath = "testpath"
+	expectedManager = &fakeSecretFileManager{}
+
+	manager.Reset()
+	secretType, secretPath, err = store.GetSecret("default/tls-secret")
+
+	if secretType != expectedSecretType {
+		t.Errorf("GetSecret() returned %v but expected %v", secretType, expectedSecretType)
+	}
+	if secretPath != expectedSecretPath {
+		t.Errorf("GetSecret() returned %v but expected %v", secretPath, expectedSecretPath)
+	}
+	if err != nil {
+		t.Errorf("GetSecret() returned unexpected error %v", err)
+	}
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("GetSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+}
+
+func TestDeleteSecretNonExisting(t *testing.T) {
+	manager := &fakeSecretFileManager{}
+	store := NewLocalSecretStore(manager)
+
+	expectedManager := &fakeSecretFileManager{}
+
+	store.DeleteSecret("default/tls-secret")
+
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("DeleteSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+}
+
+func TestDeleteSecretValidSecret(t *testing.T) {
+	manager := &fakeSecretFileManager{}
+	store := NewLocalSecretStore(manager)
+
+	// Add the valid secret
+
+	expectedManager := &fakeSecretFileManager{}
+
+	store.AddOrUpdateSecret(validSecret)
+
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("AddOrUpdateSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Get the secret
+
+	expectedSecretType := api_v1.SecretTypeTLS
+	expectedSecretPath := "testpath"
+	expectedManager = &fakeSecretFileManager{
+		AddedOrUpdatedSecret: validSecret,
+	}
+
+	manager.Reset()
+	secretType, secretPath, err := store.GetSecret("default/tls-secret")
+
+	if secretType != expectedSecretType {
+		t.Errorf("GetSecret() returned %v but expected %v", secretType, expectedSecretType)
+	}
+	if secretPath != expectedSecretPath {
+		t.Errorf("GetSecret() returned %v but expected %v", secretPath, expectedSecretPath)
+	}
+	if err != nil {
+		t.Errorf("GetSecret() returned unexpected error %v", err)
+	}
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("GetSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Delete the secret
+
+	expectedManager = &fakeSecretFileManager{
+		DeletedSecret: "default/tls-secret",
+	}
+
+	manager.Reset()
+	store.DeleteSecret("default/tls-secret")
+
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("DeleteSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Get the secret
+
+	expectedSecretType = ""
+	expectedSecretPath = ""
+	expectedManager = &fakeSecretFileManager{}
+	expectedErrorMsg := "secret doesn't exist or of an unsupported type"
+
+	manager.Reset()
+	secretType, secretPath, err = store.GetSecret("default/tls-secret")
+
+	if secretType != expectedSecretType {
+		t.Errorf("GetSecret() returned %v but expected %v", secretType, expectedSecretType)
+	}
+	if secretPath != expectedSecretPath {
+		t.Errorf("GetSecret() returned %v but expected %v", secretPath, expectedSecretPath)
+	}
+	if err == nil || err.Error() != expectedErrorMsg {
+		t.Errorf("GetSecret() returned error %v but expected %s", err, expectedErrorMsg)
+	}
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("GetSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+}
+
+func TestDeleteSecretInvalidSecret(t *testing.T) {
+	manager := &fakeSecretFileManager{}
+	store := NewLocalSecretStore(manager)
+
+	// Add invalid secret
+
+	expectedManager := &fakeSecretFileManager{}
+
+	store.AddOrUpdateSecret(invalidSecret)
+
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("AddOrUpdateSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+
+	// Delete invalid secret
+
+	expectedManager = &fakeSecretFileManager{}
+
+	manager.Reset()
+	store.DeleteSecret("default/tls-secret")
+
+	if diff := cmp.Diff(expectedManager, manager); diff != "" {
+		t.Errorf("DeleteSecret() returned unexpected result (-want +got):\n%s", diff)
+	}
+}
+
+type fakeSecretStore struct {
+	secrets map[string]*StoredSecret
+}
+
+func newFakeSecretsStore(secrets map[string]*StoredSecret) *fakeSecretStore {
+	return &fakeSecretStore{
+		secrets: secrets,
+	}
+}
+
+func (s *fakeSecretStore) AddOrUpdateSecret(secret *api_v1.Secret) {
+}
+
+func (s *fakeSecretStore) DeleteSecret(key string) {
+}
+
+func (s *fakeSecretStore) GetSecret(key string) (api_v1.SecretType, string, error) {
+	storedSecret, exists := s.secrets[key]
+	if !exists {
+		return "", "", fmt.Errorf("secret doesn't exist")
+	}
+
+	return storedSecret.Secret.Type, storedSecret.Path, storedSecret.ValidationErr
+}

--- a/tests/suite/test_jwt_policies_vsr.py
+++ b/tests/suite/test_jwt_policies_vsr.py
@@ -352,7 +352,7 @@ class TestJWTPoliciesVsr:
         assert f"Request ID:" in resp1.text
         assert crd_info["status"]["state"] == "Warning"
         assert (
-            f'"{v_s_route_setup.route_m.namespace}/{secret}" which does not exist'
+            "references an invalid Secret: secret doesn't exist or of an unsupported type"
             in crd_info["status"]["message"]
         )
         assert resp2.status_code == 500


### PR DESCRIPTION
### Proposed changes

This PR introduces LocalSecretStore for storing secrets (TLS, CA, JWK).
LocalSecretStore validates secrets and updates the secret contents on the file system when a secret is updated.
The Ingress Controller code was simplified as it is no longer necessary to update the secret contents on the file system on every regeneration of Ingress (or VS) config.
