### PR TITLE
Fix bug in TS health check

### DIFF
--- a/deployments/common/crds-v1beta1/k8s.nginx.org_transportservers.yaml
+++ b/deployments/common/crds-v1beta1/k8s.nginx.org_transportservers.yaml
@@ -87,7 +87,7 @@ spec:
                         type: boolean
                       fails:
                         type: integer
-                      intervals:
+                      interval:
                         type: string
                       jitter:
                         type: string

--- a/deployments/common/crds/k8s.nginx.org_transportservers.yaml
+++ b/deployments/common/crds/k8s.nginx.org_transportservers.yaml
@@ -88,7 +88,7 @@ spec:
                             type: boolean
                           fails:
                             type: integer
-                          intervals:
+                          interval:
                             type: string
                           jitter:
                             type: string

--- a/deployments/helm-chart/crds/k8s.nginx.org_transportservers.yaml
+++ b/deployments/helm-chart/crds/k8s.nginx.org_transportservers.yaml
@@ -88,7 +88,7 @@ spec:
                             type: boolean
                           fails:
                             type: integer
-                          intervals:
+                          interval:
                             type: string
                           jitter:
                             type: string

--- a/internal/configs/transportserver.go
+++ b/internal/configs/transportserver.go
@@ -128,9 +128,9 @@ func generateTransportServerHealthCheck(upstreamHealthCheckName string, upstream
 			hc = generateTransportServerHealthCheckWithDefaults(u)
 
 			hc.Enabled = u.HealthCheck.Enabled
-			hc.Interval = generateTime(u.HealthCheck.Interval)
-			hc.Jitter = generateTime(u.HealthCheck.Jitter)
-			hc.Timeout = generateTime(u.HealthCheck.Timeout)
+			hc.Interval = generateTime(u.HealthCheck.Interval, hc.Interval)
+			hc.Jitter = generateTime(u.HealthCheck.Jitter, hc.Jitter)
+			hc.Timeout = generateTime(u.HealthCheck.Timeout, hc.Timeout)
 
 			if u.HealthCheck.Fails > 0 {
 				hc.Fails = u.HealthCheck.Fails
@@ -152,7 +152,7 @@ func generateTransportServerHealthCheckWithDefaults(up conf_v1alpha1.Upstream) *
 	return &version2.StreamHealthCheck{
 		Enabled:  false,
 		Timeout:  "5s",
-		Jitter:   "0",
+		Jitter:   "0s",
 		Port:     up.Port,
 		Interval: "5s",
 		Passes:   1,

--- a/internal/configs/transportserver_test.go
+++ b/internal/configs/transportserver_test.go
@@ -449,6 +449,27 @@ func TestGenerateTransportServerHealthChecks(t *testing.T) {
 			},
 			msg: "valid 2 health checks",
 		},
+		{
+			upstreams: []conf_v1alpha1.Upstream{
+				{
+					Name: "dns-tcp",
+					Port: 90,
+					HealthCheck: &conf_v1alpha1.HealthCheck{
+						Enabled: true,
+					},
+				},
+			},
+			expected: &version2.StreamHealthCheck{
+				Enabled:  true,
+				Timeout:  "5s",
+				Jitter:   "0s",
+				Port:     90,
+				Interval: "5s",
+				Passes:   1,
+				Fails:    1,
+			},
+			msg: "return default values for health check",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/apis/configuration/v1alpha1/types.go
+++ b/pkg/apis/configuration/v1alpha1/types.go
@@ -91,7 +91,7 @@ type HealthCheck struct {
 	Timeout  string `json:"timeout"`
 	Jitter   string `json:"jitter"`
 	Port     int    `json:"port"`
-	Interval string `json:"intervals"`
+	Interval string `json:"interval"`
 	Passes   int    `json:"passes"`
 	Fails    int    `json:"fails"`
 }


### PR DESCRIPTION
### Proposed changes
This PR addresses a bug in the default values from health checks in transport server and refactors name of `Interval` field in yaml to be the same as in VS and VSR

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
