### PR TITLE
Fix setting host header in action proxy

### DIFF
--- a/docs-web/configuration/virtualserver-and-virtualserverroute-resources.md
+++ b/docs-web/configuration/virtualserver-and-virtualserverroute-resources.md
@@ -949,6 +949,12 @@ name: My-Header
 value: My-Value
 ```
 
+It is possible to override the default value of the `Host` header, which the Ingress Controller sets to [`$host`](https://nginx.org/en/docs/http/ngx_http_core_module.html#var_host):
+```yaml
+name: Host 
+value: example.com
+```
+
 ```eval_rst
 .. list-table::
    :header-rows: 1

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -367,7 +367,6 @@ server {
 
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $vs_connection_header;
-        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $host;

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -280,7 +280,6 @@ server {
 
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $vs_connection_header;
-        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $host;

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -1476,23 +1476,24 @@ func generateLocation(path string, upstreamName string, upstream conf_v1.Upstrea
 func generateProxySetHeaders(proxy *conf_v1.ActionProxy) []version2.Header {
 	var headers []version2.Header
 
-	hostHeaderValue := "$host"
+	hasHostHeader := false
 
 	if proxy != nil && proxy.RequestHeaders != nil {
 		for _, h := range proxy.RequestHeaders.Set {
-			if strings.ToLower(h.Name) == "host" {
-				hostHeaderValue = h.Value
-				continue
-			}
-
 			headers = append(headers, version2.Header{
 				Name:  h.Name,
 				Value: h.Value,
 			})
+
+			if strings.ToLower(h.Name) == "host" {
+				hasHostHeader = true
+			}
 		}
 	}
 
-	headers = append(headers, version2.Header{Name: "Host", Value: hostHeaderValue})
+	if !hasHostHeader {
+		headers = append(headers, version2.Header{Name: "Host", Value: "$host"})
+	}
 
 	return headers
 }

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -1474,17 +1474,25 @@ func generateLocation(path string, upstreamName string, upstream conf_v1.Upstrea
 }
 
 func generateProxySetHeaders(proxy *conf_v1.ActionProxy) []version2.Header {
-	if proxy == nil || proxy.RequestHeaders == nil {
-		return nil
+	var headers []version2.Header
+
+	hostHeaderValue := "$host"
+
+	if proxy != nil && proxy.RequestHeaders != nil {
+		for _, h := range proxy.RequestHeaders.Set {
+			if strings.ToLower(h.Name) == "host" {
+				hostHeaderValue = h.Value
+				continue
+			}
+
+			headers = append(headers, version2.Header{
+				Name:  h.Name,
+				Value: h.Value,
+			})
+		}
 	}
 
-	var headers []version2.Header
-	for _, h := range proxy.RequestHeaders.Set {
-		headers = append(headers, version2.Header{
-			Name:  h.Name,
-			Value: h.Value,
-		})
-	}
+	headers = append(headers, version2.Header{Name: "Host", Value: hostHeaderValue})
 
 	return headers
 }

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -506,6 +506,7 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 					HasKeepalive:             true,
 					ProxySSLName:             "tea-svc.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "tea-svc",
 				},
 				{
@@ -517,6 +518,7 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 					HasKeepalive:             true,
 					ProxySSLName:             "tea-svc.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "tea-svc",
 				},
 				// Order changes here because we generate first all the VS Routes and then all the VSR Subroutes (separated for loops)
@@ -537,6 +539,7 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 					},
 					ProxySSLName:            "coffee-svc.default.svc",
 					ProxyPassRequestHeaders: true,
+					ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:             "coffee-svc",
 				},
 				{
@@ -548,6 +551,7 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 					HasKeepalive:             true,
 					ProxySSLName:             "coffee-svc.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "coffee-svc",
 					IsVSR:                    true,
 					VSRName:                  "coffee",
@@ -562,6 +566,7 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 					HasKeepalive:             true,
 					ProxySSLName:             "sub-tea-svc.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "sub-tea-svc",
 					IsVSR:                    true,
 					VSRName:                  "subtea",
@@ -585,6 +590,7 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 					},
 					ProxySSLName:            "coffee-svc.default.svc",
 					ProxyPassRequestHeaders: true,
+					ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:             "coffee-svc",
 					IsVSR:                   true,
 					VSRName:                 "subcoffee",
@@ -607,6 +613,7 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 					},
 					ProxySSLName:            "coffee-svc.default.svc",
 					ProxyPassRequestHeaders: true,
+					ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:             "coffee-svc",
 					IsVSR:                   true,
 					VSRName:                 "subcoffee",
@@ -635,8 +642,8 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 	)
 
 	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil)
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("GenerateVirtualServerConfig returned \n%+v but expected \n%+v", result, expected)
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("GenerateVirtualServerConfig() mismatch (-want +got):\n%s", diff)
 	}
 
 	if len(warnings) != 0 {
@@ -729,6 +736,7 @@ func TestGenerateVirtualServerConfigWithSpiffeCerts(t *testing.T) {
 					HasKeepalive:             true,
 					ProxySSLName:             "tea-svc.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "tea-svc",
 				},
 			},
@@ -742,8 +750,8 @@ func TestGenerateVirtualServerConfigWithSpiffeCerts(t *testing.T) {
 	vsc := newVirtualServerConfigurator(&baseCfgParams, isPlus, isResolverConfigured, staticConfigParams)
 
 	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil)
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("GenerateVirtualServerConfig returned \n%+v but expected \n%+v", result, expected)
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("GenerateVirtualServerConfig() mismatch (-want +got):\n%s", diff)
 	}
 
 	if len(warnings) != 0 {
@@ -973,6 +981,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 					Internal:                 true,
 					ProxySSLName:             "tea-svc-v1.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "tea-svc-v1",
 				},
 				{
@@ -984,6 +993,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 					Internal:                 true,
 					ProxySSLName:             "tea-svc-v2.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "tea-svc-v2",
 				},
 				{
@@ -995,6 +1005,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 					Internal:                 true,
 					ProxySSLName:             "coffee-svc-v1.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "coffee-svc-v1",
 					IsVSR:                    true,
 					VSRName:                  "coffee",
@@ -1009,6 +1020,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 					Internal:                 true,
 					ProxySSLName:             "coffee-svc-v2.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "coffee-svc-v2",
 					IsVSR:                    true,
 					VSRName:                  "coffee",
@@ -1023,8 +1035,8 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 	vsc := newVirtualServerConfigurator(&baseCfgParams, isPlus, isResolverConfigured, &StaticConfigParams{})
 
 	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil)
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("GenerateVirtualServerConfig returned \n%+v but expected \n%+v", result, expected)
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("GenerateVirtualServerConfig() mismatch (-want +got):\n%s", diff)
 	}
 
 	if len(warnings) != 0 {
@@ -1286,6 +1298,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithMatches(t *testing.T) {
 					Internal:                 true,
 					ProxySSLName:             "tea-svc-v2.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "tea-svc-v2",
 				},
 				{
@@ -1297,6 +1310,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithMatches(t *testing.T) {
 					Internal:                 true,
 					ProxySSLName:             "tea-svc-v1.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "tea-svc-v1",
 				},
 				{
@@ -1308,6 +1322,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithMatches(t *testing.T) {
 					Internal:                 true,
 					ProxySSLName:             "coffee-svc-v2.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "coffee-svc-v2",
 					IsVSR:                    true,
 					VSRName:                  "coffee",
@@ -1322,6 +1337,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithMatches(t *testing.T) {
 					Internal:                 true,
 					ProxySSLName:             "coffee-svc-v1.default.svc",
 					ProxyPassRequestHeaders:  true,
+					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "coffee-svc-v1",
 					IsVSR:                    true,
 					VSRName:                  "coffee",
@@ -1336,8 +1352,8 @@ func TestGenerateVirtualServerConfigForVirtualServerWithMatches(t *testing.T) {
 	vsc := newVirtualServerConfigurator(&baseCfgParams, isPlus, isResolverConfigured, &StaticConfigParams{})
 
 	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil)
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("GenerateVirtualServerConfig returned \n%+v but expected \n%+v", result, expected)
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("GenerateVirtualServerConfig() mismatch (-want +got):\n%s", diff)
 	}
 
 	if len(warnings) != 0 {
@@ -3767,6 +3783,7 @@ func TestGenerateLocationForProxying(t *testing.T) {
 		ProxyNextUpstreamTimeout: "0s",
 		ProxyNextUpstreamTries:   0,
 		ProxyPassRequestHeaders:  true,
+		ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 		ServiceName:              "",
 		IsVSR:                    false,
 		VSRName:                  "",
@@ -3774,8 +3791,8 @@ func TestGenerateLocationForProxying(t *testing.T) {
 	}
 
 	result := generateLocationForProxying(path, upstreamName, conf_v1.Upstream{}, &cfgParams, nil, false, 0, "", nil, "", vsLocSnippets, false, "", "")
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("generateLocationForProxying() returned \n%+v but expected \n%+v", result, expected)
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("generateLocationForProxying() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -4503,6 +4520,7 @@ func TestGenerateSplits(t *testing.T) {
 			},
 			ProxySSLName:            "coffee-v1.default.svc",
 			ProxyPassRequestHeaders: true,
+			ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 			Snippets:                []string{locSnippet},
 			ServiceName:             "coffee-v1",
 			IsVSR:                   true,
@@ -4531,6 +4549,7 @@ func TestGenerateSplits(t *testing.T) {
 			},
 			ProxySSLName:            "coffee-v2.default.svc",
 			ProxyPassRequestHeaders: true,
+			ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 			Snippets:                []string{locSnippet},
 			ServiceName:             "coffee-v2",
 			IsVSR:                   true,
@@ -4645,6 +4664,7 @@ func TestGenerateDefaultSplitsConfig(t *testing.T) {
 				Internal:                 true,
 				ProxySSLName:             "coffee-v1.default.svc",
 				ProxyPassRequestHeaders:  true,
+				ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:              "coffee-v1",
 				IsVSR:                    true,
 				VSRName:                  "coffee",
@@ -4659,6 +4679,7 @@ func TestGenerateDefaultSplitsConfig(t *testing.T) {
 				Internal:                 true,
 				ProxySSLName:             "coffee-v2.default.svc",
 				ProxyPassRequestHeaders:  true,
+				ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:              "coffee-v2",
 				IsVSR:                    true,
 				VSRName:                  "coffee",
@@ -4952,6 +4973,7 @@ func TestGenerateMatchesConfig(t *testing.T) {
 				},
 				ProxySSLName:            "coffee-v1.default.svc",
 				ProxyPassRequestHeaders: true,
+				ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:             "coffee-v1",
 				IsVSR:                   false,
 				VSRName:                 "",
@@ -4979,6 +5001,7 @@ func TestGenerateMatchesConfig(t *testing.T) {
 				},
 				ProxySSLName:            "coffee-v1.default.svc",
 				ProxyPassRequestHeaders: true,
+				ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:             "coffee-v1",
 				IsVSR:                   false,
 				VSRName:                 "",
@@ -5006,6 +5029,7 @@ func TestGenerateMatchesConfig(t *testing.T) {
 				},
 				ProxySSLName:            "coffee-v2.default.svc",
 				ProxyPassRequestHeaders: true,
+				ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:             "coffee-v2",
 				IsVSR:                   false,
 				VSRName:                 "",
@@ -5033,6 +5057,7 @@ func TestGenerateMatchesConfig(t *testing.T) {
 				},
 				ProxySSLName:            "tea.default.svc",
 				ProxyPassRequestHeaders: true,
+				ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:             "tea",
 				IsVSR:                   false,
 				VSRName:                 "",
@@ -5268,6 +5293,7 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxyInterceptErrors:    true,
 				ProxySSLName:            "coffee-v1.default.svc",
 				ProxyPassRequestHeaders: true,
+				ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:             "coffee-v1",
 				IsVSR:                   true,
 				VSRName:                 "coffee",
@@ -5295,6 +5321,7 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxyInterceptErrors:    true,
 				ProxySSLName:            "coffee-v2.default.svc",
 				ProxyPassRequestHeaders: true,
+				ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:             "coffee-v2",
 				IsVSR:                   true,
 				VSRName:                 "coffee",
@@ -5322,6 +5349,7 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxyInterceptErrors:    true,
 				ProxySSLName:            "coffee-v2.default.svc",
 				ProxyPassRequestHeaders: true,
+				ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:             "coffee-v2",
 				IsVSR:                   true,
 				VSRName:                 "coffee",
@@ -5349,6 +5377,7 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxyInterceptErrors:    true,
 				ProxySSLName:            "coffee-v1.default.svc",
 				ProxyPassRequestHeaders: true,
+				ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:             "coffee-v1",
 				IsVSR:                   true,
 				VSRName:                 "coffee",
@@ -5376,6 +5405,7 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxyInterceptErrors:    true,
 				ProxySSLName:            "coffee-v1.default.svc",
 				ProxyPassRequestHeaders: true,
+				ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:             "coffee-v1",
 				IsVSR:                   true,
 				VSRName:                 "coffee",
@@ -5403,6 +5433,7 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 				ProxyInterceptErrors:    true,
 				ProxySSLName:            "coffee-v2.default.svc",
 				ProxyPassRequestHeaders: true,
+				ProxySetHeaders:         []version2.Header{{Name: "Host", Value: "$host"}},
 				ServiceName:             "coffee-v2",
 				IsVSR:                   true,
 				VSRName:                 "coffee",
@@ -6686,14 +6717,17 @@ func TestGenerateProxySetHeaders(t *testing.T) {
 	tests := []struct {
 		proxy    *conf_v1.ActionProxy
 		expected []version2.Header
+		msg      string
 	}{
 		{
 			proxy:    nil,
-			expected: nil,
+			expected: []version2.Header{{Name: "Host", Value: "$host"}},
+			msg:      "no action proxy",
 		},
 		{
 			proxy:    &conf_v1.ActionProxy{},
-			expected: nil,
+			expected: []version2.Header{{Name: "Host", Value: "$host"}},
+			msg:      "empty action proxy",
 		},
 		{
 			proxy: &conf_v1.ActionProxy{
@@ -6702,10 +6736,6 @@ func TestGenerateProxySetHeaders(t *testing.T) {
 						{
 							Name:  "Header-Name",
 							Value: "HeaderValue",
-						},
-						{
-							Name:  "Host",
-							Value: "nginx.org",
 						},
 					},
 				},
@@ -6717,16 +6747,102 @@ func TestGenerateProxySetHeaders(t *testing.T) {
 				},
 				{
 					Name:  "Host",
-					Value: "nginx.org",
+					Value: "$host",
 				},
 			},
+			msg: "set headers without host",
+		},
+		{
+			proxy: &conf_v1.ActionProxy{
+				RequestHeaders: &conf_v1.ProxyRequestHeaders{
+					Set: []conf_v1.Header{
+						{
+							Name:  "Header-Name",
+							Value: "HeaderValue",
+						},
+						{
+							Name:  "Host",
+							Value: "example.com",
+						},
+					},
+				},
+			},
+			expected: []version2.Header{
+				{
+					Name:  "Header-Name",
+					Value: "HeaderValue",
+				},
+				{
+					Name:  "Host",
+					Value: "example.com",
+				},
+			},
+			msg: "set headers with host capitalized",
+		},
+		{
+			proxy: &conf_v1.ActionProxy{
+				RequestHeaders: &conf_v1.ProxyRequestHeaders{
+					Set: []conf_v1.Header{
+						{
+							Name:  "Header-Name",
+							Value: "HeaderValue",
+						},
+						{
+							Name:  "hoST",
+							Value: "example.com",
+						},
+					},
+				},
+			},
+			expected: []version2.Header{
+				{
+					Name:  "Header-Name",
+					Value: "HeaderValue",
+				},
+				{
+					Name:  "Host",
+					Value: "example.com",
+				},
+			},
+			msg: "set headers with host in mixed case",
+		},
+		{
+			proxy: &conf_v1.ActionProxy{
+				RequestHeaders: &conf_v1.ProxyRequestHeaders{
+					Set: []conf_v1.Header{
+						{
+							Name:  "Header-Name",
+							Value: "HeaderValue",
+						},
+						{
+							Name:  "Host",
+							Value: "one.example.com",
+						},
+						{
+							Name:  "Host",
+							Value: "two.example.com",
+						},
+					},
+				},
+			},
+			expected: []version2.Header{
+				{
+					Name:  "Header-Name",
+					Value: "HeaderValue",
+				},
+				{
+					Name:  "Host",
+					Value: "two.example.com",
+				},
+			},
+			msg: "set headers with multiple hosts",
 		},
 	}
 
 	for _, test := range tests {
 		result := generateProxySetHeaders(test.proxy)
-		if !reflect.DeepEqual(result, test.expected) {
-			t.Errorf("generateProxySetHeaders(%v) returned %v but expected %v", test.proxy, result, test.expected)
+		if diff := cmp.Diff(test.expected, result); diff != "" {
+			t.Errorf("generateProxySetHeaders() '%v' mismatch (-want +got):\n%s", test.msg, diff)
 		}
 	}
 }

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -6800,7 +6800,7 @@ func TestGenerateProxySetHeaders(t *testing.T) {
 					Value: "HeaderValue",
 				},
 				{
-					Name:  "Host",
+					Name:  "hoST",
 					Value: "example.com",
 				},
 			},
@@ -6829,6 +6829,10 @@ func TestGenerateProxySetHeaders(t *testing.T) {
 				{
 					Name:  "Header-Name",
 					Value: "HeaderValue",
+				},
+				{
+					Name:  "Host",
+					Value: "one.example.com",
 				},
 				{
 					Name:  "Host",


### PR DESCRIPTION
### Proposed changes
Previously, a configuration like below will make NGINX send two host headers to the backend - the default "$host" and the configured "bar.example.com":
```yaml
apiVersion: k8s.nginx.org/v1
kind: VirtualServer
metadata:
  name: foo 
spec:
  host: foo.example.com
  upstreams:
  - name: foo
    port: 8080
    service: backend-svc
  routes:
  - path: "/"
    action:
      proxy:
        upstream: foo
        requestHeaders:
          set:
          - name: Host
            value: bar.example.com
```
Now NGINX will only send one host header: by default - "$host", or the one configured in `requestHeaders`

I also updated some of the tests to print diffs. Otherwise, it was hard to see the mismatch in results. 