### PR TITLE
Try switching AP smoke tests to mac runner on nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -254,35 +254,35 @@ jobs:
             marker: ''
             type: plus
             k8s: 1.16.15
-          - os: ubuntu-18.04
+          - os: macos-10.15
             file: build/appprotect/DockerfileWithAppProtectForPlus
             image: nginx-plus-ingress
             tag: ${{ github.sha }}-ap
             marker: '-m appprotect'
             type: plus-ap
             k8s: 1.20.0
-          - os: ubuntu-18.04
+          - os: macos-10.15
             file: build/appprotect/DockerfileWithAppProtectForPlus
             image: nginx-plus-ingress
             tag: ${{ github.sha }}-ap
             marker: '-m appprotect'
             type: plus-ap
             k8s: 1.19.1
-          - os: ubuntu-18.04
+          - os: macos-10.15
             file: build/appprotect/DockerfileWithAppProtectForPlus
             image: nginx-plus-ingress
             tag: ${{ github.sha }}-ap
             marker: '-m appprotect'
             type: plus-ap
             k8s: 1.18.8
-          - os: ubuntu-18.04
+          - os: macos-10.15
             file: build/appprotect/DockerfileWithAppProtectForPlus
             image: nginx-plus-ingress
             tag: ${{ github.sha }}-ap
             marker: '-m appprotect'
             type: plus-ap
             k8s: 1.17.11
-          - os: ubuntu-18.04
+          - os: macos-10.15
             file: build/appprotect/DockerfileWithAppProtectForPlus
             image: nginx-plus-ingress
             tag: ${{ github.sha }}-ap


### PR DESCRIPTION
### Proposed changes
The AP smoke tests have errors frequently, we think because tests are timing out due to the infrastructure not being powerful enough (the default linux and windows runners are based on on Standard_DS2_v2 virtual machines in Microsoft Azure). This commit switches the runner for these jobs to macOS, as it has a more powerful spec (see https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources for more info)

