### PR TITLE
Ingress annotation validation earlier in k8s lifecycle

### DIFF
--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -93,29 +93,21 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 		if err != nil {
 			glog.Error(err)
 		}
-		if isPlus {
-			cfgParams.HealthCheckEnabled = healthCheckEnabled
-		} else {
-			glog.Warning("Annotation 'nginx.com/health-checks' requires NGINX Plus")
-		}
+		cfgParams.HealthCheckEnabled = healthCheckEnabled
 	}
 
-	if cfgParams.HealthCheckEnabled {
-		if healthCheckMandatory, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, "nginx.com/health-checks-mandatory", ingEx.Ingress); exists {
-			if err != nil {
-				glog.Error(err)
-			}
-			cfgParams.HealthCheckMandatory = healthCheckMandatory
+	if healthCheckMandatory, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, "nginx.com/health-checks-mandatory", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
 		}
+		cfgParams.HealthCheckMandatory = healthCheckMandatory
 	}
 
-	if cfgParams.HealthCheckMandatory {
-		if healthCheckQueue, exists, err := GetMapKeyAsInt64(ingEx.Ingress.Annotations, "nginx.com/health-checks-mandatory-queue", ingEx.Ingress); exists {
-			if err != nil {
-				glog.Error(err)
-			}
-			cfgParams.HealthCheckMandatoryQueue = healthCheckQueue
+	if healthCheckQueue, exists, err := GetMapKeyAsInt64(ingEx.Ingress.Annotations, "nginx.com/health-checks-mandatory-queue", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
 		}
+		cfgParams.HealthCheckMandatoryQueue = healthCheckQueue
 	}
 
 	if slowStart, exists := ingEx.Ingress.Annotations["nginx.com/slow-start"]; exists {

--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -111,15 +111,11 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 	}
 
 	if slowStart, exists := ingEx.Ingress.Annotations["nginx.com/slow-start"]; exists {
-		if parsedSlowStart, err := ParseTime(slowStart); err != nil {
-			glog.Errorf("Ingress %s/%s: Invalid value nginx.org/slow-start: got %q: %v", ingEx.Ingress.GetNamespace(), ingEx.Ingress.GetName(), slowStart, err)
-		} else {
-			if isPlus {
-				cfgParams.SlowStart = parsedSlowStart
-			} else {
-				glog.Warning("Annotation 'nginx.com/slow-start' requires NGINX Plus")
-			}
+		parsedSlowStart, err := ParseTime(slowStart)
+		if err != nil {
+			glog.Error(err)
 		}
+		cfgParams.SlowStart = parsedSlowStart
 	}
 
 	if serverTokens, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, "nginx.org/server-tokens", ingEx.Ingress); exists {

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -162,53 +162,45 @@ func validateHashLBMethod(method string) (string, error) {
 	return "", fmt.Errorf("Invalid load balancing method: %q", method)
 }
 
-// ParseBool ensures that the string value in the annotation is a valid bool
+// ParseBool ensures that the string value is a valid bool
 func ParseBool(s string) (bool, error) {
 	return strconv.ParseBool(s)
 }
 
+// ParseInt ensures that the string value is a valid int
 func ParseInt(s string) (int, error) {
 	return strconv.Atoi(s)
 }
 
+// ParseInt64 ensures that the string value is a valid int64
 func ParseInt64(s string) (int64, error) {
 	return strconv.ParseInt(s, 10, 64)
 }
 
+// ParseUint64 ensures that the string value is a valid uint64
 func ParseUint64(s string) (uint64, error) {
 	return strconv.ParseUint(s, 10, 64)
 }
 
-// http://nginx.org/en/docs/syntax.html
-var validTimeSuffixes = []string{
-	"ms",
-	"s",
-	"m",
-	"h",
-	"d",
-	"w",
-	"M",
-	"y",
-}
-
-var durationEscaped = strings.Join(validTimeSuffixes, "|")
-var validNginxTime = regexp.MustCompile(`^([0-9]+([` + durationEscaped + `]?){0,1} *)+$`)
+// timeRegexp http://nginx.org/en/docs/syntax.html
+var timeRegexp = regexp.MustCompile(`^([0-9]+([ms|s|m|h|d|w|M|y]?){0,1} *)+$`)
 
 // ParseTime ensures that the string value in the annotation is a valid time.
 func ParseTime(s string) (string, error) {
 	s = strings.TrimSpace(s)
 
-	if validNginxTime.MatchString(s) {
+	if timeRegexp.MatchString(s) {
 		return s, nil
 	}
 	return "", errors.New("Invalid time string")
 }
 
-// http://nginx.org/en/docs/syntax.html
+// OffsetFmt http://nginx.org/en/docs/syntax.html
 const OffsetFmt = `\d+[kKmMgG]?`
 
 var offsetRegexp = regexp.MustCompile("^" + OffsetFmt + "$")
 
+// ParseOffset ensures that the string value is a valid offset
 func ParseOffset(s string) (string, error) {
 	s = strings.TrimSpace(s)
 
@@ -218,11 +210,12 @@ func ParseOffset(s string) (string, error) {
 	return "", errors.New("Invalid offset string")
 }
 
-// http://nginx.org/en/docs/syntax.html
+// SizeFmt http://nginx.org/en/docs/syntax.html
 const SizeFmt = `\d+[kKmM]?`
 
 var sizeRegexp = regexp.MustCompile("^" + SizeFmt + "$")
 
+// ParseSize ensures that the string value is a valid size
 func ParseSize(s string) (string, error) {
 	s = strings.TrimSpace(s)
 
@@ -230,17 +223,6 @@ func ParseSize(s string) (string, error) {
 		return s, nil
 	}
 	return "", errors.New("Invalid size string")
-}
-
-var proxyBuffersRegexp = regexp.MustCompile(`^\d+ \d+[kKmM]?$`)
-
-func ParseProxyBuffers(s string) (string, error) {
-	s = strings.TrimSpace(s)
-
-	if proxyBuffersRegexp.MatchString(s) {
-		return s, nil
-	}
-	return "", errors.New("must be a valid proxy buffers spec as specified here: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers, e.g. \"8 4k\"")
 }
 
 var threshEx = regexp.MustCompile(`high=([1-9]|[1-9][0-9]|100) low=([1-9]|[1-9][0-9]|100)\b`)

--- a/internal/configs/parsing_helpers_test.go
+++ b/internal/configs/parsing_helpers_test.go
@@ -383,6 +383,46 @@ func TestParseTime(t *testing.T) {
 	}
 }
 
+func TestParseOffset(t *testing.T) {
+	var testsWithValidInput = []string{"1", "2k", "2K", "3m", "3M", "4g", "4G"}
+	var invalidInput = []string{"-1", "", "blah"}
+	for _, test := range testsWithValidInput {
+		result, err := ParseOffset(test)
+		if err != nil {
+			t.Errorf("TestParseOffset(%q) returned an error for valid input", test)
+		}
+		if test != result {
+			t.Errorf("TestParseOffset(%q) returned %q expected %q", test, result, test)
+		}
+	}
+	for _, test := range invalidInput {
+		result, err := ParseOffset(test)
+		if err == nil {
+			t.Errorf("TestParseOffset(%q) didn't return error. Returned: %q", test, result)
+		}
+	}
+}
+
+func TestParseSize(t *testing.T) {
+	var testsWithValidInput = []string{"1", "2k", "2K", "3m", "3M"}
+	var invalidInput = []string{"-1", "", "blah", "4g", "4G"}
+	for _, test := range testsWithValidInput {
+		result, err := ParseSize(test)
+		if err != nil {
+			t.Errorf("TestParseSize(%q) returned an error for valid input", test)
+		}
+		if test != result {
+			t.Errorf("TestParseSize(%q) returned %q expected %q", test, result, test)
+		}
+	}
+	for _, test := range invalidInput {
+		result, err := ParseSize(test)
+		if err == nil {
+			t.Errorf("TestParseSize(%q) didn't return error. Returned: %q", test, result)
+		}
+	}
+}
+
 func TestVerifyThresholds(t *testing.T) {
 	validInput := []string{
 		"high=3 low=1",
@@ -413,6 +453,155 @@ func TestVerifyThresholds(t *testing.T) {
 	for _, input := range invalidInput {
 		if VerifyAppProtectThresholds(input) {
 			t.Errorf("VerifyAppProtectThresholds(%s) returned true,expected false", input)
+		}
+	}
+}
+
+func TestParseBool(t *testing.T) {
+	var testsWithValidInput = []struct {
+		input    string
+		expected bool
+	}{
+		{"0", false},
+		{"1", true},
+		{"true", true},
+		{"false", false},
+	}
+
+	var invalidInput = []string{
+		"",
+		"blablah",
+		"-100",
+		"-1",
+	}
+
+	for _, test := range testsWithValidInput {
+		result, err := ParseBool(test.input)
+		if err != nil {
+			t.Errorf("TestParseBool(%q) returned an error for valid input", test.input)
+		}
+
+		if result != test.expected {
+			t.Errorf("TestParseBool(%q) returned %t expected %t", test.input, result, test.expected)
+		}
+	}
+
+	for _, input := range invalidInput {
+		_, err := ParseBool(input)
+		if err == nil {
+			t.Errorf("TestParseBool(%q) does not return an error for invalid input", input)
+		}
+	}
+}
+
+func TestParseInt(t *testing.T) {
+	var testsWithValidInput = []struct {
+		input    string
+		expected int
+	}{
+		{"0", 0},
+		{"1", 1},
+		{"-100", -100},
+		{"123456789", 123456789},
+	}
+
+	var invalidInput = []string{
+		"",
+		"blablah",
+		"10000000000000000000000000000000000000000000000000000000000000000",
+		"1,000",
+	}
+
+	for _, test := range testsWithValidInput {
+		result, err := ParseInt(test.input)
+		if err != nil {
+			t.Errorf("TestParseBool(%q) returned an error for valid input", test.input)
+		}
+
+		if result != test.expected {
+			t.Errorf("TestParseBool(%q) returned %d expected %d", test.input, result, test.expected)
+		}
+	}
+
+	for _, input := range invalidInput {
+		_, err := ParseInt(input)
+		if err == nil {
+			t.Errorf("TestParseBool(%q) does not return an error for invalid input", input)
+		}
+	}
+}
+
+func TestParseInt64(t *testing.T) {
+	var testsWithValidInput = []struct {
+		input    string
+		expected int64
+	}{
+		{"0", 0},
+		{"1", 1},
+		{"-100", -100},
+		{"123456789", 123456789},
+	}
+
+	var invalidInput = []string{
+		"",
+		"blablah",
+		"10000000000000000000000000000000000000000000000000000000000000000",
+		"1,000",
+	}
+
+	for _, test := range testsWithValidInput {
+		result, err := ParseInt64(test.input)
+		if err != nil {
+			t.Errorf("TestParseBool(%q) returned an error for valid input", test.input)
+		}
+
+		if result != test.expected {
+			t.Errorf("TestParseBool(%q) returned %d expected %d", test.input, result, test.expected)
+		}
+	}
+
+	for _, input := range invalidInput {
+		_, err := ParseInt64(input)
+		if err == nil {
+			t.Errorf("TestParseBool(%q) does not return an error for invalid input", input)
+		}
+	}
+}
+
+func TestParseUint64(t *testing.T) {
+	var testsWithValidInput = []struct {
+		input    string
+		expected uint64
+	}{
+		{"0", 0},
+		{"1", 1},
+		{"100", 100},
+		{"123456789", 123456789},
+	}
+
+	var invalidInput = []string{
+		"",
+		"blablah",
+		"10000000000000000000000000000000000000000000000000000000000000000",
+		"1,000",
+		"-1023",
+	}
+
+	for _, test := range testsWithValidInput {
+		result, err := ParseUint64(test.input)
+		if err != nil {
+			t.Errorf("TestParseBool(%q) returned an error for valid input", test.input)
+		}
+
+		if result != test.expected {
+			t.Errorf("TestParseBool(%q) returned %d expected %d", test.input, result, test.expected)
+		}
+	}
+
+	for _, input := range invalidInput {
+		_, err := ParseUint64(input)
+		if err == nil {
+			t.Errorf("TestParseBool(%q) does not return an error for invalid input", input)
 		}
 	}
 }

--- a/internal/configs/parsing_helpers_test.go
+++ b/internal/configs/parsing_helpers_test.go
@@ -515,18 +515,18 @@ func TestParseInt(t *testing.T) {
 	for _, test := range testsWithValidInput {
 		result, err := ParseInt(test.input)
 		if err != nil {
-			t.Errorf("TestParseBool(%q) returned an error for valid input", test.input)
+			t.Errorf("TestParseInt(%q) returned an error for valid input", test.input)
 		}
 
 		if result != test.expected {
-			t.Errorf("TestParseBool(%q) returned %d expected %d", test.input, result, test.expected)
+			t.Errorf("TestParseInt(%q) returned %d expected %d", test.input, result, test.expected)
 		}
 	}
 
 	for _, input := range invalidInput {
 		_, err := ParseInt(input)
 		if err == nil {
-			t.Errorf("TestParseBool(%q) does not return an error for invalid input", input)
+			t.Errorf("TestParseInt(%q) does not return an error for invalid input", input)
 		}
 	}
 }
@@ -552,18 +552,18 @@ func TestParseInt64(t *testing.T) {
 	for _, test := range testsWithValidInput {
 		result, err := ParseInt64(test.input)
 		if err != nil {
-			t.Errorf("TestParseBool(%q) returned an error for valid input", test.input)
+			t.Errorf("TestParseInt64(%q) returned an error for valid input", test.input)
 		}
 
 		if result != test.expected {
-			t.Errorf("TestParseBool(%q) returned %d expected %d", test.input, result, test.expected)
+			t.Errorf("TestParseInt64(%q) returned %d expected %d", test.input, result, test.expected)
 		}
 	}
 
 	for _, input := range invalidInput {
 		_, err := ParseInt64(input)
 		if err == nil {
-			t.Errorf("TestParseBool(%q) does not return an error for invalid input", input)
+			t.Errorf("TestParseInt64(%q) does not return an error for invalid input", input)
 		}
 	}
 }
@@ -590,18 +590,18 @@ func TestParseUint64(t *testing.T) {
 	for _, test := range testsWithValidInput {
 		result, err := ParseUint64(test.input)
 		if err != nil {
-			t.Errorf("TestParseBool(%q) returned an error for valid input", test.input)
+			t.Errorf("TestParseUint64(%q) returned an error for valid input", test.input)
 		}
 
 		if result != test.expected {
-			t.Errorf("TestParseBool(%q) returned %d expected %d", test.input, result, test.expected)
+			t.Errorf("TestParseUint64(%q) returned %d expected %d", test.input, result, test.expected)
 		}
 	}
 
 	for _, input := range invalidInput {
 		_, err := ParseUint64(input)
 		if err == nil {
-			t.Errorf("TestParseBool(%q) does not return an error for invalid input", input)
+			t.Errorf("TestParseUint64(%q) does not return an error for invalid input", input)
 		}
 	}
 }

--- a/internal/k8s/configuration.go
+++ b/internal/k8s/configuration.go
@@ -307,6 +307,8 @@ type Configuration struct {
 	appPolicyReferenceChecker  *appProtectResourceReferenceChecker
 	appLogConfReferenceChecker *appProtectResourceReferenceChecker
 
+	isPlus bool
+
 	lock sync.RWMutex
 }
 
@@ -325,6 +327,7 @@ func NewConfiguration(hasCorrectIngressClass func(interface{}) bool, isPlus bool
 		policyReferenceChecker:     newPolicyReferenceChecker(),
 		appPolicyReferenceChecker:  newAppProtectResourceReferenceChecker(configs.AppProtectPolicyAnnotation),
 		appLogConfReferenceChecker: newAppProtectResourceReferenceChecker(configs.AppProtectLogConfAnnotation),
+		isPlus:                     isPlus,
 	}
 }
 
@@ -339,7 +342,7 @@ func (c *Configuration) AddOrUpdateIngress(ing *networking.Ingress) ([]ResourceC
 	if !c.hasCorrectIngressClass(ing) {
 		delete(c.ingresses, key)
 	} else {
-		validationError = validateIngress(ing).ToAggregate()
+		validationError = validateIngress(ing, c.isPlus).ToAggregate()
 		if validationError != nil {
 			delete(c.ingresses, key)
 		} else {

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -17,6 +17,7 @@ const (
 	healthChecksAnnotation               = "nginx.com/health-checks"
 	healthChecksMandatoryAnnotation      = "nginx.com/health-checks-mandatory"
 	healthChecksMandatoryQueueAnnotation = "nginx.com/health-checks-mandatory-queue"
+	slowStartAnnotation                  = "nginx.com/slow-start"
 )
 
 type annotationValidationContext struct {
@@ -56,6 +57,11 @@ var (
 			validateRelatedAnnotation(healthChecksMandatoryAnnotation, validateIsTrue),
 			validateRequiredAnnotation,
 			validateNonNegativeIntAnnotation,
+		},
+		slowStartAnnotation: {
+			validateRequiredAnnotation,
+			validatePlusOnlyAnnotation,
+			validateTimeAnnotation,
 		},
 	}
 	annotationNames = sortedAnnotationNames(annotationValidations)
@@ -175,6 +181,14 @@ func validateBoolAnnotation(context *annotationValidationContext) field.ErrorLis
 	allErrs := field.ErrorList{}
 	if _, err := configs.ParseBool(context.value); err != nil {
 		return append(allErrs, field.Invalid(context.fieldPath, context.value, "must be a valid boolean"))
+	}
+	return allErrs
+}
+
+func validateTimeAnnotation(context *annotationValidationContext) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if _, err := configs.ParseTime(context.value); err != nil {
+		return append(allErrs, field.Invalid(context.fieldPath, context.value, "must be a valid time"))
 	}
 	return allErrs
 }

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -29,6 +29,8 @@ type annotationValidationContext struct {
 type annotationValidationFunc func(context *annotationValidationContext) field.ErrorList
 type validatorFunc func(val string) error
 
+// annotationValidations defines the various validations which will be applied in order to each ingress annotation.
+// If any specified validation fails, the remaining validations for that annotation will not be run.
 var annotationValidations = map[string][]annotationValidationFunc{
 	mergeableIngressTypeAnnotation: {
 		validateRequiredAnnotation,

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -343,6 +343,35 @@ func TestValidateIngressAnnotations(t *testing.T) {
 			},
 			msg: "invalid nginx.com/health-checks-mandatory-queue nginx.com/health-checks-mandatory is not true",
 		},
+
+		{
+			annotations: map[string]string{
+				"nginx.com/slow-start": "60s",
+			},
+			isPlus:         true,
+			expectedErrors: nil,
+			msg:            "valid nginx.com/slow-start annotation",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/slow-start": "true",
+			},
+			isPlus: false,
+			expectedErrors: []string{
+				"annotations.nginx.com/slow-start: Forbidden: annotation requires NGINX Plus",
+			},
+			msg: "invalid nginx.com/slow-start annotation, nginx plus only",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/slow-start": "not_a_time",
+			},
+			isPlus: true,
+			expectedErrors: []string{
+				"annotations.nginx.com/slow-start: Invalid value: \"not_a_time\": must be a valid time",
+			},
+			msg: "invalid nginx.com/slow-start annotation",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -128,7 +128,20 @@ func TestValidateIngressAnnotations(t *testing.T) {
 			annotations:    map[string]string{},
 			isPlus:         true,
 			expectedErrors: nil,
-			msg:            "valid input",
+			msg:            "valid no annotations",
+		},
+
+		{
+			annotations: map[string]string{
+				"nginx.org/lb-method":     "invalid_method",
+				"nginx.com/health-checks": "not_a_boolean",
+			},
+			isPlus: true,
+			expectedErrors: []string{
+				"annotations.nginx.com/health-checks: Invalid value: \"not_a_boolean\": must be a valid boolean",
+				"annotations.nginx.org/lb-method: Invalid value: \"invalid_method\": Invalid load balancing method: \"invalid_method\"",
+			},
+			msg: "invalid multiple annotations messages in alphabetical order",
 		},
 
 		{

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -14,6 +14,7 @@ import (
 func TestValidateIngress(t *testing.T) {
 	tests := []struct {
 		ing            *networking.Ingress
+		isPlus         bool
 		expectedErrors []string
 		msg            string
 	}{
@@ -27,6 +28,7 @@ func TestValidateIngress(t *testing.T) {
 					},
 				},
 			},
+			isPlus:         false,
 			expectedErrors: nil,
 			msg:            "valid input",
 		},
@@ -45,6 +47,7 @@ func TestValidateIngress(t *testing.T) {
 					},
 				},
 			},
+			isPlus: false,
 			expectedErrors: []string{
 				`annotations.nginx.org/mergeable-ingress-type: Invalid value: "invalid": must be one of: 'master' or 'minion'`,
 				"spec.rules[0].host: Required value",
@@ -75,6 +78,7 @@ func TestValidateIngress(t *testing.T) {
 					},
 				},
 			},
+			isPlus: false,
 			expectedErrors: []string{
 				"spec.rules[0].http.paths: Too many: 1: must have at most 0 items",
 			},
@@ -96,6 +100,7 @@ func TestValidateIngress(t *testing.T) {
 					},
 				},
 			},
+			isPlus: false,
 			expectedErrors: []string{
 				"spec.rules[0].http.paths: Required value: must include at least one path",
 			},
@@ -104,7 +109,7 @@ func TestValidateIngress(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		allErrs := validateIngress(test.ing)
+		allErrs := validateIngress(test.ing, test.isPlus)
 		assertion := assertErrors("validateIngress()", test.msg, allErrs, test.expectedErrors)
 		if assertion != "" {
 			t.Error(assertion)
@@ -115,18 +120,22 @@ func TestValidateIngress(t *testing.T) {
 func TestValidateIngressAnnotations(t *testing.T) {
 	tests := []struct {
 		annotations    map[string]string
+		isPlus         bool
 		expectedErrors []string
 		msg            string
 	}{
 		{
 			annotations:    map[string]string{},
+			isPlus:         true,
 			expectedErrors: nil,
 			msg:            "valid input",
 		},
+
 		{
 			annotations: map[string]string{
 				"nginx.org/mergeable-ingress-type": "master",
 			},
+			isPlus:         false,
 			expectedErrors: nil,
 			msg:            "valid input with master annotation",
 		},
@@ -134,6 +143,7 @@ func TestValidateIngressAnnotations(t *testing.T) {
 			annotations: map[string]string{
 				"nginx.org/mergeable-ingress-type": "minion",
 			},
+			isPlus:         false,
 			expectedErrors: nil,
 			msg:            "valid input with minion annotation",
 		},
@@ -141,6 +151,7 @@ func TestValidateIngressAnnotations(t *testing.T) {
 			annotations: map[string]string{
 				"nginx.org/mergeable-ingress-type": "",
 			},
+			isPlus: false,
 			expectedErrors: []string{
 				"annotations.nginx.org/mergeable-ingress-type: Required value",
 			},
@@ -150,19 +161,185 @@ func TestValidateIngressAnnotations(t *testing.T) {
 			annotations: map[string]string{
 				"nginx.org/mergeable-ingress-type": "abc",
 			},
+			isPlus: false,
 			expectedErrors: []string{
 				`annotations.nginx.org/mergeable-ingress-type: Invalid value: "abc": must be one of: 'master' or 'minion'`,
 			},
 			msg: "invalid mergeable type annotation 2",
 		},
+
+		{
+			annotations: map[string]string{
+				"nginx.org/lb-method": "least_time header",
+			},
+			isPlus:         true,
+			expectedErrors: nil,
+			msg:            "valid nginx.org/lb-method annotation, nginx plus",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.org/lb-method": "random",
+			},
+			isPlus:         false,
+			expectedErrors: nil,
+			msg:            "valid nginx.org/lb-method annotation, nginx normal",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.org/lb-method": "invalid_method",
+			},
+			isPlus: true,
+			expectedErrors: []string{
+				"annotations.nginx.org/lb-method: Invalid value: \"invalid_method\": Invalid load balancing method: \"invalid_method\"",
+			},
+			msg: "invalid nginx.org/lb-method annotation, nginx",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.org/lb-method": "least_time header",
+			},
+			isPlus: false,
+			expectedErrors: []string{
+				"annotations.nginx.org/lb-method: Invalid value: \"least_time header\": Invalid load balancing method: \"least_time header\"",
+			},
+			msg: "invalid nginx.org/lb-method annotation, nginx plus",
+		},
+
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks": "true",
+			},
+			isPlus:         true,
+			expectedErrors: nil,
+			msg:            "valid nginx.com/health-checks annotation",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks": "true",
+			},
+			isPlus: false,
+			expectedErrors: []string{
+				"annotations.nginx.com/health-checks: Forbidden: annotation requires NGINX Plus",
+			},
+			msg: "invalid nginx.com/health-checks annotation, nginx plus only",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks": "not_a_boolean",
+			},
+			isPlus: true,
+			expectedErrors: []string{
+				"annotations.nginx.com/health-checks: Invalid value: \"not_a_boolean\": must be a valid boolean",
+			},
+			msg: "invalid nginx.com/health-checks annotation",
+		},
+
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks": "not_a_boolean",
+			},
+			isPlus: false,
+			expectedErrors: []string{
+				"annotations.nginx.com/health-checks: Forbidden: annotation requires NGINX Plus",
+			},
+			msg: "invalid nginx.com/health-checks annotation",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks":           "true",
+				"nginx.com/health-checks-mandatory": "true",
+			},
+			isPlus:         true,
+			expectedErrors: nil,
+			msg:            "valid nginx.com/health-checks-mandatory annotation",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks":           "true",
+				"nginx.com/health-checks-mandatory": "not_a_boolean",
+			},
+			isPlus: true,
+			expectedErrors: []string{
+				"annotations.nginx.com/health-checks-mandatory: Invalid value: \"not_a_boolean\": must be a valid boolean",
+			},
+			msg: "invalid nginx.com/health-checks-mandatory, must be a boolean",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks-mandatory": "true",
+			},
+			isPlus: true,
+			expectedErrors: []string{
+				"annotations.nginx.com/health-checks-mandatory: Forbidden: related annotation nginx.com/health-checks: must be set",
+			},
+			msg: "invalid nginx.com/health-checks-mandatory, related annotation nginx.com/health-checks not set",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks":           "false",
+				"nginx.com/health-checks-mandatory": "true",
+			},
+			isPlus: true,
+			expectedErrors: []string{
+				"annotations.nginx.com/health-checks-mandatory: Forbidden: related annotation nginx.com/health-checks: must be true",
+			},
+			msg: "invalid nginx.com/health-checks-mandatory nginx.com/health-checks is not true",
+		},
+
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks":                 "true",
+				"nginx.com/health-checks-mandatory":       "true",
+				"nginx.com/health-checks-mandatory-queue": "5",
+			},
+			isPlus:         true,
+			expectedErrors: nil,
+			msg:            "valid nginx.com/health-checks-mandatory-queue annotation",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks":                 "true",
+				"nginx.com/health-checks-mandatory":       "true",
+				"nginx.com/health-checks-mandatory-queue": "not_a_number",
+			},
+			isPlus: true,
+			expectedErrors: []string{
+				"annotations.nginx.com/health-checks-mandatory-queue: Invalid value: \"not_a_number\": must be a non-negative integer",
+			},
+			msg: "invalid nginx.com/health-checks-mandatory-queue, must be a boolean",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks-mandatory-queue": "5",
+			},
+			isPlus: true,
+			expectedErrors: []string{
+				"annotations.nginx.com/health-checks-mandatory-queue: Forbidden: related annotation nginx.com/health-checks-mandatory: must be set",
+			},
+			msg: "invalid nginx.com/health-checks-mandatory-queue, related annotation nginx.com/health-checks-mandatory not set",
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/health-checks":                 "true",
+				"nginx.com/health-checks-mandatory":       "false",
+				"nginx.com/health-checks-mandatory-queue": "5",
+			},
+			isPlus: true,
+			expectedErrors: []string{
+				"annotations.nginx.com/health-checks-mandatory-queue: Forbidden: related annotation nginx.com/health-checks-mandatory: must be true",
+			},
+			msg: "invalid nginx.com/health-checks-mandatory-queue nginx.com/health-checks-mandatory is not true",
+		},
 	}
 
 	for _, test := range tests {
-		allErrs := validateIngressAnnotations(test.annotations, field.NewPath("annotations"))
-		assertion := assertErrors("validateIngressAnnotations()", test.msg, allErrs, test.expectedErrors)
-		if assertion != "" {
-			t.Error(assertion)
-		}
+		t.Run(test.msg, func(t *testing.T) {
+			allErrs := validateIngressAnnotations(test.annotations, test.isPlus, field.NewPath("annotations"))
+			assertion := assertErrors("validateIngressAnnotations()", test.msg, allErrs, test.expectedErrors)
+			if assertion != "" {
+				t.Error(assertion)
+			}
+		})
 	}
 }
 

--- a/pkg/apis/configuration/validation/common.go
+++ b/pkg/apis/configuration/validation/common.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nginxinc/kubernetes-ingress/internal/configs"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -135,20 +136,52 @@ func validateStringWithVariables(str string, fieldPath *field.Path, specialVars 
 	return allErrs
 }
 
-const sizeFmt = `\d+[kKmM]?`
+func ValidateTime(time string, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if time == "" {
+		return allErrs
+	}
+
+	if _, err := configs.ParseTime(time); err != nil {
+		return append(allErrs, field.Invalid(fieldPath, time, err.Error()))
+	}
+
+	return allErrs
+}
+
+// http://nginx.org/en/docs/syntax.html
+const offsetErrMsg = "must consist of numeric characters followed by a valid size suffix. 'k|K|m|M|g|G"
+
+func ValidateOffset(offset string, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if offset == "" {
+		return allErrs
+	}
+
+	if _, err := configs.ParseOffset(offset); err != nil {
+		msg := validation.RegexError(offsetErrMsg, configs.OffsetFmt, "16", "32k", "64M", "2G")
+		return append(allErrs, field.Invalid(fieldPath, offset, msg))
+	}
+
+	return allErrs
+}
+
+// http://nginx.org/en/docs/syntax.html
 const sizeErrMsg = "must consist of numeric characters followed by a valid size suffix. 'k|K|m|M"
 
-var sizeRegexp = regexp.MustCompile("^" + sizeFmt + "$")
+var sizeRegexp = regexp.MustCompile("^" + configs.SizeFmt + "$")
 
-func validateSize(size string, fieldPath *field.Path) field.ErrorList {
+func ValidateSize(size string, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if size == "" {
 		return allErrs
 	}
 
-	if !sizeRegexp.MatchString(size) {
-		msg := validation.RegexError(sizeErrMsg, sizeFmt, "16", "32k", "64M")
+	if _, err := configs.ParseSize(size); err != nil {
+		msg := validation.RegexError(sizeErrMsg, configs.SizeFmt, "16", "32k", "64M")
 		return append(allErrs, field.Invalid(fieldPath, size, msg))
 	}
 	return allErrs

--- a/pkg/apis/configuration/validation/common.go
+++ b/pkg/apis/configuration/validation/common.go
@@ -136,7 +136,7 @@ func validateStringWithVariables(str string, fieldPath *field.Path, specialVars 
 	return allErrs
 }
 
-func ValidateTime(time string, fieldPath *field.Path) field.ErrorList {
+func validateTime(time string, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if time == "" {
@@ -153,7 +153,7 @@ func ValidateTime(time string, fieldPath *field.Path) field.ErrorList {
 // http://nginx.org/en/docs/syntax.html
 const offsetErrMsg = "must consist of numeric characters followed by a valid size suffix. 'k|K|m|M|g|G"
 
-func ValidateOffset(offset string, fieldPath *field.Path) field.ErrorList {
+func validateOffset(offset string, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if offset == "" {
@@ -171,9 +171,7 @@ func ValidateOffset(offset string, fieldPath *field.Path) field.ErrorList {
 // http://nginx.org/en/docs/syntax.html
 const sizeErrMsg = "must consist of numeric characters followed by a valid size suffix. 'k|K|m|M"
 
-var sizeRegexp = regexp.MustCompile("^" + configs.SizeFmt + "$")
-
-func ValidateSize(size string, fieldPath *field.Path) field.ErrorList {
+func validateSize(size string, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if size == "" {

--- a/pkg/apis/configuration/validation/common_test.go
+++ b/pkg/apis/configuration/validation/common_test.go
@@ -273,17 +273,53 @@ func TestValidateStringWithVariablesFail(t *testing.T) {
 func TestValidateSize(t *testing.T) {
 	var validInput = []string{"", "4k", "8K", "16m", "32M"}
 	for _, test := range validInput {
-		allErrs := validateSize(test, field.NewPath("size-field"))
+		allErrs := ValidateSize(test, field.NewPath("size-field"))
 		if len(allErrs) != 0 {
-			t.Errorf("validateSize(%q) returned an error for valid input", test)
+			t.Errorf("ValidateSize(%q) returned an error for valid input", test)
 		}
 	}
 
 	var invalidInput = []string{"55mm", "2mG", "6kb", "-5k", "1L", "5G"}
 	for _, test := range invalidInput {
-		allErrs := validateSize(test, field.NewPath("size-field"))
+		allErrs := ValidateSize(test, field.NewPath("size-field"))
 		if len(allErrs) == 0 {
-			t.Errorf("validateSize(%q) didn't return error for invalid input.", test)
+			t.Errorf("ValidateSize(%q) didn't return error for invalid input.", test)
+		}
+	}
+}
+
+func TestValidateTime(t *testing.T) {
+	time := "1h 2s"
+	allErrs := ValidateTime(time, field.NewPath("time-field"))
+
+	if len(allErrs) != 0 {
+		t.Errorf("ValidateTime returned errors %v valid input %v", allErrs, time)
+	}
+}
+
+func TestValidateTimeFails(t *testing.T) {
+	time := "invalid"
+	allErrs := ValidateTime(time, field.NewPath("time-field"))
+
+	if len(allErrs) == 0 {
+		t.Errorf("ValidateTime returned no errors for invalid input %v", time)
+	}
+}
+
+func TestValidateOffset(t *testing.T) {
+	var validInput = []string{"", "1", "10k", "11m", "1K", "100M", "5G"}
+	for _, test := range validInput {
+		allErrs := ValidateOffset(test, field.NewPath("offset-field"))
+		if len(allErrs) != 0 {
+			t.Errorf("ValidateOffset(%q) returned an error for valid input", test)
+		}
+	}
+
+	var invalidInput = []string{"55mm", "2mG", "6kb", "-5k", "1L", "5Gb"}
+	for _, test := range invalidInput {
+		allErrs := ValidateOffset(test, field.NewPath("offset-field"))
+		if len(allErrs) == 0 {
+			t.Errorf("ValidateOffset(%q) didn't return error for invalid input.", test)
 		}
 	}
 }

--- a/pkg/apis/configuration/validation/common_test.go
+++ b/pkg/apis/configuration/validation/common_test.go
@@ -273,53 +273,53 @@ func TestValidateStringWithVariablesFail(t *testing.T) {
 func TestValidateSize(t *testing.T) {
 	var validInput = []string{"", "4k", "8K", "16m", "32M"}
 	for _, test := range validInput {
-		allErrs := ValidateSize(test, field.NewPath("size-field"))
+		allErrs := validateSize(test, field.NewPath("size-field"))
 		if len(allErrs) != 0 {
-			t.Errorf("ValidateSize(%q) returned an error for valid input", test)
+			t.Errorf("validateSize(%q) returned an error for valid input", test)
 		}
 	}
 
 	var invalidInput = []string{"55mm", "2mG", "6kb", "-5k", "1L", "5G"}
 	for _, test := range invalidInput {
-		allErrs := ValidateSize(test, field.NewPath("size-field"))
+		allErrs := validateSize(test, field.NewPath("size-field"))
 		if len(allErrs) == 0 {
-			t.Errorf("ValidateSize(%q) didn't return error for invalid input.", test)
+			t.Errorf("validateSize(%q) didn't return error for invalid input.", test)
 		}
 	}
 }
 
 func TestValidateTime(t *testing.T) {
 	time := "1h 2s"
-	allErrs := ValidateTime(time, field.NewPath("time-field"))
+	allErrs := validateTime(time, field.NewPath("time-field"))
 
 	if len(allErrs) != 0 {
-		t.Errorf("ValidateTime returned errors %v valid input %v", allErrs, time)
+		t.Errorf("validateTime returned errors %v valid input %v", allErrs, time)
 	}
 }
 
 func TestValidateTimeFails(t *testing.T) {
 	time := "invalid"
-	allErrs := ValidateTime(time, field.NewPath("time-field"))
+	allErrs := validateTime(time, field.NewPath("time-field"))
 
 	if len(allErrs) == 0 {
-		t.Errorf("ValidateTime returned no errors for invalid input %v", time)
+		t.Errorf("validateTime returned no errors for invalid input %v", time)
 	}
 }
 
 func TestValidateOffset(t *testing.T) {
 	var validInput = []string{"", "1", "10k", "11m", "1K", "100M", "5G"}
 	for _, test := range validInput {
-		allErrs := ValidateOffset(test, field.NewPath("offset-field"))
+		allErrs := validateOffset(test, field.NewPath("offset-field"))
 		if len(allErrs) != 0 {
-			t.Errorf("ValidateOffset(%q) returned an error for valid input", test)
+			t.Errorf("validateOffset(%q) returned an error for valid input", test)
 		}
 	}
 
 	var invalidInput = []string{"55mm", "2mG", "6kb", "-5k", "1L", "5Gb"}
 	for _, test := range invalidInput {
-		allErrs := ValidateOffset(test, field.NewPath("offset-field"))
+		allErrs := validateOffset(test, field.NewPath("offset-field"))
 		if len(allErrs) == 0 {
-			t.Errorf("ValidateOffset(%q) didn't return error for invalid input.", test)
+			t.Errorf("validateOffset(%q) didn't return error for invalid input.", test)
 		}
 	}
 }

--- a/pkg/apis/configuration/validation/policy.go
+++ b/pkg/apis/configuration/validation/policy.go
@@ -221,7 +221,7 @@ func validateRateLimitZoneSize(zoneSize string, fieldPath *field.Path) field.Err
 		return append(allErrs, field.Required(fieldPath, ""))
 	}
 
-	allErrs = append(allErrs, validateSize(zoneSize, fieldPath)...)
+	allErrs = append(allErrs, ValidateSize(zoneSize, fieldPath)...)
 
 	kbZoneSize := strings.TrimSuffix(strings.ToLower(zoneSize), "k")
 	kbZoneSizeNum, err := strconv.Atoi(kbZoneSize)

--- a/pkg/apis/configuration/validation/policy.go
+++ b/pkg/apis/configuration/validation/policy.go
@@ -221,7 +221,7 @@ func validateRateLimitZoneSize(zoneSize string, fieldPath *field.Path) field.Err
 		return append(allErrs, field.Required(fieldPath, ""))
 	}
 
-	allErrs = append(allErrs, ValidateSize(zoneSize, fieldPath)...)
+	allErrs = append(allErrs, validateSize(zoneSize, fieldPath)...)
 
 	kbZoneSize := strings.TrimSuffix(strings.ToLower(zoneSize), "k")
 	kbZoneSizeNum, err := strconv.Atoi(kbZoneSize)

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -186,7 +186,7 @@ func validateBuffer(buff *v1.UpstreamBuffers, fieldPath *field.Path) field.Error
 	if buff.Size == "" {
 		allErrs = append(allErrs, field.Required(fieldPath.Child("size"), "cannot be empty"))
 	} else {
-		allErrs = append(allErrs, ValidateSize(buff.Size, fieldPath.Child("size"))...)
+		allErrs = append(allErrs, validateSize(buff.Size, fieldPath.Child("size"))...)
 	}
 
 	return allErrs
@@ -224,13 +224,13 @@ func validateUpstreamHealthCheck(hc *v1.HealthCheck, fieldPath *field.Path) fiel
 		allErrs = append(allErrs, validatePath(hc.Path, fieldPath.Child("path"))...)
 	}
 
-	allErrs = append(allErrs, ValidateTime(hc.Interval, fieldPath.Child("interval"))...)
-	allErrs = append(allErrs, ValidateTime(hc.Jitter, fieldPath.Child("jitter"))...)
+	allErrs = append(allErrs, validateTime(hc.Interval, fieldPath.Child("interval"))...)
+	allErrs = append(allErrs, validateTime(hc.Jitter, fieldPath.Child("jitter"))...)
 	allErrs = append(allErrs, validatePositiveIntOrZero(hc.Fails, fieldPath.Child("fails"))...)
 	allErrs = append(allErrs, validatePositiveIntOrZero(hc.Passes, fieldPath.Child("passes"))...)
-	allErrs = append(allErrs, ValidateTime(hc.ConnectTimeout, fieldPath.Child("connect-timeout"))...)
-	allErrs = append(allErrs, ValidateTime(hc.ReadTimeout, fieldPath.Child("read-timeout"))...)
-	allErrs = append(allErrs, ValidateTime(hc.SendTimeout, fieldPath.Child("send-timeout"))...)
+	allErrs = append(allErrs, validateTime(hc.ConnectTimeout, fieldPath.Child("connect-timeout"))...)
+	allErrs = append(allErrs, validateTime(hc.ReadTimeout, fieldPath.Child("read-timeout"))...)
+	allErrs = append(allErrs, validateTime(hc.SendTimeout, fieldPath.Child("send-timeout"))...)
 	allErrs = append(allErrs, validateStatusMatch(hc.StatusMatch, fieldPath.Child("statusMatch"))...)
 
 	for i, header := range hc.Headers {
@@ -267,7 +267,7 @@ func validateSessionCookie(sc *v1.SessionCookie, fieldPath *field.Path) field.Er
 	}
 
 	if sc.Expires != "max" {
-		allErrs = append(allErrs, ValidateTime(sc.Expires, fieldPath.Child("expires"))...)
+		allErrs = append(allErrs, validateTime(sc.Expires, fieldPath.Child("expires"))...)
 	}
 
 	if sc.Domain != "" {
@@ -412,22 +412,22 @@ func (vsv *VirtualServerValidator) validateUpstreams(upstreams []v1.Upstream, fi
 
 		allErrs = append(allErrs, validateServiceName(u.Service, idxPath.Child("service"))...)
 		allErrs = append(allErrs, validateLabels(u.Subselector, idxPath.Child("subselector"))...)
-		allErrs = append(allErrs, ValidateTime(u.ProxyConnectTimeout, idxPath.Child("connect-timeout"))...)
-		allErrs = append(allErrs, ValidateTime(u.ProxyReadTimeout, idxPath.Child("read-timeout"))...)
-		allErrs = append(allErrs, ValidateTime(u.ProxySendTimeout, idxPath.Child("send-timeout"))...)
+		allErrs = append(allErrs, validateTime(u.ProxyConnectTimeout, idxPath.Child("connect-timeout"))...)
+		allErrs = append(allErrs, validateTime(u.ProxyReadTimeout, idxPath.Child("read-timeout"))...)
+		allErrs = append(allErrs, validateTime(u.ProxySendTimeout, idxPath.Child("send-timeout"))...)
 		allErrs = append(allErrs, validateNextUpstream(u.ProxyNextUpstream, idxPath.Child("next-upstream"))...)
-		allErrs = append(allErrs, ValidateTime(u.ProxyNextUpstreamTimeout, idxPath.Child("next-upstream-timeout"))...)
+		allErrs = append(allErrs, validateTime(u.ProxyNextUpstreamTimeout, idxPath.Child("next-upstream-timeout"))...)
 		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(&u.ProxyNextUpstreamTries, idxPath.Child("next-upstream-tries"))...)
 		allErrs = append(allErrs, validateUpstreamLBMethod(u.LBMethod, idxPath.Child("lb-method"), vsv.isPlus)...)
-		allErrs = append(allErrs, ValidateTime(u.FailTimeout, idxPath.Child("fail-timeout"))...)
+		allErrs = append(allErrs, validateTime(u.FailTimeout, idxPath.Child("fail-timeout"))...)
 		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.MaxFails, idxPath.Child("max-fails"))...)
 		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.Keepalive, idxPath.Child("keepalive"))...)
 		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.MaxConns, idxPath.Child("max-conns"))...)
-		allErrs = append(allErrs, ValidateOffset(u.ClientMaxBodySize, idxPath.Child("client-max-body-size"))...)
+		allErrs = append(allErrs, validateOffset(u.ClientMaxBodySize, idxPath.Child("client-max-body-size"))...)
 		allErrs = append(allErrs, validateUpstreamHealthCheck(u.HealthCheck, idxPath.Child("healthCheck"))...)
-		allErrs = append(allErrs, ValidateTime(u.SlowStart, idxPath.Child("slow-start"))...)
+		allErrs = append(allErrs, validateTime(u.SlowStart, idxPath.Child("slow-start"))...)
 		allErrs = append(allErrs, validateBuffer(u.ProxyBuffers, idxPath.Child("buffers"))...)
-		allErrs = append(allErrs, ValidateSize(u.ProxyBufferSize, idxPath.Child("buffer-size"))...)
+		allErrs = append(allErrs, validateSize(u.ProxyBufferSize, idxPath.Child("buffer-size"))...)
 		allErrs = append(allErrs, validateQueue(u.Queue, idxPath.Child("queue"))...)
 		allErrs = append(allErrs, validateSessionCookie(u.SessionCookie, idxPath.Child("sessionCookie"))...)
 
@@ -1417,7 +1417,7 @@ func validateQueue(queue *v1.UpstreamQueue, fieldPath *field.Path) field.ErrorLi
 		return allErrs
 	}
 
-	allErrs = append(allErrs, ValidateTime(queue.Timeout, fieldPath.Child("timeout"))...)
+	allErrs = append(allErrs, validateTime(queue.Timeout, fieldPath.Child("timeout"))...)
 	if queue.Size <= 0 {
 		allErrs = append(allErrs, field.Required(fieldPath.Child("size"), "must be positive"))
 	}

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -172,41 +172,6 @@ func validatePositiveIntOrZeroFromPointer(n *int, fieldPath *field.Path) field.E
 	return allErrs
 }
 
-func validateTime(time string, fieldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if time == "" {
-		return allErrs
-	}
-
-	if _, err := configs.ParseTime(time); err != nil {
-		return append(allErrs, field.Invalid(fieldPath, time, err.Error()))
-	}
-
-	return allErrs
-}
-
-// http://nginx.org/en/docs/syntax.html
-const offsetFmt = `\d+[kKmMgG]?`
-const offsetErrMsg = "must consist of numeric characters followed by a valid size suffix. 'k|K|m|M|g|G"
-
-var offsetRegexp = regexp.MustCompile("^" + offsetFmt + "$")
-
-func validateOffset(offset string, fieldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if offset == "" {
-		return allErrs
-	}
-
-	if !offsetRegexp.MatchString(offset) {
-		msg := validation.RegexError(offsetErrMsg, offsetFmt, "16", "32k", "64M")
-		return append(allErrs, field.Invalid(fieldPath, offset, msg))
-	}
-
-	return allErrs
-}
-
 func validateBuffer(buff *v1.UpstreamBuffers, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -221,7 +186,7 @@ func validateBuffer(buff *v1.UpstreamBuffers, fieldPath *field.Path) field.Error
 	if buff.Size == "" {
 		allErrs = append(allErrs, field.Required(fieldPath.Child("size"), "cannot be empty"))
 	} else {
-		allErrs = append(allErrs, validateSize(buff.Size, fieldPath.Child("size"))...)
+		allErrs = append(allErrs, ValidateSize(buff.Size, fieldPath.Child("size"))...)
 	}
 
 	return allErrs
@@ -259,13 +224,13 @@ func validateUpstreamHealthCheck(hc *v1.HealthCheck, fieldPath *field.Path) fiel
 		allErrs = append(allErrs, validatePath(hc.Path, fieldPath.Child("path"))...)
 	}
 
-	allErrs = append(allErrs, validateTime(hc.Interval, fieldPath.Child("interval"))...)
-	allErrs = append(allErrs, validateTime(hc.Jitter, fieldPath.Child("jitter"))...)
+	allErrs = append(allErrs, ValidateTime(hc.Interval, fieldPath.Child("interval"))...)
+	allErrs = append(allErrs, ValidateTime(hc.Jitter, fieldPath.Child("jitter"))...)
 	allErrs = append(allErrs, validatePositiveIntOrZero(hc.Fails, fieldPath.Child("fails"))...)
 	allErrs = append(allErrs, validatePositiveIntOrZero(hc.Passes, fieldPath.Child("passes"))...)
-	allErrs = append(allErrs, validateTime(hc.ConnectTimeout, fieldPath.Child("connect-timeout"))...)
-	allErrs = append(allErrs, validateTime(hc.ReadTimeout, fieldPath.Child("read-timeout"))...)
-	allErrs = append(allErrs, validateTime(hc.SendTimeout, fieldPath.Child("send-timeout"))...)
+	allErrs = append(allErrs, ValidateTime(hc.ConnectTimeout, fieldPath.Child("connect-timeout"))...)
+	allErrs = append(allErrs, ValidateTime(hc.ReadTimeout, fieldPath.Child("read-timeout"))...)
+	allErrs = append(allErrs, ValidateTime(hc.SendTimeout, fieldPath.Child("send-timeout"))...)
 	allErrs = append(allErrs, validateStatusMatch(hc.StatusMatch, fieldPath.Child("statusMatch"))...)
 
 	for i, header := range hc.Headers {
@@ -302,7 +267,7 @@ func validateSessionCookie(sc *v1.SessionCookie, fieldPath *field.Path) field.Er
 	}
 
 	if sc.Expires != "max" {
-		allErrs = append(allErrs, validateTime(sc.Expires, fieldPath.Child("expires"))...)
+		allErrs = append(allErrs, ValidateTime(sc.Expires, fieldPath.Child("expires"))...)
 	}
 
 	if sc.Domain != "" {
@@ -447,22 +412,22 @@ func (vsv *VirtualServerValidator) validateUpstreams(upstreams []v1.Upstream, fi
 
 		allErrs = append(allErrs, validateServiceName(u.Service, idxPath.Child("service"))...)
 		allErrs = append(allErrs, validateLabels(u.Subselector, idxPath.Child("subselector"))...)
-		allErrs = append(allErrs, validateTime(u.ProxyConnectTimeout, idxPath.Child("connect-timeout"))...)
-		allErrs = append(allErrs, validateTime(u.ProxyReadTimeout, idxPath.Child("read-timeout"))...)
-		allErrs = append(allErrs, validateTime(u.ProxySendTimeout, idxPath.Child("send-timeout"))...)
+		allErrs = append(allErrs, ValidateTime(u.ProxyConnectTimeout, idxPath.Child("connect-timeout"))...)
+		allErrs = append(allErrs, ValidateTime(u.ProxyReadTimeout, idxPath.Child("read-timeout"))...)
+		allErrs = append(allErrs, ValidateTime(u.ProxySendTimeout, idxPath.Child("send-timeout"))...)
 		allErrs = append(allErrs, validateNextUpstream(u.ProxyNextUpstream, idxPath.Child("next-upstream"))...)
-		allErrs = append(allErrs, validateTime(u.ProxyNextUpstreamTimeout, idxPath.Child("next-upstream-timeout"))...)
+		allErrs = append(allErrs, ValidateTime(u.ProxyNextUpstreamTimeout, idxPath.Child("next-upstream-timeout"))...)
 		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(&u.ProxyNextUpstreamTries, idxPath.Child("next-upstream-tries"))...)
 		allErrs = append(allErrs, validateUpstreamLBMethod(u.LBMethod, idxPath.Child("lb-method"), vsv.isPlus)...)
-		allErrs = append(allErrs, validateTime(u.FailTimeout, idxPath.Child("fail-timeout"))...)
+		allErrs = append(allErrs, ValidateTime(u.FailTimeout, idxPath.Child("fail-timeout"))...)
 		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.MaxFails, idxPath.Child("max-fails"))...)
 		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.Keepalive, idxPath.Child("keepalive"))...)
 		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.MaxConns, idxPath.Child("max-conns"))...)
-		allErrs = append(allErrs, validateOffset(u.ClientMaxBodySize, idxPath.Child("client-max-body-size"))...)
+		allErrs = append(allErrs, ValidateOffset(u.ClientMaxBodySize, idxPath.Child("client-max-body-size"))...)
 		allErrs = append(allErrs, validateUpstreamHealthCheck(u.HealthCheck, idxPath.Child("healthCheck"))...)
-		allErrs = append(allErrs, validateTime(u.SlowStart, idxPath.Child("slow-start"))...)
+		allErrs = append(allErrs, ValidateTime(u.SlowStart, idxPath.Child("slow-start"))...)
 		allErrs = append(allErrs, validateBuffer(u.ProxyBuffers, idxPath.Child("buffers"))...)
-		allErrs = append(allErrs, validateSize(u.ProxyBufferSize, idxPath.Child("buffer-size"))...)
+		allErrs = append(allErrs, ValidateSize(u.ProxyBufferSize, idxPath.Child("buffer-size"))...)
 		allErrs = append(allErrs, validateQueue(u.Queue, idxPath.Child("queue"))...)
 		allErrs = append(allErrs, validateSessionCookie(u.SessionCookie, idxPath.Child("sessionCookie"))...)
 
@@ -1452,7 +1417,7 @@ func validateQueue(queue *v1.UpstreamQueue, fieldPath *field.Path) field.ErrorLi
 		return allErrs
 	}
 
-	allErrs = append(allErrs, validateTime(queue.Timeout, fieldPath.Child("timeout"))...)
+	allErrs = append(allErrs, ValidateTime(queue.Timeout, fieldPath.Child("timeout"))...)
 	if queue.Size <= 0 {
 		allErrs = append(allErrs, field.Required(fieldPath.Child("size"), "must be positive"))
 	}

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -2252,33 +2252,6 @@ func TestValidatePositiveIntOrZeroFails(t *testing.T) {
 	}
 }
 
-func TestValidateTime(t *testing.T) {
-	time := "1h 2s"
-	allErrs := validateTime(time, field.NewPath("time-field"))
-
-	if len(allErrs) != 0 {
-		t.Errorf("validateTime returned errors %v valid input %v", allErrs, time)
-	}
-}
-
-func TestValidateOffset(t *testing.T) {
-	var validInput = []string{"", "1", "10k", "11m", "1K", "100M", "5G"}
-	for _, test := range validInput {
-		allErrs := validateOffset(test, field.NewPath("offset-field"))
-		if len(allErrs) != 0 {
-			t.Errorf("validateOffset(%q) returned an error for valid input", test)
-		}
-	}
-
-	var invalidInput = []string{"55mm", "2mG", "6kb", "-5k", "1L", "5Gb"}
-	for _, test := range invalidInput {
-		allErrs := validateOffset(test, field.NewPath("offset-field"))
-		if len(allErrs) == 0 {
-			t.Errorf("validateOffset(%q) didn't return error for invalid input.", test)
-		}
-	}
-}
-
 func TestValidateBuffer(t *testing.T) {
 	validbuff := &v1.UpstreamBuffers{Number: 8, Size: "8k"}
 	allErrs := validateBuffer(validbuff, field.NewPath("buffers-field"))
@@ -2306,15 +2279,6 @@ func TestValidateBuffer(t *testing.T) {
 		if len(allErrs) == 0 {
 			t.Errorf("validateBuffer didn't return error for invalid input %v.", test)
 		}
-	}
-}
-
-func TestValidateTimeFails(t *testing.T) {
-	time := "invalid"
-	allErrs := validateTime(time, field.NewPath("time-field"))
-
-	if len(allErrs) == 0 {
-		t.Errorf("validateTime returned no errors for invalid input %v", time)
 	}
 }
 


### PR DESCRIPTION
Minimal validation was performed at the stage when errors can be show to the user in k8s
status messages. Most was done later, when errors could only be written to the controller's
log file. This change moves some of the validation to the earlier phase, more will follow.

### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
