### PR TITLE
Docs: Add removal of trailing CRDs to uninstall notes

### DIFF
--- a/docs-web/installation/installation-with-manifests.md
+++ b/docs-web/installation/installation-with-manifests.md
@@ -209,8 +209,17 @@ $ kubectl get pods --namespace=nginx-ingress
     ```
     $ kubectl delete namespace nginx-ingress
     ```
-2. Delete the ClusterRole and ClusterRoleBinding created in that step:
+1. Delete the ClusterRole and ClusterRoleBinding:
     ```
     $ kubectl delete clusterrole nginx-ingress
     $ kubectl delete clusterrolebinding nginx-ingress
+    ```
+1. Delete the Custom Resource Definitions:
+
+    **Note**: This step will also remove all associated Custom Resources.
+
+    **Note**: There are two different sets of custom resource definitions: one for Kubernetes <= v1.15 and one for Kubernetes >= v1.16. For Kubernetes <= v1.15 substitute `crds` with `crds-v1beta1` in the following command.
+
+    ```
+    $ kubectl delete -f common/crds/
     ```


### PR DESCRIPTION
### Proposed changes
* Uninstall instructions leave trailing Custom Resource Definitions behind. This change instructs how they can be removed and warns the reader about destruction nature of CRD removal.
* Correct ClusterRole/CRBinding step.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
