### PR TITLE
Add IC version to images pushed to Docker Hub

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -555,6 +555,7 @@ jobs:
           push: true
           build-args: |
             BUILD_OS=${{ matrix.type }}
+            IC_VERSION=${{ env.VERSION }}-${{ steps.commit.outputs.sha }}
 
   package-helm:
     name: Package Helm Chart


### PR DESCRIPTION
Adding `IC_VERSION` so it can be passed to the label in Docker at build time