### PR TITLE
Rename ingress and vs resource structs

### DIFF
--- a/internal/k8s/configuration.go
+++ b/internal/k8s/configuration.go
@@ -81,14 +81,14 @@ func compareConfigurationProblems(problem1 *ConfigurationProblem, problem2 *Conf
 		problem1.Message == problem2.Message
 }
 
-// FullIngress holds an Ingress resource with its minions. It implements the Resource interface.
-type FullIngress struct {
+// IngressConfiguration holds an Ingress resource with its minions. It implements the Resource interface.
+type IngressConfiguration struct {
 	// Ingress holds a regular Ingress or a master Ingress.
 	Ingress *networking.Ingress
 	// IsMaster is true when the Ingress is a master.
 	IsMaster bool
 	// Minions contains minions if the Ingress is a master.
-	Minions []*FullMinion
+	Minions []*MinionConfiguration
 	// ValidHosts marks the hosts of the Ingress as valid (true) or invalid (false).
 	// Regular Ingress resources can have multiple hosts. It is possible that some of the hosts are taken by other
 	// resources. In that case, those hosts will be marked as invalid.
@@ -99,9 +99,9 @@ type FullIngress struct {
 	ChildWarnings map[string][]string
 }
 
-// NewRegularFullIngress creates a FullIngress from a regular Ingress resource.
-func NewRegularFullIngress(ing *networking.Ingress) *FullIngress {
-	return &FullIngress{
+// NewRegularIngressConfiguration creates an IngressConfiguration from an Ingress resource.
+func NewRegularIngressConfiguration(ing *networking.Ingress) *IngressConfiguration {
+	return &IngressConfiguration{
 		Ingress:       ing,
 		IsMaster:      false,
 		ValidHosts:    make(map[string]bool),
@@ -109,9 +109,9 @@ func NewRegularFullIngress(ing *networking.Ingress) *FullIngress {
 	}
 }
 
-// NewMasterFullIngress creates a FullIngress from a master Ingress resource.
-func NewMasterFullIngress(ing *networking.Ingress, minions []*FullMinion, childWarnings map[string][]string) *FullIngress {
-	return &FullIngress{
+// NewMasterIngressConfiguration creates an IngressConfiguration from a master Ingress resource.
+func NewMasterIngressConfiguration(ing *networking.Ingress, minions []*MinionConfiguration, childWarnings map[string][]string) *IngressConfiguration {
+	return &IngressConfiguration{
 		Ingress:       ing,
 		IsMaster:      true,
 		Minions:       minions,
@@ -121,61 +121,61 @@ func NewMasterFullIngress(ing *networking.Ingress, minions []*FullMinion, childW
 }
 
 // GetObjectMeta returns the resource ObjectMeta.
-func (fi *FullIngress) GetObjectMeta() *metav1.ObjectMeta {
-	return &fi.Ingress.ObjectMeta
+func (ic *IngressConfiguration) GetObjectMeta() *metav1.ObjectMeta {
+	return &ic.Ingress.ObjectMeta
 }
 
 // GetKeyWithKind returns the key of the resource with its kind. For example, Ingress/my-namespace/my-name.
-func (fi *FullIngress) GetKeyWithKind() string {
-	key := getResourceKey(&fi.Ingress.ObjectMeta)
+func (ic *IngressConfiguration) GetKeyWithKind() string {
+	key := getResourceKey(&ic.Ingress.ObjectMeta)
 	return fmt.Sprintf("%s/%s", ingressKind, key)
 }
 
 // AcquireHost acquires the host for this resource.
-func (fi *FullIngress) AcquireHost(host string) {
-	fi.ValidHosts[host] = true
+func (ic *IngressConfiguration) AcquireHost(host string) {
+	ic.ValidHosts[host] = true
 }
 
 // ReleaseHost releases the host.
-func (fi *FullIngress) ReleaseHost(host string) {
-	fi.ValidHosts[host] = false
+func (ic *IngressConfiguration) ReleaseHost(host string) {
+	ic.ValidHosts[host] = false
 }
 
 // Wins tells if this resource wins over the specified resource.
-func (fi *FullIngress) Wins(resource Resource) bool {
-	return chooseObjectMetaWinner(fi.GetObjectMeta(), resource.GetObjectMeta())
+func (ic *IngressConfiguration) Wins(resource Resource) bool {
+	return chooseObjectMetaWinner(ic.GetObjectMeta(), resource.GetObjectMeta())
 }
 
 // AddWarning adds a warning.
-func (fi *FullIngress) AddWarning(warning string) {
-	fi.Warnings = append(fi.Warnings, warning)
+func (ic *IngressConfiguration) AddWarning(warning string) {
+	ic.Warnings = append(ic.Warnings, warning)
 }
 
-// IsEqual tests if the FullIngress is equal to the resource.
-func (fi *FullIngress) IsEqual(resource Resource) bool {
-	fullIngress, ok := resource.(*FullIngress)
+// IsEqual tests if the IngressConfiguration is equal to the resource.
+func (ic *IngressConfiguration) IsEqual(resource Resource) bool {
+	ingConfig, ok := resource.(*IngressConfiguration)
 	if !ok {
 		return false
 	}
 
-	if !compareObjectMetasWithAnnotations(&fi.Ingress.ObjectMeta, &fullIngress.Ingress.ObjectMeta) {
+	if !compareObjectMetasWithAnnotations(&ic.Ingress.ObjectMeta, &ingConfig.Ingress.ObjectMeta) {
 		return false
 	}
 
-	if !reflect.DeepEqual(fi.ValidHosts, fullIngress.ValidHosts) {
+	if !reflect.DeepEqual(ic.ValidHosts, ingConfig.ValidHosts) {
 		return false
 	}
 
-	if fi.IsMaster != fullIngress.IsMaster {
+	if ic.IsMaster != ingConfig.IsMaster {
 		return false
 	}
 
-	if len(fi.Minions) != len(fullIngress.Minions) {
+	if len(ic.Minions) != len(ingConfig.Minions) {
 		return false
 	}
 
-	for i := range fi.Minions {
-		if !compareObjectMetasWithAnnotations(&fi.Minions[i].Ingress.ObjectMeta, &fullIngress.Minions[i].Ingress.ObjectMeta) {
+	for i := range ic.Minions {
+		if !compareObjectMetasWithAnnotations(&ic.Minions[i].Ingress.ObjectMeta, &ingConfig.Minions[i].Ingress.ObjectMeta) {
 			return false
 		}
 	}
@@ -183,8 +183,8 @@ func (fi *FullIngress) IsEqual(resource Resource) bool {
 	return true
 }
 
-// FullMinion holds a Minion resource.
-type FullMinion struct {
+// MinionConfiguration holds a Minion resource.
+type MinionConfiguration struct {
 	// Ingress is the Ingress behind a minion.
 	Ingress *networking.Ingress
 	// ValidPaths marks the paths of the Ingress as valid (true) or invalid (false).
@@ -193,24 +193,24 @@ type FullMinion struct {
 	ValidPaths map[string]bool
 }
 
-// NewFullMinion creates a new FullMinion.
-func NewFullMinion(ing *networking.Ingress) *FullMinion {
-	return &FullMinion{
+// NewMinionConfiguration creates a new MinionConfiguration.
+func NewMinionConfiguration(ing *networking.Ingress) *MinionConfiguration {
+	return &MinionConfiguration{
 		Ingress:    ing,
 		ValidPaths: make(map[string]bool),
 	}
 }
 
-// FullVirtualServer holds a VirtualServer along with its VirtualServerRoutes.
-type FullVirtualServer struct {
+// VirtualServerConfiguration holds a VirtualServer along with its VirtualServerRoutes.
+type VirtualServerConfiguration struct {
 	VirtualServer       *conf_v1.VirtualServer
 	VirtualServerRoutes []*conf_v1.VirtualServerRoute
 	Warnings            []string
 }
 
-// NewFullVirtualServer creates a NewFullVirtualServer.
-func NewFullVirtualServer(vs *conf_v1.VirtualServer, vsrs []*conf_v1.VirtualServerRoute, warnings []string) *FullVirtualServer {
-	return &FullVirtualServer{
+// NewVirtualServerConfiguration creates a VirtualServerConfiguration.
+func NewVirtualServerConfiguration(vs *conf_v1.VirtualServer, vsrs []*conf_v1.VirtualServerRoute, warnings []string) *VirtualServerConfiguration {
+	return &VirtualServerConfiguration{
 		VirtualServer:       vs,
 		VirtualServerRoutes: vsrs,
 		Warnings:            warnings,
@@ -218,54 +218,54 @@ func NewFullVirtualServer(vs *conf_v1.VirtualServer, vsrs []*conf_v1.VirtualServ
 }
 
 // GetObjectMeta returns the resource ObjectMeta.
-func (fvs *FullVirtualServer) GetObjectMeta() *metav1.ObjectMeta {
-	return &fvs.VirtualServer.ObjectMeta
+func (vsc *VirtualServerConfiguration) GetObjectMeta() *metav1.ObjectMeta {
+	return &vsc.VirtualServer.ObjectMeta
 }
 
 // GetKeyWithKind returns the key of the resource with its kind. For example, VirtualServer/my-namespace/my-name.
-func (fvs *FullVirtualServer) GetKeyWithKind() string {
-	key := getResourceKey(&fvs.VirtualServer.ObjectMeta)
+func (vsc *VirtualServerConfiguration) GetKeyWithKind() string {
+	key := getResourceKey(&vsc.VirtualServer.ObjectMeta)
 	return fmt.Sprintf("%s/%s", virtualServerKind, key)
 }
 
 // AcquireHost acquires the host for this resource.
-func (fvs *FullVirtualServer) AcquireHost(host string) {
+func (vsc *VirtualServerConfiguration) AcquireHost(host string) {
 	// we do nothing because we don't need to track which host belongs to VirtualServer, in contrast with the Ingress resource.
 }
 
 // ReleaseHost releases the host.
-func (fvs *FullVirtualServer) ReleaseHost(host string) {
+func (vsc *VirtualServerConfiguration) ReleaseHost(host string) {
 	// we do nothing because we don't need to track which host belongs to VirtualServer, in contrast with the Ingress resource.
 }
 
 // Wins tells if this resource wins over the specified resource.
 // It is used to determine which resource should win over a host.
-func (fvs *FullVirtualServer) Wins(resource Resource) bool {
-	return chooseObjectMetaWinner(fvs.GetObjectMeta(), resource.GetObjectMeta())
+func (vsc *VirtualServerConfiguration) Wins(resource Resource) bool {
+	return chooseObjectMetaWinner(vsc.GetObjectMeta(), resource.GetObjectMeta())
 }
 
 // AddWarning adds a warning.
-func (fvs *FullVirtualServer) AddWarning(warning string) {
-	fvs.Warnings = append(fvs.Warnings, warning)
+func (vsc *VirtualServerConfiguration) AddWarning(warning string) {
+	vsc.Warnings = append(vsc.Warnings, warning)
 }
 
-// IsEqual tests if the FullVirtualServer is equal to the resource.
-func (fvs *FullVirtualServer) IsEqual(resource Resource) bool {
-	fullVS, ok := resource.(*FullVirtualServer)
+// IsEqual tests if the VirtualServerConfiguration is equal to the resource.
+func (vsc *VirtualServerConfiguration) IsEqual(resource Resource) bool {
+	vsConfig, ok := resource.(*VirtualServerConfiguration)
 	if !ok {
 		return false
 	}
 
-	if !compareObjectMetas(&fvs.VirtualServer.ObjectMeta, &fullVS.VirtualServer.ObjectMeta) {
+	if !compareObjectMetas(&vsc.VirtualServer.ObjectMeta, &vsConfig.VirtualServer.ObjectMeta) {
 		return false
 	}
 
-	if len(fvs.VirtualServerRoutes) != len(fullVS.VirtualServerRoutes) {
+	if len(vsc.VirtualServerRoutes) != len(vsConfig.VirtualServerRoutes) {
 		return false
 	}
 
-	for i := range fvs.VirtualServerRoutes {
-		if !compareObjectMetas(&fvs.VirtualServerRoutes[i].ObjectMeta, &fullVS.VirtualServerRoutes[i].ObjectMeta) {
+	for i := range vsc.VirtualServerRoutes {
+		if !compareObjectMetas(&vsc.VirtualServerRoutes[i].ObjectMeta, &vsConfig.VirtualServerRoutes[i].ObjectMeta) {
 			return false
 		}
 	}
@@ -534,11 +534,11 @@ func (c *Configuration) GetResourcesWithFilter(filter resourceFilter) []Resource
 
 	for _, r := range c.hosts {
 		switch r.(type) {
-		case *FullIngress:
+		case *IngressConfiguration:
 			if filter.Ingresses {
 				resources[r.GetKeyWithKind()] = r
 			}
-		case *FullVirtualServer:
+		case *VirtualServerConfiguration:
 			if filter.VirtualServers {
 				resources[r.GetKeyWithKind()] = r
 			}
@@ -594,7 +594,7 @@ func (c *Configuration) findResourcesForResourceReference(namespace string, name
 		r := c.hosts[h]
 
 		switch impl := r.(type) {
-		case *FullIngress:
+		case *IngressConfiguration:
 			if checker.IsReferencedByIngress(namespace, name, impl.Ingress) {
 				result = append(result, r)
 				continue
@@ -606,7 +606,7 @@ func (c *Configuration) findResourcesForResourceReference(namespace string, name
 					break
 				}
 			}
-		case *FullVirtualServer:
+		case *VirtualServerConfiguration:
 			if checker.IsReferencedByVirtualServer(namespace, name, impl.VirtualServer) {
 				result = append(result, r)
 				continue
@@ -689,7 +689,7 @@ func (c *Configuration) addProblemsForResourcesWithoutActiveHost(resources map[s
 		r := resources[k]
 
 		switch impl := r.(type) {
-		case *FullIngress:
+		case *IngressConfiguration:
 			atLeastOneValidHost := false
 			for _, v := range impl.ValidHosts {
 				if v {
@@ -706,7 +706,7 @@ func (c *Configuration) addProblemsForResourcesWithoutActiveHost(resources map[s
 				}
 				problems[r.GetKeyWithKind()] = p
 			}
-		case *FullVirtualServer:
+		case *VirtualServerConfiguration:
 			res, exists := c.hosts[impl.VirtualServer.Spec.Host]
 
 			if !exists {
@@ -735,9 +735,9 @@ func (c *Configuration) addProblemsForOrphanMinions(problems map[string]Configur
 		}
 
 		r, exists := c.hosts[ing.Spec.Rules[0].Host]
-		fullIngress, ok := r.(*FullIngress)
+		ingressConf, ok := r.(*IngressConfiguration)
 
-		if !exists || !ok || !fullIngress.IsMaster {
+		if !exists || !ok || !ingressConf.IsMaster {
 			p := ConfigurationProblem{
 				Object:  ing,
 				IsError: false,
@@ -755,7 +755,7 @@ func (c *Configuration) addProblemsForOrphanOrIgnoredVsrs(problems map[string]Co
 		vsr := c.virtualServerRoutes[key]
 
 		r, exists := c.hosts[vsr.Spec.Host]
-		fullVS, ok := r.(*FullVirtualServer)
+		vsConfig, ok := r.(*VirtualServerConfiguration)
 
 		if !exists || !ok {
 			p := ConfigurationProblem{
@@ -770,7 +770,7 @@ func (c *Configuration) addProblemsForOrphanOrIgnoredVsrs(problems map[string]Co
 		}
 
 		found := false
-		for _, v := range fullVS.VirtualServerRoutes {
+		for _, v := range vsConfig.VirtualServerRoutes {
 			if vsr.Namespace == v.Namespace && vsr.Name == v.Name {
 				found = true
 				break
@@ -782,7 +782,7 @@ func (c *Configuration) addProblemsForOrphanOrIgnoredVsrs(problems map[string]Co
 				Object:  vsr,
 				IsError: false,
 				Reason:  "Ignored",
-				Message: fmt.Sprintf("VirtualServer %s ignores VirtualServerRoute", getResourceKey(&fullVS.VirtualServer.ObjectMeta)),
+				Message: fmt.Sprintf("VirtualServer %s ignores VirtualServerRoute", getResourceKey(&vsConfig.VirtualServer.ObjectMeta)),
 			}
 			k := getResourceKeyWithKind(virtualServerRouteKind, &vsr.ObjectMeta)
 			problems[k] = p
@@ -892,13 +892,13 @@ func (c *Configuration) buildHostsAndResources() (newHosts map[string]Resource, 
 			continue
 		}
 
-		var resource *FullIngress
+		var resource *IngressConfiguration
 
 		if isMaster(ing) {
-			minions, childWarnings := c.buildFullMinions(ing.Spec.Rules[0].Host)
-			resource = NewMasterFullIngress(ing, minions, childWarnings)
+			minions, childWarnings := c.buildMinionConfigs(ing.Spec.Rules[0].Host)
+			resource = NewMasterIngressConfiguration(ing, minions, childWarnings)
 		} else {
-			resource = NewRegularFullIngress(ing)
+			resource = NewRegularIngressConfiguration(ing)
 		}
 
 		newResources[resource.GetKeyWithKind()] = resource
@@ -930,7 +930,7 @@ func (c *Configuration) buildHostsAndResources() (newHosts map[string]Resource, 
 		vs := c.virtualServers[key]
 
 		vsrs, warnings := c.buildVirtualServerRoutes(vs)
-		resource := NewFullVirtualServer(vs, vsrs, warnings)
+		resource := NewVirtualServerConfiguration(vs, vsrs, warnings)
 
 		newResources[resource.GetKeyWithKind()] = resource
 
@@ -956,10 +956,10 @@ func (c *Configuration) buildHostsAndResources() (newHosts map[string]Resource, 
 	return newHosts, newResources
 }
 
-func (c *Configuration) buildFullMinions(masterHost string) ([]*FullMinion, map[string][]string) {
-	var fullMinions []*FullMinion
+func (c *Configuration) buildMinionConfigs(masterHost string) ([]*MinionConfiguration, map[string][]string) {
+	var minionConfigs []*MinionConfiguration
 	childWarnings := make(map[string][]string)
-	paths := make(map[string]*FullMinion)
+	paths := make(map[string]*MinionConfiguration)
 
 	for _, minionKey := range getSortedIngressKeys(c.ingresses) {
 		ingress := c.ingresses[minionKey]
@@ -972,35 +972,35 @@ func (c *Configuration) buildFullMinions(masterHost string) ([]*FullMinion, map[
 			continue
 		}
 
-		fullMinion := NewFullMinion(ingress)
+		minionConfig := NewMinionConfiguration(ingress)
 
 		for _, p := range ingress.Spec.Rules[0].HTTP.Paths {
 			holder, exists := paths[p.Path]
 			if !exists {
-				paths[p.Path] = fullMinion
-				fullMinion.ValidPaths[p.Path] = true
+				paths[p.Path] = minionConfig
+				minionConfig.ValidPaths[p.Path] = true
 				continue
 			}
 
 			warning := fmt.Sprintf("path %s is taken by another resource", p.Path)
 
 			if !chooseObjectMetaWinner(&holder.Ingress.ObjectMeta, &ingress.ObjectMeta) {
-				paths[p.Path] = fullMinion
-				fullMinion.ValidPaths[p.Path] = true
+				paths[p.Path] = minionConfig
+				minionConfig.ValidPaths[p.Path] = true
 
 				holder.ValidPaths[p.Path] = false
 				key := getResourceKey(&holder.Ingress.ObjectMeta)
 				childWarnings[key] = append(childWarnings[key], warning)
 			} else {
-				key := getResourceKey(&fullMinion.Ingress.ObjectMeta)
+				key := getResourceKey(&minionConfig.Ingress.ObjectMeta)
 				childWarnings[key] = append(childWarnings[key], warning)
 			}
 		}
 
-		fullMinions = append(fullMinions, fullMinion)
+		minionConfigs = append(minionConfigs, minionConfig)
 	}
 
-	return fullMinions, childWarnings
+	return minionConfigs, childWarnings
 }
 
 func (c *Configuration) buildVirtualServerRoutes(vs *conf_v1.VirtualServer) ([]*conf_v1.VirtualServerRoute, []string) {

--- a/internal/k8s/configuration_test.go
+++ b/internal/k8s/configuration_test.go
@@ -32,7 +32,7 @@ func TestAddIngressForRegularIngress(t *testing.T) {
 	expectedChanges := []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: ing,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
@@ -58,7 +58,7 @@ func TestAddIngressForRegularIngress(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: updatedIng,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
@@ -94,7 +94,7 @@ func TestAddIngressForRegularIngress(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: updatedIng,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
@@ -118,7 +118,7 @@ func TestAddIngressForRegularIngress(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: updatedIng,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
@@ -150,7 +150,7 @@ func TestAddIngressForRegularIngress(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: updatedHostIng,
 				ValidHosts: map[string]bool{
 					"bar.example.com": true,
@@ -173,7 +173,7 @@ func TestAddIngressForRegularIngress(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: updatedHostIng,
 				ValidHosts: map[string]bool{
 					"bar.example.com": true,
@@ -260,13 +260,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: minion1,
 						ValidPaths: map[string]bool{
@@ -294,13 +294,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: minion1,
 						ValidPaths: map[string]bool{
@@ -335,13 +335,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: updatedMinion1,
 						ValidPaths: map[string]bool{
@@ -387,13 +387,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: minion2,
 						ValidPaths: map[string]bool{
@@ -427,13 +427,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: updatedMinion1,
 						ValidPaths: map[string]bool{
@@ -470,13 +470,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: updatedMinion1,
 						ValidPaths: map[string]bool{
@@ -513,13 +513,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: updatedMaster,
 				ValidHosts: map[string]bool{
 					"bar.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: updatedMinion2,
 						ValidPaths: map[string]bool{
@@ -551,13 +551,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: updatedMinion1,
 						ValidPaths: map[string]bool{
@@ -590,13 +590,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: updatedMinion1,
 						ValidPaths: map[string]bool{
@@ -629,13 +629,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: minion2,
 						ValidPaths: map[string]bool{
@@ -662,13 +662,13 @@ func TestAddIngressForMergeableIngresses(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: minion2,
 						ValidPaths: map[string]bool{
@@ -719,7 +719,7 @@ func TestMinionPathCollisions(t *testing.T) {
 	expectedChanges := []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
@@ -745,13 +745,13 @@ func TestMinionPathCollisions(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: minion1,
 						ValidPaths: map[string]bool{
@@ -779,13 +779,13 @@ func TestMinionPathCollisions(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: minion1,
 						ValidPaths: map[string]bool{
@@ -820,13 +820,13 @@ func TestMinionPathCollisions(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: master,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
 				},
 				IsMaster: true,
-				Minions: []*FullMinion{
+				Minions: []*MinionConfiguration{
 					{
 						Ingress: minion2,
 						ValidPaths: map[string]bool{
@@ -876,7 +876,7 @@ func TestAddIngressWithIncorrectClass(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: updatedIng,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
@@ -900,7 +900,7 @@ func TestAddIngressWithIncorrectClass(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress: updatedIng,
 				ValidHosts: map[string]bool{
 					"foo.example.com": true,
@@ -932,7 +932,7 @@ func TestAddVirtualServer(t *testing.T) {
 	expectedChanges := []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: vs,
 			},
 		},
@@ -955,7 +955,7 @@ func TestAddVirtualServer(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: updatedVS,
 			},
 		},
@@ -978,7 +978,7 @@ func TestAddVirtualServer(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: updatedVS,
 			},
 			Error: "spec.host: Required value",
@@ -998,7 +998,7 @@ func TestAddVirtualServer(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: updatedVS,
 			},
 		},
@@ -1021,7 +1021,7 @@ func TestAddVirtualServer(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: updatedHostVS,
 			},
 		},
@@ -1040,7 +1040,7 @@ func TestAddVirtualServer(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: updatedHostVS,
 			},
 		},
@@ -1107,7 +1107,7 @@ func TestAddInvalidVirtualServerWithIncorrectClass(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: updatedVS,
 			},
 		},
@@ -1127,7 +1127,7 @@ func TestAddInvalidVirtualServerWithIncorrectClass(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: updatedVS,
 			},
 		},
@@ -1199,7 +1199,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr1},
 				Warnings:            []string{"VirtualServerRoute default/virtualserverroute-2 doesn't exist or invalid"},
@@ -1223,7 +1223,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr1, vsr2},
 			},
@@ -1247,7 +1247,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{updatedVSR1, vsr2},
 			},
@@ -1271,7 +1271,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr2},
 				Warnings:            []string{"VirtualServerRoute default/virtualserverroute-1 doesn't exist or invalid"},
@@ -1300,7 +1300,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr1, vsr2},
 			},
@@ -1324,7 +1324,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr2},
 				Warnings:            []string{"VirtualServerRoute default/virtualserverroute-1 is invalid: spec.subroutes[0]: Invalid value: \"/\": must start with '/first'"},
@@ -1352,7 +1352,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr1, vsr2},
 			},
@@ -1376,7 +1376,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr1},
 				Warnings:            []string{"VirtualServerRoute default/virtualserverroute-2 is invalid: spec.host: Invalid value: \"bar.example.com\": must be equal to 'foo.example.com'"},
@@ -1407,7 +1407,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       updatedVS,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{updatedVSR2},
 				Warnings:            []string{"VirtualServerRoute default/virtualserverroute-1 is invalid: spec.host: Invalid value: \"foo.example.com\": must be equal to 'bar.example.com'"},
@@ -1435,7 +1435,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr1},
 				Warnings:            []string{"VirtualServerRoute default/virtualserverroute-2 is invalid: spec.host: Invalid value: \"bar.example.com\": must be equal to 'foo.example.com'"},
@@ -1463,7 +1463,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr1, vsr2},
 			},
@@ -1484,7 +1484,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr2},
 				Warnings:            []string{"VirtualServerRoute default/virtualserverroute-1 doesn't exist or invalid"},
@@ -1506,7 +1506,7 @@ func TestAddVirtualServerWithVirtualServerRoutes(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer:       vs,
 				VirtualServerRoutes: []*conf_v1.VirtualServerRoute{vsr2},
 				Warnings:            []string{"VirtualServerRoute default/virtualserverroute-1 doesn't exist or invalid"},
@@ -1615,7 +1615,7 @@ func TestHostCollisions(t *testing.T) {
 	expectedChanges := []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: vs,
 			},
 		},
@@ -1635,14 +1635,14 @@ func TestHostCollisions(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: vs,
 				Warnings:      []string{"host foo.example.com is taken by another resource"},
 			},
 		},
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress:       regularIng,
 				ValidHosts:    map[string]bool{"foo.example.com": true, "bar.example.com": true},
 				ChildWarnings: map[string][]string{},
@@ -1671,7 +1671,7 @@ func TestHostCollisions(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress:       regularIng,
 				ValidHosts:    map[string]bool{"bar.example.com": true},
 				Warnings:      []string{"host foo.example.com is taken by another resource"},
@@ -1680,7 +1680,7 @@ func TestHostCollisions(t *testing.T) {
 		},
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress:       masterIng,
 				IsMaster:      true,
 				ValidHosts:    map[string]bool{"foo.example.com": true},
@@ -1735,7 +1735,7 @@ func TestHostCollisions(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress:       masterIng,
 				IsMaster:      true,
 				ValidHosts:    map[string]bool{"foo.example.com": true},
@@ -1744,7 +1744,7 @@ func TestHostCollisions(t *testing.T) {
 		},
 		{
 			Op: AddOrUpdate,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress:       regularIng,
 				ValidHosts:    map[string]bool{"foo.example.com": true, "bar.example.com": true},
 				ChildWarnings: map[string][]string{},
@@ -1766,7 +1766,7 @@ func TestHostCollisions(t *testing.T) {
 	expectedChanges = []ResourceChange{
 		{
 			Op: Delete,
-			Resource: &FullIngress{
+			Resource: &IngressConfiguration{
 				Ingress:       regularIng,
 				ValidHosts:    map[string]bool{"foo.example.com": true, "bar.example.com": true},
 				ChildWarnings: map[string][]string{},
@@ -1774,7 +1774,7 @@ func TestHostCollisions(t *testing.T) {
 		},
 		{
 			Op: AddOrUpdate,
-			Resource: &FullVirtualServer{
+			Resource: &VirtualServerConfiguration{
 				VirtualServer: vs,
 			},
 		},
@@ -1938,11 +1938,11 @@ func TestChooseObjectMetaWinner(t *testing.T) {
 }
 
 func TestSquashResourceChanges(t *testing.T) {
-	fullIng := &FullIngress{
+	ingConfig := &IngressConfiguration{
 		Ingress: createTestIngress("test", "foo.example.com"),
 	}
 
-	fullVS := &FullVirtualServer{
+	vsConfig := &VirtualServerConfiguration{
 		VirtualServer: createTestVirtualServer("test", "bar.example.com"),
 	}
 
@@ -1955,17 +1955,17 @@ func TestSquashResourceChanges(t *testing.T) {
 			changes: []ResourceChange{
 				{
 					Op:       Delete,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 				{
 					Op:       Delete,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 			},
 			expected: []ResourceChange{
 				{
 					Op:       Delete,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 			},
 			msg: "squash deletes",
@@ -1974,17 +1974,17 @@ func TestSquashResourceChanges(t *testing.T) {
 			changes: []ResourceChange{
 				{
 					Op:       AddOrUpdate,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 				{
 					Op:       AddOrUpdate,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 			},
 			expected: []ResourceChange{
 				{
 					Op:       AddOrUpdate,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 			},
 			msg: "squash updates",
@@ -1993,17 +1993,17 @@ func TestSquashResourceChanges(t *testing.T) {
 			changes: []ResourceChange{
 				{
 					Op:       Delete,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 				{
 					Op:       AddOrUpdate,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 			},
 			expected: []ResourceChange{
 				{
 					Op:       AddOrUpdate,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 			},
 			msg: "squash update and delete",
@@ -2012,21 +2012,21 @@ func TestSquashResourceChanges(t *testing.T) {
 			changes: []ResourceChange{
 				{
 					Op:       Delete,
-					Resource: fullVS,
+					Resource: vsConfig,
 				},
 				{
 					Op:       AddOrUpdate,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 			},
 			expected: []ResourceChange{
 				{
 					Op:       Delete,
-					Resource: fullVS,
+					Resource: vsConfig,
 				},
 				{
 					Op:       AddOrUpdate,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 			},
 			msg: "preserve the order",
@@ -2035,21 +2035,21 @@ func TestSquashResourceChanges(t *testing.T) {
 			changes: []ResourceChange{
 				{
 					Op:       Delete,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 				{
 					Op:       AddOrUpdate,
-					Resource: fullVS,
+					Resource: vsConfig,
 				},
 			},
 			expected: []ResourceChange{
 				{
 					Op:       Delete,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 				{
 					Op:       AddOrUpdate,
-					Resource: fullVS,
+					Resource: vsConfig,
 				},
 			},
 			msg: "do not squash different resource with same ns/name",
@@ -2058,25 +2058,25 @@ func TestSquashResourceChanges(t *testing.T) {
 			changes: []ResourceChange{
 				{
 					Op:       Delete,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 				{
 					Op:       AddOrUpdate,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 				{
 					Op:       Delete,
-					Resource: fullVS,
+					Resource: vsConfig,
 				},
 			},
 			expected: []ResourceChange{
 				{
 					Op:       Delete,
-					Resource: fullVS,
+					Resource: vsConfig,
 				},
 				{
 					Op:       AddOrUpdate,
-					Resource: fullIng,
+					Resource: ingConfig,
 				},
 			},
 			msg: "squashed delete and update must follow delete",
@@ -2251,14 +2251,14 @@ func TestGetResources(t *testing.T) {
 	}
 }
 
-func TestIsEqualForFullIngresses(t *testing.T) {
+func TestIsEqualForIngressConfigurationes(t *testing.T) {
 	regularIng := createTestIngress("regular-ingress", "foo.example.com")
 
-	fullIngWithInvalidHost := NewRegularFullIngress(regularIng)
-	fullIngWithInvalidHost.ValidHosts["foo.example.com"] = false
+	ingConfigWithInvalidHost := NewRegularIngressConfiguration(regularIng)
+	ingConfigWithInvalidHost.ValidHosts["foo.example.com"] = false
 
-	fullIngWithUpdatedIsMaster := NewRegularFullIngress(regularIng)
-	fullIngWithUpdatedIsMaster.IsMaster = true
+	ingConfigWithUpdatedIsMaster := NewRegularIngressConfiguration(regularIng)
+	ingConfigWithUpdatedIsMaster.IsMaster = true
 
 	regularIngWithUpdatedGen := regularIng.DeepCopy()
 	regularIngWithUpdatedGen.Generation++
@@ -2276,69 +2276,69 @@ func TestIsEqualForFullIngresses(t *testing.T) {
 	minionIngWithUpdatedAnnotations.Annotations["new"] = "value"
 
 	tests := []struct {
-		fullIng1 *FullIngress
-		fullIng2 *FullIngress
-		expected bool
-		msg      string
+		ingConfig1 *IngressConfiguration
+		ingConfig2 *IngressConfiguration
+		expected   bool
+		msg        string
 	}{
 		{
-			fullIng1: NewRegularFullIngress(regularIng),
-			fullIng2: NewRegularFullIngress(regularIng),
-			expected: true,
-			msg:      "equal regular ingresses",
+			ingConfig1: NewRegularIngressConfiguration(regularIng),
+			ingConfig2: NewRegularIngressConfiguration(regularIng),
+			expected:   true,
+			msg:        "equal regular ingresses",
 		},
 		{
-			fullIng1: NewRegularFullIngress(regularIng),
-			fullIng2: fullIngWithInvalidHost,
-			expected: false,
-			msg:      "regular ingresses with different valid hosts",
+			ingConfig1: NewRegularIngressConfiguration(regularIng),
+			ingConfig2: ingConfigWithInvalidHost,
+			expected:   false,
+			msg:        "regular ingresses with different valid hosts",
 		},
 		{
-			fullIng1: NewRegularFullIngress(regularIng),
-			fullIng2: fullIngWithUpdatedIsMaster,
-			expected: false,
-			msg:      "regular ingresses with different IsMaster value",
+			ingConfig1: NewRegularIngressConfiguration(regularIng),
+			ingConfig2: ingConfigWithUpdatedIsMaster,
+			expected:   false,
+			msg:        "regular ingresses with different IsMaster value",
 		},
 		{
-			fullIng1: NewRegularFullIngress(regularIng),
-			fullIng2: NewRegularFullIngress(regularIngWithUpdatedGen),
-			expected: false,
-			msg:      "regular ingresses with different generation",
+			ingConfig1: NewRegularIngressConfiguration(regularIng),
+			ingConfig2: NewRegularIngressConfiguration(regularIngWithUpdatedGen),
+			expected:   false,
+			msg:        "regular ingresses with different generation",
 		},
 		{
-			fullIng1: NewRegularFullIngress(regularIng),
-			fullIng2: NewRegularFullIngress(regularIngWithUpdatedAnnotations),
-			expected: false,
-			msg:      "regular ingresses with different annotations",
+			ingConfig1: NewRegularIngressConfiguration(regularIng),
+			ingConfig2: NewRegularIngressConfiguration(regularIngWithUpdatedAnnotations),
+			expected:   false,
+			msg:        "regular ingresses with different annotations",
 		},
 		{
-			fullIng1: NewMasterFullIngress(masterIng, []*FullMinion{NewFullMinion(minionIng)}, map[string][]string{}),
-			fullIng2: NewMasterFullIngress(masterIng, []*FullMinion{NewFullMinion(minionIng)}, map[string][]string{}),
-			expected: true,
-			msg:      "equal master ingresses",
+			ingConfig1: NewMasterIngressConfiguration(masterIng, []*MinionConfiguration{NewMinionConfiguration(minionIng)}, map[string][]string{}),
+			ingConfig2: NewMasterIngressConfiguration(masterIng, []*MinionConfiguration{NewMinionConfiguration(minionIng)}, map[string][]string{}),
+			expected:   true,
+			msg:        "equal master ingresses",
 		},
 		{
-			fullIng1: NewMasterFullIngress(masterIng, []*FullMinion{NewFullMinion(minionIng)}, map[string][]string{}),
-			fullIng2: NewMasterFullIngress(masterIng, []*FullMinion{}, map[string][]string{}),
-			expected: false,
-			msg:      "masters with different number of minions",
+			ingConfig1: NewMasterIngressConfiguration(masterIng, []*MinionConfiguration{NewMinionConfiguration(minionIng)}, map[string][]string{}),
+			ingConfig2: NewMasterIngressConfiguration(masterIng, []*MinionConfiguration{}, map[string][]string{}),
+			expected:   false,
+			msg:        "masters with different number of minions",
 		},
 		{
-			fullIng1: NewMasterFullIngress(masterIng, []*FullMinion{NewFullMinion(minionIng)}, map[string][]string{}),
-			fullIng2: NewMasterFullIngress(masterIng, []*FullMinion{NewFullMinion(minionIngWithUpdatedGen)}, map[string][]string{}),
-			expected: false,
-			msg:      "masters with minions with different generation",
+			ingConfig1: NewMasterIngressConfiguration(masterIng, []*MinionConfiguration{NewMinionConfiguration(minionIng)}, map[string][]string{}),
+			ingConfig2: NewMasterIngressConfiguration(masterIng, []*MinionConfiguration{NewMinionConfiguration(minionIngWithUpdatedGen)}, map[string][]string{}),
+			expected:   false,
+			msg:        "masters with minions with different generation",
 		},
 		{
-			fullIng1: NewMasterFullIngress(masterIng, []*FullMinion{NewFullMinion(minionIng)}, map[string][]string{}),
-			fullIng2: NewMasterFullIngress(masterIng, []*FullMinion{NewFullMinion(minionIngWithUpdatedAnnotations)}, map[string][]string{}),
-			expected: false,
-			msg:      "masters with minions with different annotations",
+			ingConfig1: NewMasterIngressConfiguration(masterIng, []*MinionConfiguration{NewMinionConfiguration(minionIng)}, map[string][]string{}),
+			ingConfig2: NewMasterIngressConfiguration(masterIng, []*MinionConfiguration{NewMinionConfiguration(minionIngWithUpdatedAnnotations)}, map[string][]string{}),
+			expected:   false,
+			msg:        "masters with minions with different annotations",
 		},
 	}
 
 	for _, test := range tests {
-		result := test.fullIng1.IsEqual(test.fullIng2)
+		result := test.ingConfig1.IsEqual(test.ingConfig2)
 		if result != test.expected {
 			t.Errorf("IsEqual() returned %v but expected %v for the case of %s", result, test.expected, test.msg)
 		}
@@ -2364,39 +2364,39 @@ func TestIsEqualForVirtualServers(t *testing.T) {
 	vsrWithUpdatedGen.Generation++
 
 	tests := []struct {
-		fullVS1  *FullVirtualServer
-		fullVS2  *FullVirtualServer
-		expected bool
-		msg      string
+		vsConfig1 *VirtualServerConfiguration
+		vsConfig2 *VirtualServerConfiguration
+		expected  bool
+		msg       string
 	}{
 		{
-			fullVS1:  NewFullVirtualServer(vs, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
-			fullVS2:  NewFullVirtualServer(vs, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
-			expected: true,
-			msg:      "equal virtual servers",
+			vsConfig1: NewVirtualServerConfiguration(vs, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
+			vsConfig2: NewVirtualServerConfiguration(vs, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
+			expected:  true,
+			msg:       "equal virtual servers",
 		},
 		{
-			fullVS1:  NewFullVirtualServer(vs, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
-			fullVS2:  NewFullVirtualServer(vsWithUpdatedGen, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
-			expected: false,
-			msg:      "virtual servers with different generation",
+			vsConfig1: NewVirtualServerConfiguration(vs, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
+			vsConfig2: NewVirtualServerConfiguration(vsWithUpdatedGen, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
+			expected:  false,
+			msg:       "virtual servers with different generation",
 		},
 		{
-			fullVS1:  NewFullVirtualServer(vs, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
-			fullVS2:  NewFullVirtualServer(vs, []*conf_v1.VirtualServerRoute{}, []string{}),
-			expected: false,
-			msg:      "virtual servers with different number of virtual server routes",
+			vsConfig1: NewVirtualServerConfiguration(vs, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
+			vsConfig2: NewVirtualServerConfiguration(vs, []*conf_v1.VirtualServerRoute{}, []string{}),
+			expected:  false,
+			msg:       "virtual servers with different number of virtual server routes",
 		},
 		{
-			fullVS1:  NewFullVirtualServer(vs, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
-			fullVS2:  NewFullVirtualServer(vs, []*conf_v1.VirtualServerRoute{vsrWithUpdatedGen}, []string{}),
-			expected: false,
-			msg:      "virtual servers with virtual server routes with different generation",
+			vsConfig1: NewVirtualServerConfiguration(vs, []*conf_v1.VirtualServerRoute{vsr}, []string{}),
+			vsConfig2: NewVirtualServerConfiguration(vs, []*conf_v1.VirtualServerRoute{vsrWithUpdatedGen}, []string{}),
+			expected:  false,
+			msg:       "virtual servers with virtual server routes with different generation",
 		},
 	}
 
 	for _, test := range tests {
-		result := test.fullVS1.IsEqual(test.fullVS2)
+		result := test.vsConfig1.IsEqual(test.vsConfig2)
 		if result != test.expected {
 			t.Errorf("IsEqual() returned %v but expected %v for the case of %s", result, test.expected, test.msg)
 		}
@@ -2404,10 +2404,10 @@ func TestIsEqualForVirtualServers(t *testing.T) {
 }
 
 func TestIsEqualForDifferentResources(t *testing.T) {
-	fullIng := NewRegularFullIngress(createTestIngress("ingress", "foo.example.com"))
-	fullVS := NewFullVirtualServer(createTestVirtualServer("virtualserver", "bar.example.com"), []*conf_v1.VirtualServerRoute{}, []string{})
+	ingConfig := NewRegularIngressConfiguration(createTestIngress("ingress", "foo.example.com"))
+	vsConfig := NewVirtualServerConfiguration(createTestVirtualServer("virtualserver", "bar.example.com"), []*conf_v1.VirtualServerRoute{}, []string{})
 
-	result := fullIng.IsEqual(fullVS)
+	result := ingConfig.IsEqual(vsConfig)
 	if result != false {
 		t.Error("IsEqual() for different resources returned true but expected false")
 	}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -588,11 +588,11 @@ func (lbc *LoadBalancerController) createExtendedResources(resources []Resource)
 
 	for _, r := range resources {
 		switch impl := r.(type) {
-		case *FullVirtualServer:
+		case *VirtualServerConfiguration:
 			vs := impl.VirtualServer
 			vsEx := lbc.createVirtualServerEx(vs, impl.VirtualServerRoutes)
 			virtualServersExes = append(virtualServersExes, vsEx)
-		case *FullIngress:
+		case *IngressConfiguration:
 			if impl.IsMaster {
 				mergeableIng := lbc.createMergeableIngresses(impl)
 				mergeableIngresses = append(mergeableIngresses, mergeableIng)
@@ -929,12 +929,12 @@ func (lbc *LoadBalancerController) processChanges(changes []ResourceChange) {
 	for _, c := range changes {
 		if c.Op == AddOrUpdate {
 			switch impl := c.Resource.(type) {
-			case *FullVirtualServer:
+			case *VirtualServerConfiguration:
 				vsEx := lbc.createVirtualServerEx(impl.VirtualServer, impl.VirtualServerRoutes)
 
 				warnings, addOrUpdateErr := lbc.configurator.AddOrUpdateVirtualServer(vsEx)
 				lbc.updateVirtualServerStatusAndEvents(impl, warnings, addOrUpdateErr)
-			case *FullIngress:
+			case *IngressConfiguration:
 				if impl.IsMaster {
 					mergeableIng := lbc.createMergeableIngresses(impl)
 
@@ -950,7 +950,7 @@ func (lbc *LoadBalancerController) processChanges(changes []ResourceChange) {
 			}
 		} else if c.Op == Delete {
 			switch impl := c.Resource.(type) {
-			case *FullVirtualServer:
+			case *VirtualServerConfiguration:
 				key := getResourceKey(&impl.VirtualServer.ObjectMeta)
 
 				deleteErr := lbc.configurator.DeleteVirtualServer(key)
@@ -966,7 +966,7 @@ func (lbc *LoadBalancerController) processChanges(changes []ResourceChange) {
 				if vsExists {
 					lbc.UpdateVirtualServerStatusAndEventsOnDelete(impl, c.Error, deleteErr)
 				}
-			case *FullIngress:
+			case *IngressConfiguration:
 				key := getResourceKey(&impl.Ingress.ObjectMeta)
 
 				glog.V(2).Infof("Deleting Ingress: %v\n", key)
@@ -989,7 +989,7 @@ func (lbc *LoadBalancerController) processChanges(changes []ResourceChange) {
 	}
 }
 
-func (lbc *LoadBalancerController) UpdateVirtualServerStatusAndEventsOnDelete(fullVS *FullVirtualServer, changeError string, deleteErr error) {
+func (lbc *LoadBalancerController) UpdateVirtualServerStatusAndEventsOnDelete(vsConfig *VirtualServerConfiguration, changeError string, deleteErr error) {
 	eventType := api_v1.EventTypeWarning
 	eventTitle := "Rejected"
 	eventWarningMessage := ""
@@ -999,8 +999,8 @@ func (lbc *LoadBalancerController) UpdateVirtualServerStatusAndEventsOnDelete(fu
 	if changeError != "" {
 		eventWarningMessage = fmt.Sprintf("with error: %s", changeError)
 		state = conf_v1.StateInvalid
-	} else if len(fullVS.Warnings) > 0 {
-		eventWarningMessage = fmt.Sprintf("with warning(s): %s", formatWarningMessages(fullVS.Warnings))
+	} else if len(vsConfig.Warnings) > 0 {
+		eventWarningMessage = fmt.Sprintf("with warning(s): %s", formatWarningMessages(vsConfig.Warnings))
 		state = conf_v1.StateWarning
 	}
 
@@ -1015,14 +1015,14 @@ func (lbc *LoadBalancerController) UpdateVirtualServerStatusAndEventsOnDelete(fu
 			state = conf_v1.StateInvalid
 		}
 
-		msg := fmt.Sprintf("VirtualServer %s was rejected %s", getResourceKey(&fullVS.VirtualServer.ObjectMeta), eventWarningMessage)
-		lbc.recorder.Eventf(fullVS.VirtualServer, eventType, eventTitle, msg)
+		msg := fmt.Sprintf("VirtualServer %s was rejected %s", getResourceKey(&vsConfig.VirtualServer.ObjectMeta), eventWarningMessage)
+		lbc.recorder.Eventf(vsConfig.VirtualServer, eventType, eventTitle, msg)
 
 		if lbc.reportVsVsrStatusEnabled() {
-			err := lbc.statusUpdater.UpdateVirtualServerStatus(fullVS.VirtualServer, state, eventTitle, msg)
+			err := lbc.statusUpdater.UpdateVirtualServerStatus(vsConfig.VirtualServer, state, eventTitle, msg)
 
 			if err != nil {
-				glog.Errorf("Error when updating the status for VirtualServer %v/%v: %v", fullVS.VirtualServer.Namespace, fullVS.VirtualServer.Name, err)
+				glog.Errorf("Error when updating the status for VirtualServer %v/%v: %v", vsConfig.VirtualServer.Namespace, vsConfig.VirtualServer.Name, err)
 			}
 		}
 	}
@@ -1031,15 +1031,15 @@ func (lbc *LoadBalancerController) UpdateVirtualServerStatusAndEventsOnDelete(fu
 	// for each VSR, a dedicated problem exists
 }
 
-func (lbc *LoadBalancerController) UpdateIngressStatusAndEventsOnDelete(fullIng *FullIngress, changeError string, deleteErr error) {
+func (lbc *LoadBalancerController) UpdateIngressStatusAndEventsOnDelete(ingConfig *IngressConfiguration, changeError string, deleteErr error) {
 	eventTitle := "Rejected"
 	eventWarningMessage := ""
 
 	// Ingress either became invalid or lost all its hosts
 	if changeError != "" {
 		eventWarningMessage = fmt.Sprintf("with error: %s", changeError)
-	} else if len(fullIng.Warnings) > 0 {
-		eventWarningMessage = fmt.Sprintf("with warning(s): %s", formatWarningMessages(fullIng.Warnings))
+	} else if len(ingConfig.Warnings) > 0 {
+		eventWarningMessage = fmt.Sprintf("with warning(s): %s", formatWarningMessages(ingConfig.Warnings))
 	}
 
 	// we don't need to report anything if eventWarningMessage is empty
@@ -1051,9 +1051,9 @@ func (lbc *LoadBalancerController) UpdateIngressStatusAndEventsOnDelete(fullIng 
 			eventWarningMessage = fmt.Sprintf("%s; but was not applied: %v", eventWarningMessage, deleteErr)
 		}
 
-		lbc.recorder.Eventf(fullIng.Ingress, api_v1.EventTypeWarning, eventTitle, "%v was rejected: %v", getResourceKey(&fullIng.Ingress.ObjectMeta), eventWarningMessage)
+		lbc.recorder.Eventf(ingConfig.Ingress, api_v1.EventTypeWarning, eventTitle, "%v was rejected: %v", getResourceKey(&ingConfig.Ingress.ObjectMeta), eventWarningMessage)
 		if lbc.reportStatusEnabled() {
-			err := lbc.statusUpdater.ClearIngressStatus(*fullIng.Ingress)
+			err := lbc.statusUpdater.ClearIngressStatus(*ingConfig.Ingress)
 			if err != nil {
 				glog.V(3).Infof("Error clearing Ingress status: %v", err)
 			}
@@ -1067,9 +1067,9 @@ func (lbc *LoadBalancerController) UpdateIngressStatusAndEventsOnDelete(fullIng 
 func (lbc *LoadBalancerController) updateResourcesStatusAndEvents(resources []Resource, warnings configs.Warnings, operationErr error) {
 	for _, r := range resources {
 		switch impl := r.(type) {
-		case *FullVirtualServer:
+		case *VirtualServerConfiguration:
 			lbc.updateVirtualServerStatusAndEvents(impl, warnings, operationErr)
-		case *FullIngress:
+		case *IngressConfiguration:
 			if impl.IsMaster {
 				lbc.updateMergeableIngressStatusAndEvents(impl, warnings, operationErr)
 			} else {
@@ -1079,18 +1079,18 @@ func (lbc *LoadBalancerController) updateResourcesStatusAndEvents(resources []Re
 	}
 }
 
-func (lbc *LoadBalancerController) updateMergeableIngressStatusAndEvents(fullIng *FullIngress, warnings configs.Warnings, operationErr error) {
+func (lbc *LoadBalancerController) updateMergeableIngressStatusAndEvents(ingConfig *IngressConfiguration, warnings configs.Warnings, operationErr error) {
 	eventType := api_v1.EventTypeNormal
 	eventTitle := "AddedOrUpdated"
 	eventWarningMessage := ""
 
-	if len(fullIng.Warnings) > 0 {
+	if len(ingConfig.Warnings) > 0 {
 		eventType = api_v1.EventTypeWarning
 		eventTitle = "AddedOrUpdatedWithWarning"
-		eventWarningMessage = fmt.Sprintf("with warning(s): %s", formatWarningMessages(fullIng.Warnings))
+		eventWarningMessage = fmt.Sprintf("with warning(s): %s", formatWarningMessages(ingConfig.Warnings))
 	}
 
-	if messages, ok := warnings[fullIng.Ingress]; ok {
+	if messages, ok := warnings[ingConfig.Ingress]; ok {
 		eventType = api_v1.EventTypeWarning
 		eventTitle = "AddedOrUpdatedWithWarning"
 		eventWarningMessage = fmt.Sprintf("%s; with warning(s): %v", eventWarningMessage, formatWarningMessages(messages))
@@ -1102,15 +1102,15 @@ func (lbc *LoadBalancerController) updateMergeableIngressStatusAndEvents(fullIng
 		eventWarningMessage = fmt.Sprintf("%s; but was not applied: %v", eventWarningMessage, operationErr)
 	}
 
-	msg := fmt.Sprintf("Configuration for %v was added or updated %s", getResourceKey(&fullIng.Ingress.ObjectMeta), eventWarningMessage)
-	lbc.recorder.Eventf(fullIng.Ingress, eventType, eventTitle, msg)
+	msg := fmt.Sprintf("Configuration for %v was added or updated %s", getResourceKey(&ingConfig.Ingress.ObjectMeta), eventWarningMessage)
+	lbc.recorder.Eventf(ingConfig.Ingress, eventType, eventTitle, msg)
 
-	for _, fm := range fullIng.Minions {
+	for _, fm := range ingConfig.Minions {
 		minionEventType := api_v1.EventTypeNormal
 		minionEventTitle := "AddedOrUpdated"
 		minionEventWarningMessage := ""
 
-		minionChangeWarnings := fullIng.ChildWarnings[getResourceKey(&fm.Ingress.ObjectMeta)]
+		minionChangeWarnings := ingConfig.ChildWarnings[getResourceKey(&fm.Ingress.ObjectMeta)]
 		if len(minionChangeWarnings) > 0 {
 			minionEventType = api_v1.EventTypeWarning
 			minionEventTitle = "AddedOrUpdatedWithWarning"
@@ -1134,9 +1134,9 @@ func (lbc *LoadBalancerController) updateMergeableIngressStatusAndEvents(fullIng
 	}
 
 	if lbc.reportStatusEnabled() {
-		ings := []networking.Ingress{*fullIng.Ingress}
+		ings := []networking.Ingress{*ingConfig.Ingress}
 
-		for _, fm := range fullIng.Minions {
+		for _, fm := range ingConfig.Minions {
 			ings = append(ings, *fm.Ingress)
 		}
 
@@ -1147,18 +1147,18 @@ func (lbc *LoadBalancerController) updateMergeableIngressStatusAndEvents(fullIng
 	}
 }
 
-func (lbc *LoadBalancerController) updateRegularIngressStatusAndEvents(fullIng *FullIngress, warnings configs.Warnings, operationErr error) {
+func (lbc *LoadBalancerController) updateRegularIngressStatusAndEvents(ingConfig *IngressConfiguration, warnings configs.Warnings, operationErr error) {
 	eventType := api_v1.EventTypeNormal
 	eventTitle := "AddedOrUpdated"
 	eventWarningMessage := ""
 
-	if len(fullIng.Warnings) > 0 {
+	if len(ingConfig.Warnings) > 0 {
 		eventType = api_v1.EventTypeWarning
 		eventTitle = "AddedOrUpdatedWithWarning"
-		eventWarningMessage = fmt.Sprintf("with warning(s): %s", formatWarningMessages(fullIng.Warnings))
+		eventWarningMessage = fmt.Sprintf("with warning(s): %s", formatWarningMessages(ingConfig.Warnings))
 	}
 
-	if messages, ok := warnings[fullIng.Ingress]; ok {
+	if messages, ok := warnings[ingConfig.Ingress]; ok {
 		eventType = api_v1.EventTypeWarning
 		eventTitle = "AddedOrUpdatedWithWarning"
 		eventWarningMessage = fmt.Sprintf("%s; with warning(s): %v", eventWarningMessage, formatWarningMessages(messages))
@@ -1170,31 +1170,31 @@ func (lbc *LoadBalancerController) updateRegularIngressStatusAndEvents(fullIng *
 		eventWarningMessage = fmt.Sprintf("%s; but was not applied: %v", eventWarningMessage, operationErr)
 	}
 
-	msg := fmt.Sprintf("Configuration for %v was added or updated %s", getResourceKey(&fullIng.Ingress.ObjectMeta), eventWarningMessage)
-	lbc.recorder.Eventf(fullIng.Ingress, eventType, eventTitle, msg)
+	msg := fmt.Sprintf("Configuration for %v was added or updated %s", getResourceKey(&ingConfig.Ingress.ObjectMeta), eventWarningMessage)
+	lbc.recorder.Eventf(ingConfig.Ingress, eventType, eventTitle, msg)
 
 	if lbc.reportStatusEnabled() {
-		err := lbc.statusUpdater.UpdateIngressStatus(*fullIng.Ingress)
+		err := lbc.statusUpdater.UpdateIngressStatus(*ingConfig.Ingress)
 		if err != nil {
 			glog.V(3).Infof("error updating ing status: %v", err)
 		}
 	}
 }
 
-func (lbc *LoadBalancerController) updateVirtualServerStatusAndEvents(fullVS *FullVirtualServer, warnings configs.Warnings, operationErr error) {
+func (lbc *LoadBalancerController) updateVirtualServerStatusAndEvents(vsConfig *VirtualServerConfiguration, warnings configs.Warnings, operationErr error) {
 	eventType := api_v1.EventTypeNormal
 	eventTitle := "AddedOrUpdated"
 	eventWarningMessage := ""
 	state := conf_v1.StateValid
 
-	if len(fullVS.Warnings) > 0 {
+	if len(vsConfig.Warnings) > 0 {
 		eventType = api_v1.EventTypeWarning
 		eventTitle = "AddedOrUpdatedWithWarning"
-		eventWarningMessage = fmt.Sprintf("with warning(s): %s", formatWarningMessages(fullVS.Warnings))
+		eventWarningMessage = fmt.Sprintf("with warning(s): %s", formatWarningMessages(vsConfig.Warnings))
 		state = conf_v1.StateWarning
 	}
 
-	if messages, ok := warnings[fullVS.VirtualServer]; ok {
+	if messages, ok := warnings[vsConfig.VirtualServer]; ok {
 		eventType = api_v1.EventTypeWarning
 		eventTitle = "AddedOrUpdatedWithWarning"
 		eventWarningMessage = fmt.Sprintf("%s; with warning(s): %v", eventWarningMessage, formatWarningMessages(messages))
@@ -1208,17 +1208,17 @@ func (lbc *LoadBalancerController) updateVirtualServerStatusAndEvents(fullVS *Fu
 		state = conf_v1.StateInvalid
 	}
 
-	msg := fmt.Sprintf("Configuration for %v was added or updated %s", getResourceKey(&fullVS.VirtualServer.ObjectMeta), eventWarningMessage)
-	lbc.recorder.Eventf(fullVS.VirtualServer, eventType, eventTitle, msg)
+	msg := fmt.Sprintf("Configuration for %v was added or updated %s", getResourceKey(&vsConfig.VirtualServer.ObjectMeta), eventWarningMessage)
+	lbc.recorder.Eventf(vsConfig.VirtualServer, eventType, eventTitle, msg)
 
 	if lbc.reportVsVsrStatusEnabled() {
-		err := lbc.statusUpdater.UpdateVirtualServerStatus(fullVS.VirtualServer, state, eventTitle, msg)
+		err := lbc.statusUpdater.UpdateVirtualServerStatus(vsConfig.VirtualServer, state, eventTitle, msg)
 		if err != nil {
-			glog.Errorf("Error when updating the status for VirtualServer %v/%v: %v", fullVS.VirtualServer.Namespace, fullVS.VirtualServer.Name, err)
+			glog.Errorf("Error when updating the status for VirtualServer %v/%v: %v", vsConfig.VirtualServer.Namespace, vsConfig.VirtualServer.Name, err)
 		}
 	}
 
-	for _, vsr := range fullVS.VirtualServerRoutes {
+	for _, vsr := range vsConfig.VirtualServerRoutes {
 		vsrEventType := api_v1.EventTypeNormal
 		vsrEventTitle := "AddedOrUpdated"
 		vsrEventWarningMessage := ""
@@ -1242,7 +1242,7 @@ func (lbc *LoadBalancerController) updateVirtualServerStatusAndEvents(fullVS *Fu
 		lbc.recorder.Eventf(vsr, vsrEventType, vsrEventTitle, msg)
 
 		if lbc.reportVsVsrStatusEnabled() {
-			vss := []*conf_v1.VirtualServer{fullVS.VirtualServer}
+			vss := []*conf_v1.VirtualServer{vsConfig.VirtualServer}
 			err := lbc.statusUpdater.UpdateVirtualServerRouteStatusWithReferencedBy(vsr, vsrState, vsrEventTitle, msg, vss)
 			if err != nil {
 				glog.Errorf("Error when updating the status for VirtualServerRoute %v/%v: %v", vsr.Namespace, vsr.Name, err)
@@ -1727,14 +1727,14 @@ func getIPAddressesFromEndpoints(endpoints []podEndpoint) []string {
 	return endps
 }
 
-func (lbc *LoadBalancerController) createMergeableIngresses(fullIng *FullIngress) *configs.MergeableIngresses {
+func (lbc *LoadBalancerController) createMergeableIngresses(ingConfig *IngressConfiguration) *configs.MergeableIngresses {
 	// for master Ingress, validMinionPaths are nil
-	masterIngressEx := lbc.createIngressEx(fullIng.Ingress, fullIng.ValidHosts, nil)
+	masterIngressEx := lbc.createIngressEx(ingConfig.Ingress, ingConfig.ValidHosts, nil)
 
 	var minions []*configs.IngressEx
 
-	for _, fm := range fullIng.Minions {
-		minions = append(minions, lbc.createIngressEx(fm.Ingress, fullIng.ValidHosts, fm.ValidPaths))
+	for _, m := range ingConfig.Minions {
+		minions = append(minions, lbc.createIngressEx(m.Ingress, ingConfig.ValidHosts, m.ValidPaths))
 	}
 
 	return &configs.MergeableIngresses{

--- a/internal/k8s/status.go
+++ b/internal/k8s/status.go
@@ -60,7 +60,7 @@ func (su *statusUpdater) UpdateExternalEndpointsForResources(resource []Resource
 
 func (su *statusUpdater) UpdateExternalEndpointsForResource(r Resource) error {
 	switch impl := r.(type) {
-	case *FullIngress:
+	case *IngressConfiguration:
 		var ings []networking.Ingress
 		ings = append(ings, *impl.Ingress)
 
@@ -69,7 +69,7 @@ func (su *statusUpdater) UpdateExternalEndpointsForResource(r Resource) error {
 		}
 
 		return su.BulkUpdateIngressStatus(ings)
-	case *FullVirtualServer:
+	case *VirtualServerConfiguration:
 		failed := false
 
 		err := su.updateVirtualServerExternalEndpoints(impl.VirtualServer)


### PR DESCRIPTION
### Proposed changes
Rename structs to be more clear about their responsibility and what data they hold.

Rename:
* `FullIngress` -> `IngressConfiguration`
* `FullMinion` -> `MinionConfiguration`
* `FullVirtualServer` -> `VirtualServerConfiguration`

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
