### PR TITLE
K8s log variables for splits & matches

### DIFF
--- a/examples/custom-log-format/README.md
+++ b/examples/custom-log-format/README.md
@@ -6,14 +6,16 @@ This example lets you set the log-format for NGINX using the configmap reosurce
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: oss-nginx-ingress
+  name: nginx-config
+  namespace: nginx-ingress
 data:
-  log-format:  $remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\"  \"$http_user_agent\" \"$http_x_forwarded_for\" $resource_name $resource_type $resource_namespace $service;
+  log-format:  '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer"  "$http_user_agent" "$http_x_forwarded_for" "$resource_name" "$resource_type" "$resource_namespace" "$service";'
 ```
 
-In addition to the built-in NGINX variables, you can also use the variables that the Ingress Controller configures:
-
-- $resource_type - The type of k8s resource. 
-- $resource_name - The name of the k8s resource
+In addition to the [built-in NGINX variables](https://nginx.org/en/docs/varindex.html), you can also use the variables that the Ingress Controller configures:
+- $resource_type - The type of kubernetes resource that handled the client request.
+- $resource_name - The name of the resource
 - $resource_namespace - The namespace the resource exists in.
-- $service - The service that exposes the resource.
+- $service - The name of the server the client request was sent to.
+
+**note** These variables are only available for Ingress, VirtualServer and VirtualServerRoute resources.

--- a/examples/custom-log-format/README.md
+++ b/examples/custom-log-format/README.md
@@ -1,6 +1,6 @@
 # Custom NGINX log format
 
-This example lets you set the log-format for NGINX using the configmap reosurce 
+This example lets you set the log-format for NGINX using the configmap resource
 
 ```yaml 
 kind: ConfigMap
@@ -9,13 +9,13 @@ metadata:
   name: nginx-config
   namespace: nginx-ingress
 data:
-  log-format:  '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer"  "$http_user_agent" "$http_x_forwarded_for" "$resource_name" "$resource_type" "$resource_namespace" "$service";'
+  log-format:  '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer"  "$http_user_agent" "$http_x_forwarded_for" "$resource_name" "$resource_type" "$resource_namespace" "$service"'
 ```
 
 In addition to the [built-in NGINX variables](https://nginx.org/en/docs/varindex.html), you can also use the variables that the Ingress Controller configures:
 - $resource_type - The type of kubernetes resource that handled the client request.
 - $resource_name - The name of the resource
 - $resource_namespace - The namespace the resource exists in.
-- $service - The name of the server the client request was sent to.
+- $service - The name of the service the client request was sent to.
 
 **note** These variables are only available for Ingress, VirtualServer and VirtualServerRoute resources.

--- a/examples/custom-log-format/README.md
+++ b/examples/custom-log-format/README.md
@@ -6,12 +6,9 @@ This example lets you set the log-format for NGINX using the configmap reosurce
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: nginx-config
+  name: oss-nginx-ingress
 data:
-  log-format: |
-      compression '$remote_addr - $remote_user [$time_local] '
-                       '"$request" $status $bytes_sent '
-                       '"$http_referer" "$http_user_agent" "$gzip_ratio"'
+  log-format:  $remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\"  \"$http_user_agent\" \"$http_x_forwarded_for\" $resource_name $resource_type $resource_namespace $service;
 ```
 
 In addition to the built-in NGINX variables, you can also use the variables that the Ingress Controller configures:

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -59,7 +59,6 @@ server {
 	server_name {{$server.Name}};
 
 	status_zone {{$server.StatusZone}};
-
 	set $resource_type "ingress";
 	set $resource_name "{{$.Ingress.Name}}";
 	set $resource_namespace "{{$.Ingress.Namespace}}";

--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -44,11 +44,7 @@ http {
     {{- else -}}
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for" '
-                      'resource_type="$resource_type" '
-                      'resource_name="$resource_name" '
-                      'resource_namespace="$resource_namespace" '
-                      'service="$service"';
+                      '"$http_user_agent" "$http_x_forwarded_for"';
     {{- end}}
 
     {{if .AccessLogOff}}

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -93,6 +93,9 @@ http {
         # required to support the Websocket protocol in VirtualServer/VirtualServerRoutes
         set $default_connection_header "";
         set $resource_type "";
+        set $resource_name "";
+        set $resource_namespace "";
+        set $service "";
 
         listen 80 default_server{{if .ProxyProtocol}} proxy_protocol{{end}};
 

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -70,8 +70,8 @@ type Server struct {
 	IngressMTLS               *IngressMTLS
 	EgressMTLS                *EgressMTLS
 	PoliciesErrorReturn       *Return
-	Namespace                 string
-	Name                      string
+	VSNamespace               string
+	VSName                    string
 }
 
 // SSL defines SSL configuration for a server.

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -71,6 +71,7 @@ type Server struct {
 	EgressMTLS                *EgressMTLS
 	PoliciesErrorReturn       *Return
 	Namespace                 string
+	Name                      string
 }
 
 // SSL defines SSL configuration for a server.

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -61,8 +61,8 @@ server {
     server_name {{ $s.ServerName }};
     status_zone {{ $s.StatusZone }};
     set $resource_type "virtualserver";
-    set $resource_name "{{$s.Name}}";
-    set $resource_namespace "{{$s.Namespace}}";
+    set $resource_name "{{$s.VSName}}";
+    set $resource_namespace "{{$s.VSNamespace}}";
 
     {{ with $ssl := $s.SSL }}
         {{ if $s.TLSPassthrough }}

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -60,7 +60,6 @@ server {
 
     server_name {{ $s.ServerName }};
     status_zone {{ $s.StatusZone }};
-
     set $resource_type "virtualserver";
     set $resource_name "{{$s.ServerName}}";
     set $resource_namespace "{{$s.Namespace}}";

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -61,7 +61,7 @@ server {
     server_name {{ $s.ServerName }};
     status_zone {{ $s.StatusZone }};
     set $resource_type "virtualserver";
-    set $resource_name "{{$s.ServerName}}";
+    set $resource_name "{{$s.Name}}";
     set $resource_namespace "{{$s.Namespace}}";
 
     {{ with $ssl := $s.SSL }}

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -45,7 +45,7 @@ server {
     server_name {{ $s.ServerName }};
 
     set $resource_type "virtualserver";
-    set $resource_name "{{$s.ServerName}}";
+    set $resource_name "{{$s.Name}}";
     set $resource_namespace "{{$s.Namespace}}";
 
 

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -45,8 +45,8 @@ server {
     server_name {{ $s.ServerName }};
 
     set $resource_type "virtualserver";
-    set $resource_name "{{$s.Name}}";
-    set $resource_namespace "{{$s.Namespace}}";
+    set $resource_name "{{$s.VSName}}";
+    set $resource_namespace "{{$s.VSNamespace}}";
 
 
     {{ with $ssl := $s.SSL }}

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -176,7 +176,12 @@ server {
 
     {{ range $l := $s.Locations }}
     location {{ $l.Path }} {
-        set $service "{{$l.ServiceName}}";
+        set $service "{{ $l.ServiceName }}";
+        {{ if $l.IsVSR }}
+        set $resource_type "virtualserverroute";
+        set $resource_name "{{ $l.VSRName }}";
+        set $resource_namespace "{{ $l.VSRNamespace }}";
+        {{ end }}
         {{ if $l.Internal }}
         internal;
         {{ end }}

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -580,6 +580,7 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(vsEx *VirtualS
 			EgressMTLS:                policiesCfg.EgressMTLS,
 			PoliciesErrorReturn:       policiesCfg.ErrorReturn,
 			Namespace:                 vsEx.VirtualServer.Namespace,
+			Name:                      vsEx.VirtualServer.Name,
 		},
 		SpiffeCerts: vsc.spiffeCerts,
 	}

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -403,6 +403,8 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(vsEx *VirtualS
 				vsLocSnippets,
 				vsc.enableSnippets,
 				len(returnLocations),
+				isVSR,
+				"", "",
 			)
 			addPoliciesCfgToLocations(routePoliciesCfg, cfg.Locations)
 
@@ -414,7 +416,7 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(vsEx *VirtualS
 			matchesRoutes++
 		} else if len(r.Splits) > 0 {
 			cfg := generateDefaultSplitsConfig(r, virtualServerUpstreamNamer, crUpstreams, variableNamer, len(splitClients),
-				vsc.cfgParams, r.ErrorPages, errorPageIndex, r.Path, vsLocSnippets, vsc.enableSnippets, len(returnLocations))
+				vsc.cfgParams, r.ErrorPages, errorPageIndex, r.Path, vsLocSnippets, vsc.enableSnippets, len(returnLocations), isVSR, "", "")
 			addPoliciesCfgToLocations(routePoliciesCfg, cfg.Locations)
 
 			splitClients = append(splitClients, cfg.SplitClients...)
@@ -486,7 +488,6 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(vsEx *VirtualS
 			}
 			routePoliciesCfg := vsc.generatePolicies(ownerDetails, policyRefs, vsEx.Policies, context, policyOpts)
 			limitReqZones = append(limitReqZones, routePoliciesCfg.LimitReqZones...)
-
 			if len(r.Matches) > 0 {
 				cfg := generateMatchesConfig(
 					r,
@@ -501,6 +502,9 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(vsEx *VirtualS
 					locSnippets,
 					vsc.enableSnippets,
 					len(returnLocations),
+					isVSR,
+					vsr.Name,
+					vsr.Namespace,
 				)
 				addPoliciesCfgToLocations(routePoliciesCfg, cfg.Locations)
 
@@ -512,7 +516,7 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(vsEx *VirtualS
 				matchesRoutes++
 			} else if len(r.Splits) > 0 {
 				cfg := generateDefaultSplitsConfig(r, upstreamNamer, crUpstreams, variableNamer, len(splitClients), vsc.cfgParams,
-					errorPages, errorPageIndex, r.Path, locSnippets, vsc.enableSnippets, len(returnLocations))
+					errorPages, errorPageIndex, r.Path, locSnippets, vsc.enableSnippets, len(returnLocations), isVSR, vsr.Name, vsr.Namespace)
 				addPoliciesCfgToLocations(routePoliciesCfg, cfg.Locations)
 
 				splitClients = append(splitClients, cfg.SplitClients...)
@@ -1476,12 +1480,12 @@ func generateSplits(
 	locSnippets string,
 	enableSnippets bool,
 	retLocIndex int,
+	isVSR bool,
+	vsrName string,
+	vsrNamespace string,
 ) (version2.SplitClient, []version2.Location, []version2.ReturnLocation) {
 
 	var distributions []version2.Distribution
-	isVSR := false
-	vsrName := ""
-	vsrNamespace := ""
 
 	for i, s := range splits {
 		d := version2.Distribution{
@@ -1530,10 +1534,13 @@ func generateDefaultSplitsConfig(
 	locSnippets string,
 	enableSnippets bool,
 	retLocIndex int,
+	isVSR bool,
+	vsrName string,
+	vsrNamespace string,
 ) routingCfg {
 
 	sc, locs, returnLocs := generateSplits(route.Splits, upstreamNamer, crUpstreams, variableNamer, scIndex, cfgParams,
-		errorPages, errPageIndex, originalPath, locSnippets, enableSnippets, retLocIndex)
+		errorPages, errPageIndex, originalPath, locSnippets, enableSnippets, retLocIndex, isVSR, vsrName, vsrNamespace)
 
 	splitClientVarName := variableNamer.GetNameForSplitClientVariable(scIndex)
 
@@ -1552,7 +1559,7 @@ func generateDefaultSplitsConfig(
 
 func generateMatchesConfig(route conf_v1.Route, upstreamNamer *upstreamNamer, crUpstreams map[string]conf_v1.Upstream,
 	variableNamer *variableNamer, index int, scIndex int, cfgParams *ConfigParams, errorPages []conf_v1.ErrorPage,
-	errPageIndex int, locSnippets string, enableSnippets bool, retLocIndex int) routingCfg {
+	errPageIndex int, locSnippets string, enableSnippets bool, retLocIndex int, isVSR bool, vsrName string, vsrNamespace string) routingCfg {
 	// Generate maps
 	var maps []version2.Map
 
@@ -1622,9 +1629,6 @@ func generateMatchesConfig(route conf_v1.Route, upstreamNamer *upstreamNamer, cr
 	var locations []version2.Location
 	var returnLocations []version2.ReturnLocation
 	var splitClients []version2.SplitClient
-	isVSR := false
-	vsrName := ""
-	vsrNamespace := ""
 	scLocalIndex = 0
 
 	for i, m := range route.Matches {
@@ -1643,6 +1647,9 @@ func generateMatchesConfig(route conf_v1.Route, upstreamNamer *upstreamNamer, cr
 				locSnippets,
 				enableSnippets,
 				newRetLocIndex,
+				isVSR,
+				vsrName,
+				vsrNamespace,
 			)
 			scLocalIndex++
 			splitClients = append(splitClients, sc)
@@ -1679,6 +1686,9 @@ func generateMatchesConfig(route conf_v1.Route, upstreamNamer *upstreamNamer, cr
 			locSnippets,
 			enableSnippets,
 			newRetLocIndex,
+			isVSR,
+			vsrName,
+			vsrNamespace,
 		)
 		splitClients = append(splitClients, sc)
 		locations = append(locations, locs...)

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -579,8 +579,8 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(vsEx *VirtualS
 			IngressMTLS:               policiesCfg.IngressMTLS,
 			EgressMTLS:                policiesCfg.EgressMTLS,
 			PoliciesErrorReturn:       policiesCfg.ErrorReturn,
-			Namespace:                 vsEx.VirtualServer.Namespace,
-			Name:                      vsEx.VirtualServer.Name,
+			VSNamespace:               vsEx.VirtualServer.Namespace,
+			VSName:                    vsEx.VirtualServer.Name,
 		},
 		SpiffeCerts: vsc.spiffeCerts,
 	}

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -488,8 +488,8 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 		Server: version2.Server{
 			ServerName:      "cafe.example.com",
 			StatusZone:      "cafe.example.com",
-			Namespace:       "default",
-			Name:            "cafe",
+			VSNamespace:     "default",
+			VSName:          "cafe",
 			ProxyProtocol:   true,
 			ServerTokens:    "off",
 			SetRealIPFrom:   []string{"0.0.0.0/0"},
@@ -711,8 +711,8 @@ func TestGenerateVirtualServerConfigWithSpiffeCerts(t *testing.T) {
 		Server: version2.Server{
 			ServerName:      "cafe.example.com",
 			StatusZone:      "cafe.example.com",
-			Namespace:       "default",
-			Name:            "cafe",
+			VSNamespace:     "default",
+			VSName:          "cafe",
 			ProxyProtocol:   true,
 			ServerTokens:    "off",
 			SetRealIPFrom:   []string{"0.0.0.0/0"},
@@ -949,10 +949,10 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 		HTTPSnippets:  []string{""},
 		LimitReqZones: []version2.LimitReqZone{},
 		Server: version2.Server{
-			ServerName: "cafe.example.com",
-			StatusZone: "cafe.example.com",
-			Namespace:  "default",
-			Name:       "cafe",
+			ServerName:  "cafe.example.com",
+			StatusZone:  "cafe.example.com",
+			VSNamespace: "default",
+			VSName:      "cafe",
 			InternalRedirectLocations: []version2.InternalRedirectLocation{
 				{
 					Path:        "/tea",
@@ -1262,10 +1262,10 @@ func TestGenerateVirtualServerConfigForVirtualServerWithMatches(t *testing.T) {
 		HTTPSnippets:  []string{""},
 		LimitReqZones: []version2.LimitReqZone{},
 		Server: version2.Server{
-			ServerName: "cafe.example.com",
-			StatusZone: "cafe.example.com",
-			Namespace:  "default",
-			Name:       "cafe",
+			ServerName:  "cafe.example.com",
+			StatusZone:  "cafe.example.com",
+			VSNamespace: "default",
+			VSName:      "cafe",
 			InternalRedirectLocations: []version2.InternalRedirectLocation{
 				{
 					Path:        "/tea",
@@ -1575,10 +1575,10 @@ func TestGenerateVirtualServerConfigForVirtualServerWithReturns(t *testing.T) {
 		HTTPSnippets:  []string{""},
 		LimitReqZones: []version2.LimitReqZone{},
 		Server: version2.Server{
-			ServerName: "example.com",
-			StatusZone: "example.com",
-			Namespace:  "default",
-			Name:       "returns",
+			ServerName:  "example.com",
+			StatusZone:  "example.com",
+			VSNamespace: "default",
+			VSName:      "returns",
 			InternalRedirectLocations: []version2.InternalRedirectLocation{
 				{
 					Path:        "/splits-with-return",

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -489,6 +489,7 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 			ServerName:      "cafe.example.com",
 			StatusZone:      "cafe.example.com",
 			Namespace:       "default",
+			Name:            "cafe",
 			ProxyProtocol:   true,
 			ServerTokens:    "off",
 			SetRealIPFrom:   []string{"0.0.0.0/0"},
@@ -711,6 +712,7 @@ func TestGenerateVirtualServerConfigWithSpiffeCerts(t *testing.T) {
 			ServerName:      "cafe.example.com",
 			StatusZone:      "cafe.example.com",
 			Namespace:       "default",
+			Name:            "cafe",
 			ProxyProtocol:   true,
 			ServerTokens:    "off",
 			SetRealIPFrom:   []string{"0.0.0.0/0"},
@@ -950,6 +952,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 			ServerName: "cafe.example.com",
 			StatusZone: "cafe.example.com",
 			Namespace:  "default",
+			Name:       "cafe",
 			InternalRedirectLocations: []version2.InternalRedirectLocation{
 				{
 					Path:        "/tea",
@@ -1262,6 +1265,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithMatches(t *testing.T) {
 			ServerName: "cafe.example.com",
 			StatusZone: "cafe.example.com",
 			Namespace:  "default",
+			Name:       "cafe",
 			InternalRedirectLocations: []version2.InternalRedirectLocation{
 				{
 					Path:        "/tea",
@@ -1574,6 +1578,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithReturns(t *testing.T) {
 			ServerName: "example.com",
 			StatusZone: "example.com",
 			Namespace:  "default",
+			Name:       "returns",
 			InternalRedirectLocations: []version2.InternalRedirectLocation{
 				{
 					Path:        "/splits-with-return",

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -993,6 +993,9 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 					ProxySSLName:             "coffee-svc-v1.default.svc",
 					ProxyPassRequestHeaders:  true,
 					ServiceName:              "coffee-svc-v1",
+					IsVSR:                    true,
+					VSRName:                  "coffee",
+					VSRNamespace:             "default",
 				},
 				{
 					Path:                     "/internal_location_splits_1_split_1",
@@ -1004,6 +1007,9 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 					ProxySSLName:             "coffee-svc-v2.default.svc",
 					ProxyPassRequestHeaders:  true,
 					ServiceName:              "coffee-svc-v2",
+					IsVSR:                    true,
+					VSRName:                  "coffee",
+					VSRNamespace:             "default",
 				},
 			},
 		},
@@ -1299,6 +1305,9 @@ func TestGenerateVirtualServerConfigForVirtualServerWithMatches(t *testing.T) {
 					ProxySSLName:             "coffee-svc-v2.default.svc",
 					ProxyPassRequestHeaders:  true,
 					ServiceName:              "coffee-svc-v2",
+					IsVSR:                    true,
+					VSRName:                  "coffee",
+					VSRNamespace:             "default",
 				},
 				{
 					Path:                     "/internal_location_matches_1_default",
@@ -1310,6 +1319,9 @@ func TestGenerateVirtualServerConfigForVirtualServerWithMatches(t *testing.T) {
 					ProxySSLName:             "coffee-svc-v1.default.svc",
 					ProxyPassRequestHeaders:  true,
 					ServiceName:              "coffee-svc-v1",
+					IsVSR:                    true,
+					VSRName:                  "coffee",
+					VSRNamespace:             "default",
 				},
 			},
 		},
@@ -3870,6 +3882,9 @@ func TestGenerateSplits(t *testing.T) {
 			ProxyPassRequestHeaders: true,
 			Snippets:                []string{locSnippet},
 			ServiceName:             "coffee-v1",
+			IsVSR:                   true,
+			VSRName:                 "coffee",
+			VSRNamespace:            "default",
 		},
 		{
 			Path:                     "/internal_location_splits_1_split_1",
@@ -3895,6 +3910,9 @@ func TestGenerateSplits(t *testing.T) {
 			ProxyPassRequestHeaders: true,
 			Snippets:                []string{locSnippet},
 			ServiceName:             "coffee-v2",
+			IsVSR:                   true,
+			VSRName:                 "coffee",
+			VSRNamespace:            "default",
 		},
 		{
 			Path:                 "/internal_location_splits_1_split_2",
@@ -3934,6 +3952,9 @@ func TestGenerateSplits(t *testing.T) {
 		locSnippet,
 		enableSnippets,
 		returnLocationIndex,
+		true,
+		"coffee",
+		"default",
 	)
 	if !reflect.DeepEqual(resultSplitClient, expectedSplitClient) {
 		t.Errorf("generateSplits() returned \n%+v but expected \n%+v", resultSplitClient, expectedSplitClient)
@@ -4003,6 +4024,9 @@ func TestGenerateDefaultSplitsConfig(t *testing.T) {
 				ProxySSLName:             "coffee-v1.default.svc",
 				ProxyPassRequestHeaders:  true,
 				ServiceName:              "coffee-v1",
+				IsVSR:                    true,
+				VSRName:                  "coffee",
+				VSRNamespace:             "default",
 			},
 			{
 				Path:                     "/internal_location_splits_1_split_1",
@@ -4014,6 +4038,9 @@ func TestGenerateDefaultSplitsConfig(t *testing.T) {
 				ProxySSLName:             "coffee-v2.default.svc",
 				ProxyPassRequestHeaders:  true,
 				ServiceName:              "coffee-v2",
+				IsVSR:                    true,
+				VSRName:                  "coffee",
+				VSRNamespace:             "default",
 			},
 		},
 		InternalRedirectLocation: version2.InternalRedirectLocation{
@@ -4035,7 +4062,7 @@ func TestGenerateDefaultSplitsConfig(t *testing.T) {
 	}
 
 	result := generateDefaultSplitsConfig(route, upstreamNamer, crUpstreams, variableNamer, index, &cfgParams,
-		route.ErrorPages, 0, "", locSnippet, enableSnippets, 0)
+		route.ErrorPages, 0, "", locSnippet, enableSnippets, 0, true, "coffee", "default")
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("generateDefaultSplitsConfig() returned \n%+v but expected \n%+v", result, expected)
 	}
@@ -4304,6 +4331,9 @@ func TestGenerateMatchesConfig(t *testing.T) {
 				ProxySSLName:            "coffee-v1.default.svc",
 				ProxyPassRequestHeaders: true,
 				ServiceName:             "coffee-v1",
+				IsVSR:                   false,
+				VSRName:                 "",
+				VSRNamespace:            "",
 			},
 			{
 				Path:                     "/internal_location_splits_2_split_0",
@@ -4328,6 +4358,9 @@ func TestGenerateMatchesConfig(t *testing.T) {
 				ProxySSLName:            "coffee-v1.default.svc",
 				ProxyPassRequestHeaders: true,
 				ServiceName:             "coffee-v1",
+				IsVSR:                   false,
+				VSRName:                 "",
+				VSRNamespace:            "",
 			},
 			{
 				Path:                     "/internal_location_splits_2_split_1",
@@ -4352,6 +4385,9 @@ func TestGenerateMatchesConfig(t *testing.T) {
 				ProxySSLName:            "coffee-v2.default.svc",
 				ProxyPassRequestHeaders: true,
 				ServiceName:             "coffee-v2",
+				IsVSR:                   false,
+				VSRName:                 "",
+				VSRNamespace:            "",
 			},
 			{
 				Path:                     "/internal_location_matches_1_default",
@@ -4376,6 +4412,9 @@ func TestGenerateMatchesConfig(t *testing.T) {
 				ProxySSLName:            "tea.default.svc",
 				ProxyPassRequestHeaders: true,
 				ServiceName:             "tea",
+				IsVSR:                   false,
+				VSRName:                 "",
+				VSRNamespace:            "",
 			},
 		},
 		InternalRedirectLocation: version2.InternalRedirectLocation{
@@ -4422,6 +4461,9 @@ func TestGenerateMatchesConfig(t *testing.T) {
 		locSnippets,
 		enableSnippets,
 		0,
+		false,
+		"",
+		"",
 	)
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("generateMatchesConfig() returned \n%+v but expected \n%+v", result, expected)
@@ -4605,6 +4647,9 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxySSLName:            "coffee-v1.default.svc",
 				ProxyPassRequestHeaders: true,
 				ServiceName:             "coffee-v1",
+				IsVSR:                   true,
+				VSRName:                 "coffee",
+				VSRNamespace:            "default",
 			},
 			{
 				Path:                     "/internal_location_splits_2_split_1",
@@ -4629,6 +4674,9 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxySSLName:            "coffee-v2.default.svc",
 				ProxyPassRequestHeaders: true,
 				ServiceName:             "coffee-v2",
+				IsVSR:                   true,
+				VSRName:                 "coffee",
+				VSRNamespace:            "default",
 			},
 			{
 				Path:                     "/internal_location_splits_3_split_0",
@@ -4653,6 +4701,9 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxySSLName:            "coffee-v2.default.svc",
 				ProxyPassRequestHeaders: true,
 				ServiceName:             "coffee-v2",
+				IsVSR:                   true,
+				VSRName:                 "coffee",
+				VSRNamespace:            "default",
 			},
 			{
 				Path:                     "/internal_location_splits_3_split_1",
@@ -4677,6 +4728,9 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxySSLName:            "coffee-v1.default.svc",
 				ProxyPassRequestHeaders: true,
 				ServiceName:             "coffee-v1",
+				IsVSR:                   true,
+				VSRName:                 "coffee",
+				VSRNamespace:            "default",
 			},
 			{
 				Path:                     "/internal_location_splits_4_split_0",
@@ -4701,6 +4755,9 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxySSLName:            "coffee-v1.default.svc",
 				ProxyPassRequestHeaders: true,
 				ServiceName:             "coffee-v1",
+				IsVSR:                   true,
+				VSRName:                 "coffee",
+				VSRNamespace:            "default",
 			},
 			{
 				Path:                     "/internal_location_splits_4_split_1",
@@ -4725,6 +4782,9 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxySSLName:            "coffee-v2.default.svc",
 				ProxyPassRequestHeaders: true,
 				ServiceName:             "coffee-v2",
+				IsVSR:                   true,
+				VSRName:                 "coffee",
+				VSRNamespace:            "default",
 			},
 		},
 		InternalRedirectLocation: version2.InternalRedirectLocation{
@@ -4797,6 +4857,9 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 		locSnippets,
 		enableSnippets,
 		0,
+		true,
+		"coffee",
+		"default",
 	)
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("generateMatchesConfig() returned \n%+v but expected \n%+v", result, expected)


### PR DESCRIPTION
### Proposed changes
This PR adds the k8s object variables to the log format for splits and matches.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
