### PR TITLE
Enable repo sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -3,14 +3,14 @@ name: Sync
 on:
   push:
     branches:
-      - enable-repo-sync
+      - master
   schedule:
     - cron: '0 */12 * * *'
 
 env:
   IC_SOURCE_REPO_URL: https://github.com/nginxinc/kubernetes-ingress.git
   IC_SOURCE_BRANCH: master
-  IC_DEST_BRANCH: enable-repo-sync
+  IC_DEST_BRANCH: master
 
 jobs:
   repo-sync:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,26 @@
+name: Sync
+
+on:
+  push:
+    branches:
+      - enable-repo-sync
+  schedule:
+    - cron: '0 */12 * * *'
+
+env:
+  IC_SOURCE_REPO_URL: https://github.com/nginxinc/kubernetes-ingress.git
+  IC_SOURCE_BRANCH: master
+  IC_DEST_BRANCH: enable-repo-sync
+
+jobs:
+  repo-sync:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: repo-sync
+        uses: wei/git-sync@v3
+        with:
+          source_repo: ${{ env.IC_SOURCE_REPO_URL }}
+          source_branch: ${{ env.IC_SOURCE_BRANCH }}
+          destination_repo: ${{ secrets.SYNC_DEST_REPO_URL }}
+          destination_branch: ${{ env.IC_DEST_BRANCH }}
+          ssh_private_key: ${{ secrets.SYNC_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
### Proposed changes
Create a sync workflow to keep our internal repo up to date. This change uses wei/git-sync@v3 action instead of repo-sync/github-sync@v2, which allows us to push to a remote repo.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
