### PR TITLE
Refactor timeout calculation to use duration

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -835,12 +835,12 @@ func handleTerminationWithAppProtect(lbc *k8s.LoadBalancerController, nginxManag
 	os.Exit(0)
 }
 
-func parseReloadTimeout(appProtectEnabled bool, timeout int) int {
-	const defaultTimeout = 4000
-	const defaultTimeoutAppProtect = 20000
+func parseReloadTimeout(appProtectEnabled bool, timeout int) time.Duration {
+	const defaultTimeout = 4000 * time.Millisecond
+	const defaultTimeoutAppProtect = 20000 * time.Millisecond
 
 	if timeout != 0 {
-		return timeout
+		return time.Duration(timeout) * time.Millisecond
 	}
 
 	if appProtectEnabled {

--- a/cmd/nginx-ingress/main_test.go
+++ b/cmd/nginx-ingress/main_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestValidatePort(t *testing.T) {
@@ -129,27 +130,27 @@ func TestParseReloadTimeout(t *testing.T) {
 	tests := []struct {
 		timeout           int
 		appProtectEnabled bool
-		expected          int
+		expected          time.Duration
 	}{
 		{
 			timeout:           0,
 			appProtectEnabled: true,
-			expected:          20000,
+			expected:          20000 * time.Millisecond,
 		},
 		{
 			timeout:           0,
 			appProtectEnabled: false,
-			expected:          4000,
+			expected:          4000 * time.Millisecond,
 		},
 		{
 			timeout:           1000,
 			appProtectEnabled: true,
-			expected:          1000,
+			expected:          1000 * time.Millisecond,
 		},
 		{
 			timeout:           1000,
 			appProtectEnabled: false,
-			expected:          1000,
+			expected:          1000 * time.Millisecond,
 		},
 	}
 

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -103,7 +103,7 @@ type LocalManager struct {
 }
 
 // NewLocalManager creates a LocalManager.
-func NewLocalManager(confPath string, binaryFilename string, mc collectors.ManagerCollector, timeout int) *LocalManager {
+func NewLocalManager(confPath string, binaryFilename string, mc collectors.ManagerCollector, timeout time.Duration) *LocalManager {
 	verifyConfigGenerator, err := newVerifyConfigGenerator()
 	if err != nil {
 		glog.Fatalf("error instantiating a verifyConfigGenerator: %v", err)

--- a/internal/nginx/verify_test.go
+++ b/internal/nginx/verify_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 type Transport struct {
@@ -30,7 +31,7 @@ func getTestHTTPClient() *http.Client {
 func TestVerifyClient(t *testing.T) {
 	c := verifyClient{
 		client:  getTestHTTPClient(),
-		timeout: 25,
+		timeout: 25 * time.Millisecond,
 	}
 
 	configVersion, err := c.GetConfigVersion()


### PR DESCRIPTION
### Proposed changes
An issue was found where the time spent waiting for a reload was logged incorrectly.

```
I1002 17:56:06.864138       1 manager.go:282] Reloading nginx with configVersion: 11
. . .
I1002 17:56:33.685380       1 verify.go:75] success, version 11 ensured. iterations: 613. took: 15.325s
```

This change adjusts the logic in a polling loop to use time.duration to correctly calculate the times.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
