### PR TITLE
disable interfacer linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - gofmt
     - unparam
     - unconvert
-    - interfacer
     - structcheck
     - errcheck
     disable-all: true


### PR DESCRIPTION
### Proposed changes
Disable "interfacer" linter since it is deprecated and prone to bad suggestions. 
ref: https://github.com/mvdan/interfacer

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
