### PR TITLE
Run nightly k8s tests on 1.20.0; drop testing on 1.15.12

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -190,6 +190,13 @@ jobs:
             tag: ${{ github.sha }}
             marker: ''
             type: oss
+            k8s: 1.20.0
+          - os: ubuntu-18.04
+            file: build/Dockerfile
+            image: nginx-ingress
+            tag: ${{ github.sha }}
+            marker: ''
+            type: oss
             k8s: 1.19.1
           - os: ubuntu-18.04
             file: build/Dockerfile
@@ -213,12 +220,12 @@ jobs:
             type: oss
             k8s: 1.16.15
           - os: ubuntu-18.04
-            file: build/Dockerfile
-            image: nginx-ingress
+            file: build/DockerfileForPlus
+            image: nginx-plus-ingress
             tag: ${{ github.sha }}
             marker: ''
-            type: oss
-            k8s: 1.15.12
+            type: plus
+            k8s: 1.20.0
           - os: ubuntu-18.04
             file: build/DockerfileForPlus
             image: nginx-plus-ingress
@@ -248,12 +255,12 @@ jobs:
             type: plus
             k8s: 1.16.15
           - os: ubuntu-18.04
-            file: build/DockerfileForPlus
+            file: build/appprotect/DockerfileWithAppProtectForPlus
             image: nginx-plus-ingress
-            tag: ${{ github.sha }}
-            marker: ''
-            type: plus
-            k8s: 1.15.12
+            tag: ${{ github.sha }}-ap
+            marker: '-m appprotect'
+            type: plus-ap
+            k8s: 1.20.0
           - os: ubuntu-18.04
             file: build/appprotect/DockerfileWithAppProtectForPlus
             image: nginx-plus-ingress
@@ -282,13 +289,6 @@ jobs:
             marker: '-m appprotect'
             type: plus-ap
             k8s: 1.16.15
-          - os: ubuntu-18.04
-            file: build/appprotect/DockerfileWithAppProtectForPlus
-            image: nginx-plus-ingress
-            tag: ${{ github.sha }}-ap
-            marker: '-m appprotect'
-            type: plus-ap
-            k8s: 1.15.12
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
### Proposed changes
This commit changes the K8s test matrix in nightly smoke tests to support 1.20.0 (already the default in the edge pipeline), and drop testing for 1.15.12 (which won't be receiving patch support anyway from Feb 21 - see https://kubernetes.io/docs/setup/release/version-skew-policy/)

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
