### PR TITLE
Fix enablePreviewPolicies arg when using daemonset

### DIFF
--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -146,6 +146,7 @@ spec:
 {{- if .Values.controller.enableCustomResources }}
           - -enable-tls-passthrough={{ .Values.controller.enableTLSPassthrough }}
           - -enable-snippets={{ .Values.controller.enableSnippets }}
+          - -enable-preview-policies={{ .Values.controller.enablePreviewPolicies }}
 {{- if .Values.controller.globalConfiguration.create }}
           - -global-configuration=$(POD_NAMESPACE)/{{ include "nginx-ingress.name" . }}
 {{- end }}


### PR DESCRIPTION
### Bug
Bug first appeared in: https://github.com/nginxinc/kubernetes-ingress/commit/d652a427494aada6a238d6691236625e71d1cb3b

* `--set controller.enablePreviewPolicies=true` will do nothing if `--set controller.kind=daemonset` is also set. The resulting daemonset manifest does not have `-enable-preview-policies` set.

### Proposed changes
* Add `enablePreviewPolicies` arg to daemonset template, which was accidentally omitted.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
