### PR TITLE
Fix WAF policy example

### DIFF
--- a/examples-of-custom-resources/jwt/README.md
+++ b/examples-of-custom-resources/jwt/README.md
@@ -35,7 +35,7 @@ Create a policy with the name `jwt-policy` that references the secret from the p
 $ kubectl apply -f jwt.yaml
 ```
 
-## Step 3 - Configure Load Balancing
+## Step 4 - Configure Load Balancing
 
 Create a VirtualServer resource for the web application:
 ```
@@ -44,7 +44,7 @@ $ kubectl apply -f virtual-server.yaml
 
 Note that the VirtualServer references the policy `jwt-policy` created in Step 3.
 
-## Step 4 - Test the Configuration
+## Step 5 - Test the Configuration
 
 If you attempt to access the application without providing a valid JWT, NGINX will reject your requests for that VirtualServer:
 ```

--- a/examples-of-custom-resources/waf/virtual-server.yaml
+++ b/examples-of-custom-resources/waf/virtual-server.yaml
@@ -14,5 +14,3 @@ spec:
   - path: /
     action:
       pass: webapp
-    policies:
-    - name: waf-policy


### PR DESCRIPTION
### Proposed changes
* Remove reference to WAF policy in path. There are references in both spec and path, ref in path is redundant.
* VS does not have a TLS so requests to HTTPS are not valid. Fixed to be HTTP.
* Add missing step to create WAF policy.
* Fix file name references
* Make User Defined Signature creation a prerequisite to creation of AP policy.
* Fix minor typo in JWT policy.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
