### PR TITLE
Fixes validation of ms time expressions

### DIFF
--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -183,7 +183,7 @@ func ParseUint64(s string) (uint64, error) {
 }
 
 // timeRegexp http://nginx.org/en/docs/syntax.html
-var timeRegexp = regexp.MustCompile(`^(\d+y)?\s*(\d+M)?\s*(\d+w)?\s*(\d+d)?\s*(\d+h)?\s*(\d+m)?\s*(\d+s?)?\s*(\d+ms)?$`)
+var timeRegexp = regexp.MustCompile(`^(\d+y)?(\d+M)?(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s?)?(\d+ms)?$`)
 
 // ParseTime ensures that the string value in the annotation is a valid time.
 func ParseTime(s string) (string, error) {

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -183,13 +183,13 @@ func ParseUint64(s string) (uint64, error) {
 }
 
 // timeRegexp http://nginx.org/en/docs/syntax.html
-var timeRegexp = regexp.MustCompile(`^([0-9]+(ms|s|m|h|d|w|M|y)? *)+$`)
+var timeRegexp = regexp.MustCompile(`^(\d+y)?\s*(\d+M)?\s*(\d+w)?\s*(\d+d)?\s*(\d+h)?\s*(\d+m)?\s*(\d+s?)?\s*(\d+ms)?$`)
 
 // ParseTime ensures that the string value in the annotation is a valid time.
 func ParseTime(s string) (string, error) {
 	s = strings.TrimSpace(s)
 
-	if timeRegexp.MatchString(s) {
+	if s != "" && timeRegexp.MatchString(s) {
 		return s, nil
 	}
 	return "", errors.New("Invalid time string")

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -183,7 +183,7 @@ func ParseUint64(s string) (uint64, error) {
 }
 
 // timeRegexp http://nginx.org/en/docs/syntax.html
-var timeRegexp = regexp.MustCompile(`^(\d+y)?(\d+M)?(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s?)?(\d+ms)?$`)
+var timeRegexp = regexp.MustCompile(`^(\d+y)?\s*(\d+M)?\s*(\d+w)?\s*(\d+d)?\s*(\d+h)?\s*(\d+m)?\s*(\d+s?)?\s*(\d+ms)?$`)
 
 // ParseTime ensures that the string value in the annotation is a valid time.
 func ParseTime(s string) (string, error) {

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -183,7 +183,7 @@ func ParseUint64(s string) (uint64, error) {
 }
 
 // timeRegexp http://nginx.org/en/docs/syntax.html
-var timeRegexp = regexp.MustCompile(`^([0-9]+([ms|s|m|h|d|w|M|y]?){0,1} *)+$`)
+var timeRegexp = regexp.MustCompile(`^([0-9]+(ms|s|m|h|d|w|M|y)? *)+$`)
 
 // ParseTime ensures that the string value in the annotation is a valid time.
 func ParseTime(s string) (string, error) {

--- a/internal/configs/parsing_helpers_test.go
+++ b/internal/configs/parsing_helpers_test.go
@@ -364,8 +364,8 @@ func TestParseLBMethodForPlus(t *testing.T) {
 }
 
 func TestParseTime(t *testing.T) {
-	var testsWithValidInput = []string{"1h30m 5 100ms", "10ms", "1", "1m10s", "5m 30s", "1s", "100m", "5w", "15m", "11M", "3h", "100y", "600"}
-	var invalidInput = []string{"5s 5s", "ss", "rM", "m0m", "s1s", "-5s", "", "1L", "11 11"}
+	var testsWithValidInput = []string{"1m30", "1h30m5s100ms", "10ms", "1", "1m10s", "1s", "100m", "5w", "15m", "11M", "3h", "100y", "600"}
+	var invalidInput = []string{"1h30m 5 100ms", "5s 5s", "5m 30s", "ss", "rM", "m0m", "s1s", "-5s", "", "1L", "11 11"}
 	for _, test := range testsWithValidInput {
 		result, err := ParseTime(test)
 		if err != nil {

--- a/internal/configs/parsing_helpers_test.go
+++ b/internal/configs/parsing_helpers_test.go
@@ -364,8 +364,8 @@ func TestParseLBMethodForPlus(t *testing.T) {
 }
 
 func TestParseTime(t *testing.T) {
-	var testsWithValidInput = []string{"10ms", "1", "1m10s", "11 11", "5m 30s", "1s", "100m", "5w", "15m", "11M", "3h", "100y", "600"}
-	var invalidInput = []string{"ss", "rM", "m0m", "s1s", "-5s", "", "1L"}
+	var testsWithValidInput = []string{"1h30m 5 100ms", "10ms", "1", "1m10s", "5m 30s", "1s", "100m", "5w", "15m", "11M", "3h", "100y", "600"}
+	var invalidInput = []string{"5s 5s", "ss", "rM", "m0m", "s1s", "-5s", "", "1L", "11 11"}
 	for _, test := range testsWithValidInput {
 		result, err := ParseTime(test)
 		if err != nil {

--- a/internal/configs/parsing_helpers_test.go
+++ b/internal/configs/parsing_helpers_test.go
@@ -364,8 +364,8 @@ func TestParseLBMethodForPlus(t *testing.T) {
 }
 
 func TestParseTime(t *testing.T) {
-	var testsWithValidInput = []string{"1m30", "1h30m5s100ms", "10ms", "1", "1m10s", "1s", "100m", "5w", "15m", "11M", "3h", "100y", "600"}
-	var invalidInput = []string{"1h30m 5 100ms", "5s 5s", "5m 30s", "ss", "rM", "m0m", "s1s", "-5s", "", "1L", "11 11"}
+	var testsWithValidInput = []string{"1h30m 5 100ms", "10ms", "1", "1m10s", "5m 30s", "1s", "100m", "5w", "15m", "11M", "3h", "100y", "600"}
+	var invalidInput = []string{"5s 5s", "ss", "rM", "m0m", "s1s", "-5s", "", "1L", "11 11"}
 	for _, test := range testsWithValidInput {
 		result, err := ParseTime(test)
 		if err != nil {

--- a/internal/configs/parsing_helpers_test.go
+++ b/internal/configs/parsing_helpers_test.go
@@ -364,7 +364,7 @@ func TestParseLBMethodForPlus(t *testing.T) {
 }
 
 func TestParseTime(t *testing.T) {
-	var testsWithValidInput = []string{"1", "1m10s", "11 11", "5m 30s", "1s", "100m", "5w", "15m", "11M", "3h", "100y", "600"}
+	var testsWithValidInput = []string{"10ms", "1", "1m10s", "11 11", "5m 30s", "1s", "100m", "5w", "15m", "11M", "3h", "100y", "600"}
 	var invalidInput = []string{"ss", "rM", "m0m", "s1s", "-5s", "", "1L"}
 	for _, test := range testsWithValidInput {
 		result, err := ParseTime(test)

--- a/pkg/apis/configuration/validation/common_test.go
+++ b/pkg/apis/configuration/validation/common_test.go
@@ -289,7 +289,7 @@ func TestValidateSize(t *testing.T) {
 }
 
 func TestValidateTime(t *testing.T) {
-	time := "1h2s"
+	time := "1h 2s"
 	allErrs := validateTime(time, field.NewPath("time-field"))
 
 	if len(allErrs) != 0 {

--- a/pkg/apis/configuration/validation/common_test.go
+++ b/pkg/apis/configuration/validation/common_test.go
@@ -289,7 +289,7 @@ func TestValidateSize(t *testing.T) {
 }
 
 func TestValidateTime(t *testing.T) {
-	time := "1h 2s"
+	time := "1h2s"
 	allErrs := validateTime(time, field.NewPath("time-field"))
 
 	if len(allErrs) != 0 {


### PR DESCRIPTION
### Proposed changes
KIC used an incorrect regex to validate time annotation values, and would consider expressions such as `10ms` to be invalid. This fix corrects that regex.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
