### PR TITLE
Fix helm chart version to be a valid semver

### DIFF
--- a/deployments/helm-chart/Chart.yaml
+++ b/deployments/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: edge
+version: 0.0.0-edge
 appVersion: edge
 apiVersion: v1
 kubeVersion: ">= 1.14.0-0"


### PR DESCRIPTION
### Proposed changes
* As of helm [3.5.2](https://github.com/helm/helm/releases/tag/v3.5.2) the helm client requires the version metadata to be a valid semver. This fixes smoke tests that are currently failing.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
