### PR TITLE
Update names of secrets created by Helm

### DIFF
--- a/deployments/helm-chart/templates/_helpers.tpl
+++ b/deployments/helm-chart/templates/_helpers.tpl
@@ -53,14 +53,14 @@ Expand service name.
 Expand default TLS name.
 */}}
 {{- define "nginx-ingress.defaultTLSName" -}}
-{{- printf "%s-%s" (include "nginx-ingress.name" .) "default-server-secret" -}}
+{{- printf "%s-%s" (include "nginx-ingress.name" .) "default-server-tls" -}}
 {{- end -}}
 
 {{/*
 Expand wildcard TLS name.
 */}}
 {{- define "nginx-ingress.wildcardTLSName" -}}
-{{- printf "%s-%s" (include "nginx-ingress.name" .) "wildcard-tls-secret" -}}
+{{- printf "%s-%s" (include "nginx-ingress.name" .) "wildcard-tls" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Version 0.7.1 of our Helm chart creates the default and wildcard
secrets with the type 'Opaque'.

The upcoming version 0.8.0 creates those secret with the type
'kubernetes.io/tls` (which is required by the Ingress Controller
since d4a1e95).

Updating the names will make Helm remove the old secrets and create
the new ones, which ensures a sucessfull 'helm upgrade'.

If we don't update the names of those secrets, Helm will not be able
to perform an upgrade, because the field type of the secret
resource is immutable.

It is possible to keep the old names. However, that
will require users to perform several manual steps during
the helm upgrade.
