### PR TITLE
Fixes writing of time values to templates

### DIFF
--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -4,8 +4,8 @@ upstream {{$upstream.Name}} {
 	zone {{$upstream.Name}} {{if ne $upstream.UpstreamZoneSize "0"}}{{$upstream.UpstreamZoneSize}}{{else}}256k{{end}};
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
-	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}}
-	    {{- if $server.SlowStart}} slow_start={{$server.SlowStart}}{{end}}{{if $server.Resolve}} resolve{{end}};{{end}}
+	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} "fail_timeout={{$server.FailTimeout}}" max_conns={{$server.MaxConns}}
+	    {{- if $server.SlowStart}} "slow_start={{$server.SlowStart}}"{{end}}{{if $server.Resolve}} resolve{{end}};{{end}}
 	{{if $upstream.StickyCookie}}
 	sticky cookie {{$upstream.StickyCookie}};
 	{{end}}
@@ -179,9 +179,9 @@ server {
 		auth_jwt "{{.Realm}}"{{if $jwt.Token}} token={{$jwt.Token}}{{end}};
 		{{end}}
 
-		grpc_connect_timeout {{$location.ProxyConnectTimeout}};
-		grpc_read_timeout {{$location.ProxyReadTimeout}};
-		grpc_send_timeout {{$location.ProxySendTimeout}};
+		grpc_connect_timeout "{{$location.ProxyConnectTimeout}}";
+		grpc_read_timeout "{{$location.ProxyReadTimeout}}";
+		grpc_send_timeout "{{$location.ProxySendTimeout}}";
 		grpc_set_header Host $host;
 		grpc_set_header X-Real-IP $remote_addr;
 		grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -228,9 +228,9 @@ server {
 		{{end}}
 		{{end}}
 
-		proxy_connect_timeout {{$location.ProxyConnectTimeout}};
-		proxy_read_timeout {{$location.ProxyReadTimeout}};
-		proxy_send_timeout {{$location.ProxySendTimeout}};
+		proxy_connect_timeout "{{$location.ProxyConnectTimeout}}";
+		proxy_read_timeout "{{$location.ProxyReadTimeout}}";
+		proxy_send_timeout "{{$location.ProxySendTimeout}}";
 		client_max_body_size {{$location.ClientMaxBodySize}};
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -4,7 +4,7 @@ upstream {{$upstream.Name}} {
 	{{if ne $upstream.UpstreamZoneSize "0"}}zone {{$upstream.Name}} {{$upstream.UpstreamZoneSize}};{{end}}
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
-	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}};{{end}}
+	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} "fail_timeout={{$server.FailTimeout}}" max_conns={{$server.MaxConns}};{{end}}
 	{{if $.Keepalive}}keepalive {{$.Keepalive}};{{end}}
 }{{end}}
 
@@ -116,9 +116,9 @@ server {
 		{{$value}}{{end}}
 		{{- end}}
 
-		grpc_connect_timeout {{$location.ProxyConnectTimeout}};
-		grpc_read_timeout {{$location.ProxyReadTimeout}};
-		grpc_send_timeout {{$location.ProxySendTimeout}};
+		grpc_connect_timeout "{{$location.ProxyConnectTimeout}}";
+		grpc_read_timeout "{{$location.ProxyReadTimeout}}";
+		grpc_send_timeout "{{$location.ProxySendTimeout}}";
 		grpc_set_header Host $host;
 		grpc_set_header X-Real-IP $remote_addr;
 		grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -148,9 +148,9 @@ server {
 		{{$value}}{{end}}
 		{{- end}}
 
-		proxy_connect_timeout {{$location.ProxyConnectTimeout}};
-		proxy_read_timeout {{$location.ProxyReadTimeout}};
-		proxy_send_timeout {{$location.ProxySendTimeout}};
+		proxy_connect_timeout "{{$location.ProxyConnectTimeout}}";
+		proxy_read_timeout "{{$location.ProxyReadTimeout}}";
+		proxy_send_timeout "{{$location.ProxySendTimeout}}";
 		client_max_body_size {{$location.ClientMaxBodySize}};
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;

--- a/internal/configs/version2/nginx-plus.transportserver.tmpl
+++ b/internal/configs/version2/nginx-plus.transportserver.tmpl
@@ -31,7 +31,7 @@ server {
     proxy_pass {{ $s.ProxyPass }};
 
     proxy_timeout {{ $s.ProxyTimeout }};
-    proxy_connect_timeout {{ $s.ProxyConnectTimeout }};
+    proxy_connect_timeout "{{ $s.ProxyConnectTimeout }}";
 
     {{ if $s.ProxyNextUpstream }}
     proxy_next_upstream on;

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -5,7 +5,7 @@ upstream {{ $u.Name }} {
     {{ if $u.LBMethod }}{{ $u.LBMethod }};{{ end }}
 
     {{ range $s := $u.Servers }}
-    server {{ $s.Address }} max_fails={{ $u.MaxFails }} fail_timeout={{ $u.FailTimeout }}{{ if $u.SlowStart }} slow_start={{ $u.SlowStart }}{{ end }} max_conns={{ $u.MaxConns }}{{ if $u.Resolve }} resolve{{ end }};
+    server {{ $s.Address }} max_fails={{ $u.MaxFails }} "fail_timeout={{ $u.FailTimeout }}"{{ if $u.SlowStart }} "slow_start={{ $u.SlowStart }}"{{ end }} max_conns={{ $u.MaxConns }}{{ if $u.Resolve }} resolve{{ end }};
     {{ end }}
 
     {{ if $u.Keepalive }}
@@ -194,9 +194,9 @@ server {
         {{ range $n, $v := $hc.Headers }}
         proxy_set_header {{ $n }} "{{ $v }}";
         {{ end }}
-        proxy_connect_timeout {{ $hc.ProxyConnectTimeout }};
-        proxy_read_timeout {{ $hc.ProxyReadTimeout }};
-        proxy_send_timeout {{ $hc.ProxySendTimeout }};
+        proxy_connect_timeout "{{ $hc.ProxyConnectTimeout }}";
+        proxy_read_timeout "{{ $hc.ProxyReadTimeout }}";
+        proxy_send_timeout "{{ $hc.ProxySendTimeout }}";
         proxy_pass {{ $hc.ProxyPass }};
         health_check uri={{ $hc.URI }} port={{ $hc.Port }} interval={{ $hc.Interval }} jitter={{ $hc.Jitter }}
             fails={{ $hc.Fails }} passes={{ $hc.Passes }}{{ if $hc.Match }} match={{ $hc.Match }}{{ end }};
@@ -323,9 +323,9 @@ server {
             {{ range $r := $l.Rewrites }}
         rewrite {{ $r }};
             {{ end }}
-        proxy_connect_timeout {{ $l.ProxyConnectTimeout }};
-        proxy_read_timeout {{ $l.ProxyReadTimeout }};
-        proxy_send_timeout {{ $l.ProxySendTimeout }};
+        proxy_connect_timeout "{{ $l.ProxyConnectTimeout }}";
+        proxy_read_timeout "{{ $l.ProxyReadTimeout }}";
+        proxy_send_timeout "{{ $l.ProxySendTimeout }}";
         client_max_body_size {{ $l.ClientMaxBodySize }};
 
             {{ if $l.ProxyMaxTempFileSize }}

--- a/internal/configs/version2/nginx.transportserver.tmpl
+++ b/internal/configs/version2/nginx.transportserver.tmpl
@@ -29,7 +29,7 @@ server {
     proxy_pass {{ $s.ProxyPass }};
 
     proxy_timeout {{ $s.ProxyTimeout }};
-    proxy_connect_timeout {{ $s.ProxyConnectTimeout }};
+    proxy_connect_timeout "{{ $s.ProxyConnectTimeout }}";
 
     {{ if $s.ProxyNextUpstream }}
     proxy_next_upstream on;

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -5,7 +5,7 @@ upstream {{ $u.Name }} {
     {{ if $u.LBMethod }}{{ $u.LBMethod }};{{ end }}
 
     {{ range $s := $u.Servers }}
-    server {{ $s.Address }} max_fails={{ $u.MaxFails }} fail_timeout={{ $u.FailTimeout }} max_conns={{ $u.MaxConns }};
+    server {{ $s.Address }} max_fails={{ $u.MaxFails }} "fail_timeout={{ $u.FailTimeout }}" max_conns={{ $u.MaxConns }};
     {{ end }}
 
     {{ if $u.Keepalive }}
@@ -260,9 +260,9 @@ server {
             {{ range $r := $l.Rewrites }}
         rewrite {{ $r }};
             {{ end }}
-        proxy_connect_timeout {{ $l.ProxyConnectTimeout }};
-        proxy_read_timeout {{ $l.ProxyReadTimeout }};
-        proxy_send_timeout {{ $l.ProxySendTimeout }};
+        proxy_connect_timeout "{{ $l.ProxyConnectTimeout }}";
+        proxy_read_timeout "{{ $l.ProxyReadTimeout }}";
+        proxy_send_timeout "{{ $l.ProxySendTimeout }}";
         client_max_body_size {{ $l.ClientMaxBodySize }};
 
             {{ if $l.ProxyMaxTempFileSize }}


### PR DESCRIPTION
### Proposed changes
Time values as described here https://nginx.org/en/docs/syntax.html are valid for time-based nginx directives, including values such as `1m 30s` (note the space).

If a directive such as `proxy_connect_timeout 1m 30s` is written to the nginx conf file it will be invalid, instead it must be quoted, like `proxy_connect_timeout "1m 30s"`

This fix adds this quoting of time values.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
