### PR TITLE
fix: don't attempt to delete rhel license

### DIFF
--- a/build/appprotect/DockerfileWithAppProtectForPlusForOpenShift
+++ b/build/appprotect/DockerfileWithAppProtectForPlusForOpenShift
@@ -61,7 +61,7 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	          'cap_net_bind_service=+ep' /usr/sbin/nginx-debug \
 	&& yum remove -y wget \
 	&& rm /etc/yum.repos.d/nginx-plus-7.repo \
-	&& rm nginx_signing.key /tmp/rhel_license
+	&& rm nginx_signing.key
 
 
 # forward nginx access and error logs to stdout and stderr of the ingress


### PR DESCRIPTION
### Proposed changes
There is no need to delete the rhel_license any more as it is directly mounted as a secret - attempting to do so results in a "Device or resource busy" error

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes

