### PR TITLE
Add release-drafter and pr-labeler

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,4 @@
+feature: ['feature/*', 'feat/*']
+fix: fix/*
+chore: ['chore/*', 'deps/*']
+documentation: docs/*

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,44 @@
+name-template: 'v$NEXT_MINOR_VERSION'
+tag-template: 'v$NEXT_MINOR_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: '💣 Breaking Change'
+    labels:
+      - "breaking"
+      - "change"
+  - title: '🐛 Bug Fixes'
+    labels:
+      - "fix"
+      - "bug"
+      - "bugfix"
+  - title: '📝 Documentation'
+    labels:
+      - "documentation"
+      - "docs"
+  - title: '🔨 Maintenance'
+    labels:
+      - "chore"
+      - "dependencies"
+change-template: '- $TITLE (#$NUMBER)'
+template: |
+  *Help make the NGINX Ingress Controller better by participating in our [survey](https://forms.office.com/Pages/ResponsePage.aspx?id=L_093Ttq0UCb4L-DJ9gcUM6Dh1A0cORCorfgZAMdkwJUREhJUFAyM1ZHRzZLSzQyMUlCNFhXVkZENy4u)!*
+
+  ## New in NGINX Ingress Controller v$NEXT_MINOR_VERSION
+
+  $CHANGES
+
+  ## Upgrade
+
+  For NGINX, use the v$NEXT_MINOR_VERSION image from our DockerHub: `nginx/nginx-ingress:$NEXT_MINOR_VERSION`, `nginx/nginx-ingress:$NEXT_MINOR_VERSION-alpine` or `nginx/nginx-ingress:$NEXT_MINOR_VERSION-ubi`
+  For NGINX Plus, please build your own image using the v$NEXT_MINOR_VERSION source code.
+  For Helm, use version 0.7.1 of the chart.
+
+  ## Resources
+
+  Documentation -- https://docs.nginx.com/nginx-ingress-controller/
+  Configuration examples -- https://github.com/nginxinc/kubernetes-ingress/tree/v$NEXT_MINOR_VERSION/examples and https://github.com/nginxinc/kubernetes-ingress/tree/v$NEXT_MINOR_VERSION/examples-of-custom-resources
+  Helm Chart -- https://github.com/nginxinc/kubernetes-ingress/tree/v$NEXT_MINOR_VERSION/deployments/helm-chart
+  Operator -- https://github.com/nginxinc/nginx-ingress-operator/

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,12 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added:
- PR labeler: automatically add labels to PRs, when the branch name is a match. For example, using `feature/oidc` as a branch name will add the label `feature`
- Release drafter: automatically create a draft for the next release based on the labels found on the PRs.

(Suggestions about labels and branch names are welcome 🙂)

What do you guys think?