### PR TITLE
Increase operations per run to 100 in actions/stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,3 +17,4 @@ jobs:
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
           exempt-all-pr-assignees: true
+          operations-per-run: 100


### PR DESCRIPTION
The action is hitting the limit of 30 operations per run. Devs of the action suggested to increase the limit to 100.
