### PR TITLE
Wait for caches to sync when IC starts

### DIFF
--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -152,11 +152,6 @@ func findPort(pod *v1.Pod, svcPort *v1.ServicePort) (int32, error) {
 	return 0, fmt.Errorf("no suitable port for manifest: %s", pod.UID)
 }
 
-// storeToSecretLister makes a Store that lists Secrets
-type storeToSecretLister struct {
-	cache.Store
-}
-
 // isMinion determines is an ingress is a minion or not
 func isMinion(ing *networking.Ingress) bool {
 	return ing.Annotations["nginx.org/mergeable-ingress-type"] == "minion"

--- a/tests/suite/fixtures.py
+++ b/tests/suite/fixtures.py
@@ -537,9 +537,11 @@ def crd_ingress_controller_with_ap(
         print("------------------------- Register AP CRD -----------------------------------")
         ap_pol_crd_name = get_name_from_yaml(f"{DEPLOYMENTS}/common/crds-v1beta1/appprotect.f5.com_appolicies.yaml")
         ap_log_crd_name = get_name_from_yaml(f"{DEPLOYMENTS}/common/crds-v1beta1/appprotect.f5.com_aplogconfs.yaml")
+        ap_uds_crd_name = get_name_from_yaml(f"{DEPLOYMENTS}/common/crds-v1beta1/appprotect.f5.com_apusersigs.yaml")
         vs_crd_name = get_name_from_yaml(f"{DEPLOYMENTS}/common/crds-v1beta1/k8s.nginx.org_virtualservers.yaml")
         vsr_crd_name = get_name_from_yaml(f"{DEPLOYMENTS}/common/crds-v1beta1/k8s.nginx.org_virtualserverroutes.yaml")
         pol_crd_name = get_name_from_yaml(f"{DEPLOYMENTS}/common/crds-v1beta1/k8s.nginx.org_policies.yaml")
+        ts_crd_name = get_name_from_yaml(f"{DEPLOYMENTS}/common/crds-v1beta1/k8s.nginx.org_transportservers.yaml")
         create_crd_from_yaml(
             kube_apis.api_extensions_v1_beta1,
             ap_pol_crd_name,
@@ -549,6 +551,11 @@ def crd_ingress_controller_with_ap(
             kube_apis.api_extensions_v1_beta1,
             ap_log_crd_name,
             f"{DEPLOYMENTS}/common/crds-v1beta1/appprotect.f5.com_aplogconfs.yaml",
+        )
+        create_crd_from_yaml(
+            kube_apis.api_extensions_v1_beta1,
+            ap_uds_crd_name,
+            f"{DEPLOYMENTS}/common/crds-v1beta1/appprotect.f5.com_apusersigs.yaml",
         )
         create_crd_from_yaml(
             kube_apis.api_extensions_v1_beta1,
@@ -564,6 +571,11 @@ def crd_ingress_controller_with_ap(
             kube_apis.api_extensions_v1_beta1,
             pol_crd_name,
             f"{DEPLOYMENTS}/common/crds-v1beta1/k8s.nginx.org_policies.yaml",
+        )
+        create_crd_from_yaml(
+            kube_apis.api_extensions_v1_beta1,
+            ts_crd_name,
+            f"{DEPLOYMENTS}/common/crds-v1beta1/k8s.nginx.org_transportservers.yaml",
         )
 
         print("------------------------- Create IC -----------------------------------")
@@ -587,6 +599,21 @@ def crd_ingress_controller_with_ap(
         delete_crd(
             kube_apis.api_extensions_v1_beta1, ap_log_crd_name,
         )
+        delete_crd(
+            kube_apis.api_extensions_v1_beta1, ap_uds_crd_name,
+        )
+        delete_crd(
+            kube_apis.api_extensions_v1_beta1, vs_crd_name,
+        )
+        delete_crd(
+            kube_apis.api_extensions_v1_beta1, vsr_crd_name,
+        )
+        delete_crd(
+            kube_apis.api_extensions_v1_beta1, pol_crd_name,
+        )
+        delete_crd(
+            kube_apis.api_extensions_v1_beta1, ts_crd_name,
+        )
         print("Remove ap-rbac")
         cleanup_rbac(kube_apis.rbac_v1, rbac)
         print("Remove the IC:")
@@ -603,6 +630,9 @@ def crd_ingress_controller_with_ap(
             kube_apis.api_extensions_v1_beta1, ap_log_crd_name,
         )
         delete_crd(
+            kube_apis.api_extensions_v1_beta1, ap_uds_crd_name,
+        )
+        delete_crd(
             kube_apis.api_extensions_v1_beta1, vs_crd_name,
         )
         delete_crd(
@@ -610,6 +640,9 @@ def crd_ingress_controller_with_ap(
         )
         delete_crd(
             kube_apis.api_extensions_v1_beta1, pol_crd_name,
+        )
+        delete_crd(
+            kube_apis.api_extensions_v1_beta1, ts_crd_name,
         )
         print("Remove ap-rbac")
         cleanup_rbac(kube_apis.rbac_v1, rbac)

--- a/tests/suite/test_app_protect_integration.py
+++ b/tests/suite/test_app_protect_integration.py
@@ -369,12 +369,6 @@ class TestAppProtect:
         Test request with UDS rule string is rejected while AppProtect with User Defined Signatures is enabled in Ingress
         """
 
-        ap_uds_crd_name = get_name_from_yaml(uds_crd)
-        create_crd_from_yaml(
-            kube_apis.api_extensions_v1_beta1, ap_uds_crd_name, uds_crd,
-        )
-        wait_before_test()
-
         usersig_name = create_ap_usersig_from_yaml(
             kube_apis.custom_objects, uds_crd_resource, test_namespace
         )
@@ -413,10 +407,6 @@ class TestAppProtect:
             ap_policy,
             f"{TEST_DATA}/appprotect/{ap_policy}.yaml",
             test_namespace,
-        )
-        delete_ap_usersig(kube_apis.custom_objects, usersig_name, test_namespace)
-        delete_crd(
-            kube_apis.api_extensions_v1_beta1, ap_uds_crd_name,
         )
         delete_items_from_yaml(kube_apis, src_ing_yaml, test_namespace)
         assert_invalid_responses(response)

--- a/tests/suite/test_app_protect_waf_policies.py
+++ b/tests/suite/test_app_protect_waf_policies.py
@@ -52,7 +52,6 @@ waf_subroute_vsr_src = f"{TEST_DATA}/ap-waf/virtual-server-route-waf-subroute.ya
 waf_pol_default_src = f"{TEST_DATA}/ap-waf/policies/waf-default.yaml"
 waf_pol_dataguard_src = f"{TEST_DATA}/ap-waf/policies/waf-dataguard.yaml"
 ap_policy_uds = "dataguard-alarm-uds"
-uds_crd = f"{DEPLOYMENTS}/common/crds-v1beta1/appprotect.f5.com_apusersigs.yaml"
 uds_crd_resource = f"{TEST_DATA}/ap-waf/ap-ic-uds.yaml"
 valid_resp_addr = "Server address:"
 valid_resp_name = "Server name:"
@@ -76,13 +75,6 @@ def appprotect_setup(request, kube_apis, test_namespace) -> None:
     global log_name
     log_name = create_ap_logconf_from_yaml(kube_apis.custom_objects, src_log_yaml, test_namespace)
 
-    print("------------------------- Create UserSig CRD -----------------------------")
-    ap_uds_crd_name = get_name_from_yaml(uds_crd)
-    create_crd_from_yaml(
-        kube_apis.api_extensions_v1_beta1, ap_uds_crd_name, uds_crd,
-    )
-    wait_before_test()
-
     print("------------------------- Create UserSig CRD resource-----------------------------")
     usersig_name = create_ap_usersig_from_yaml(
         kube_apis.custom_objects, uds_crd_resource, test_namespace
@@ -97,9 +89,6 @@ def appprotect_setup(request, kube_apis, test_namespace) -> None:
         print("Clean up:")
         delete_ap_policy(kube_apis.custom_objects, ap_pol_name, test_namespace)
         delete_ap_usersig(kube_apis.custom_objects, usersig_name, test_namespace)
-        delete_crd(
-            kube_apis.api_extensions_v1_beta1, ap_uds_crd_name,
-        )
         delete_ap_logconf(kube_apis.custom_objects, log_name, test_namespace)
 
     request.addfinalizer(fin)

--- a/tests/suite/test_wildcard_tls_secret.py
+++ b/tests/suite/test_wildcard_tls_secret.py
@@ -77,7 +77,7 @@ def wildcard_tls_secret_ingress_controller(cli_arguments, kube_apis, ingress_con
     print("------------------------- Create IC and wildcard secret -----------------------------------")
     secret_name = create_secret_from_yaml(kube_apis.v1, namespace,
                                           f"{TEST_DATA}/wildcard-tls-secret/wildcard-tls-secret.yaml")
-    extra_args = [f"-wildcard-tls-secret={namespace}/{secret_name}"]
+    extra_args = [f"-wildcard-tls-secret={namespace}/{secret_name}", "-enable-custom-resources=false"]
     name = create_ingress_controller(kube_apis.v1, kube_apis.apps_v1_api, cli_arguments, namespace, extra_args)
     ensure_connection_to_public_endpoint(wildcard_tls_secret_setup.public_endpoint.public_ip,
                                          wildcard_tls_secret_setup.public_endpoint.port,


### PR DESCRIPTION
### Proposed changes

When the Ingress Controller is ready, its readiness probe succeeds, and it starts accepting client traffic.

The IC becomes ready when it drains the work queue at the start - this means the IC generated the configuration for all Ingress and other relevant resources in the cluster.

However, because the IC didn't wait for the caches to sync before starting processing the work queue, the work queue could contain only a fraction of the resources in the cluster. As a result, the IC would drain the queue quickly and mistakenly become ready. This is a bug, as not every relevant resource was processed.

Now, before starting the work queue, the IC waits for the caches to sync. This fixes the problem

Changes:
- Use shared informer factories for most of the controllers (informers), instead of creating them manually. 
- For controllers that need special parameters, continue creating them manually
- Wait for the caches of all controllers to sync before starting processing the work queue
