### PR TITLE
Call setcap(8) one time only.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /var/lib/nginx \
 	&& apt-get update \
 	&& apt-get install -y libcap2-bin \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
+	          'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& chown -R nginx:0 /etc/nginx \
 	&& chown -R nginx:0 /var/cache/nginx \
 	&& chown -R nginx:0 /var/lib/nginx \

--- a/build/DockerfileForAlpine
+++ b/build/DockerfileForAlpine
@@ -13,7 +13,7 @@ RUN mkdir -p /etc/nginx/secrets \
 	&& mkdir -p /var/lib/nginx \
 	&& apk add --no-cache libcap \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
+	          'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& chown -R nginx:0 /etc/nginx \
 	&& chown -R nginx:0 /var/cache/nginx \
 	&& chown -R nginx:0 /var/lib/nginx \

--- a/build/DockerfileForPlus
+++ b/build/DockerfileForPlus
@@ -38,7 +38,7 @@ RUN --mount=type=secret,id=nginx-repo.crt \
 	&& printf "deb https://plus-pkgs.nginx.com/debian buster nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
 	&& apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION} \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
+	          'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& apt-get remove --purge --auto-remove -y gnupg1 \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /etc/ssl/nginx \

--- a/build/DockerfileWithOpentracing
+++ b/build/DockerfileWithOpentracing
@@ -80,7 +80,7 @@ RUN mkdir -p /var/lib/nginx \
 	&& apt-get update \
 	&& apt-get install -y libcap2-bin \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
+	          'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& chown -R nginx:0 /etc/nginx \
 	&& chown -R nginx:0 /var/cache/nginx \
 	&& chown -R nginx:0 /var/lib/nginx \

--- a/build/DockerfileWithOpentracingForPlus
+++ b/build/DockerfileWithOpentracingForPlus
@@ -51,7 +51,7 @@ RUN --mount=type=secret,id=nginx-repo.crt \
 	# Install OpenTracing module
 	nginx-plus-module-opentracing=${NGINX_OPENTRACING_MODULE_VERSION} \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
+	          'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& apt-get remove --purge --auto-remove -y gnupg1 \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /etc/ssl/nginx \

--- a/build/appprotect/DockerfileWithAppProtectForPlus
+++ b/build/appprotect/DockerfileWithAppProtectForPlus
@@ -58,7 +58,7 @@ RUN --mount=type=secret,id=nginx-repo.crt \
 	&& apt-get install -y app-protect-attack-signatures${APPPROTECT_SIG_VERSION:+=$APPPROTECT_SIG_VERSION} \
 	&& apt-get install -y app-protect-threat-campaigns${APPPROTECT_THREAT_CAMPAIGNS_VERSION:+=$APPPROTECT_THREAT_CAMPAIGNS_VERSION} \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
+	          'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& apt-get remove --purge --auto-remove -y gnupg1 wget\
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /etc/ssl/nginx \

--- a/build/appprotect/DockerfileWithAppProtectForPlusForOpenShift
+++ b/build/appprotect/DockerfileWithAppProtectForPlusForOpenShift
@@ -61,7 +61,7 @@ RUN --mount=type=secret,id=nginx-repo.crt \
 	&& yum install -y app-protect-attack-signatures${APPPROTECT_SIG_VERSION:+-$APPPROTECT_SIG_VERSION} \
 	&& yum install -y app-protect-threat-campaigns${APPPROTECT_THREAT_CAMPAIGNS_VERSION:+-$APPPROTECT_THREAT_CAMPAIGNS_VERSION} \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
+	          'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& yum remove -y wget \
 	&& rm -rf /etc/ssl/nginx \
 	&& rm /etc/yum.repos.d/nginx-plus-7.repo \

--- a/build/openshift/Dockerfile
+++ b/build/openshift/Dockerfile
@@ -25,7 +25,7 @@ RUN set -x \
 	&& mkdir -p /etc/nginx/secrets \
 	&& mkdir -p /etc/nginx/stream-conf.d \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
+	          'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& chown -R nginx:0 /etc/nginx \
 	&& chown -R nginx:0 /var/cache/nginx \
 	&& chown -R nginx:0 /var/lib/nginx \

--- a/build/openshift/DockerfileForPlus
+++ b/build/openshift/DockerfileForPlus
@@ -45,7 +45,7 @@ RUN --mount=type=secret,id=nginx-repo.crt \
 	&& echo "enabled=1" >> /etc/yum.repos.d/nginx-plus-8.repo \
 	&& yum install -y nginx-plus-${NGINX_PLUS_VERSION} \
 	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
-	&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
+	          'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& yum remove -y wget \
 	&& rm -rf /etc/ssl/nginx \
 	&& rm /etc/yum.repos.d/nginx-plus-8.repo \


### PR DESCRIPTION
The setcap(8) utility supports multiple arguments, so it's possible
to manage more than one permission for more than one file at the
same time.

### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
