### PR TITLE
Add whitespace to invalid values for time fields in resources

### DIFF
--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -187,8 +187,8 @@ var timeRegexp = regexp.MustCompile(`^(\d+y)??\s*(\d+M)??\s*(\d+w)??\s*(\d+d)??\
 
 // ParseTime ensures that the string value in the annotation is a valid time.
 func ParseTime(s string) (string, error) {
-	if s == "" || !timeRegexp.MatchString(s) {
-		return "", errors.New("Invalid time string")
+	if s == "" || strings.TrimSpace(s) == "" || !timeRegexp.MatchString(s) {
+		return "", errors.New("invalid time string")
 	}
 	units := timeRegexp.FindStringSubmatch(s)
 	years := units[1]

--- a/internal/configs/parsing_helpers_test.go
+++ b/internal/configs/parsing_helpers_test.go
@@ -381,7 +381,7 @@ func TestParseTime(t *testing.T) {
 		{"100y", "100y"},
 		{"600", "600s"},
 	}
-	var invalidInput = []string{"5s 5s", "ss", "rM", "m0m", "s1s", "-5s", "", "1L", "11 11"}
+	var invalidInput = []string{"5s 5s", "ss", "rM", "m0m", "s1s", "-5s", "", "1L", "11 11", " ", "   "}
 
 	for _, test := range testsWithValidInput {
 		result, err := ParseTime(test.input)


### PR DESCRIPTION
### Proposed changes
This change makes whitespace values for time fields invalid. Since they are marked as invalid, the associated resources will be rejected when parsed.

It includes a test to confirm the change in behaviour.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
