### PR TITLE
Add max connections config to TransportServer

### DIFF
--- a/deployments/common/crds-v1beta1/k8s.nginx.org_transportservers.yaml
+++ b/deployments/common/crds-v1beta1/k8s.nginx.org_transportservers.yaml
@@ -114,6 +114,8 @@ spec:
                         type: integer
                       timeout:
                         type: string
+                  maxConnections:
+                    type: integer
                   maxFails:
                     type: integer
                   name:

--- a/deployments/common/crds/k8s.nginx.org_transportservers.yaml
+++ b/deployments/common/crds/k8s.nginx.org_transportservers.yaml
@@ -113,6 +113,8 @@ spec:
                             type: integer
                           timeout:
                             type: string
+                      maxConnections:
+                        type: integer
                       maxFails:
                         type: integer
                       name:

--- a/deployments/helm-chart/crds/k8s.nginx.org_transportservers.yaml
+++ b/deployments/helm-chart/crds/k8s.nginx.org_transportservers.yaml
@@ -113,6 +113,8 @@ spec:
                             type: integer
                           timeout:
                             type: string
+                      maxConnections:
+                        type: integer
                       maxFails:
                         type: integer
                       name:

--- a/docs-web/configuration/transportserver-resource.md
+++ b/docs-web/configuration/transportserver-resource.md
@@ -168,6 +168,7 @@ name: secure-app
 service: secure-app
 port: 8443
 maxFails: 3
+maxConnections: 100
 failTimeout: 30s
 ```
 
@@ -193,6 +194,10 @@ failTimeout: 30s
      - Yes
    * - ``maxFails``
      - Sets the `number <https://nginx.org/en/docs/stream/ngx_stream_upstream_module.html#max_fails>`_ of unsuccessful attempts to communicate with the server that should happen in the duration set by the failTimeout parameter to consider the server unavailable. The default ``1``.
+     - ``int``
+     - No
+   * - ``maxConnections``
+     - Sets the `number <https://nginx.org/en/docs/stream/ngx_stream_upstream_module.html#max_conns>`_ of maximum connections to the proxied server. Default value is zero, meaning there is no limit. The default is ``0``.
      - ``int``
      - No
    * - ``failTimeout``

--- a/internal/configs/transportserver.go
+++ b/internal/configs/transportserver.go
@@ -169,6 +169,7 @@ func generateStreamUpstream(upstream *conf_v1alpha1.Upstream, upstreamNamer *ups
 
 	name := upstreamNamer.GetNameForUpstream(upstream.Name)
 	maxFails := generateIntFromPointer(upstream.MaxFails, 1)
+	maxConnections := generateIntFromPointer(upstream.MaxConnections, 0)
 	failTimeout := generateTimeWithDefault(upstream.FailTimeout, "10s")
 
 	for _, e := range endpoints {
@@ -183,9 +184,10 @@ func generateStreamUpstream(upstream *conf_v1alpha1.Upstream, upstreamNamer *ups
 
 	if !isPlus && len(endpoints) == 0 {
 		upsServers = append(upsServers, version2.StreamUpstreamServer{
-			Address:     nginxNonExistingUnixSocket,
-			MaxFails:    maxFails,
-			FailTimeout: failTimeout,
+			Address:        nginxNonExistingUnixSocket,
+			MaxFails:       maxFails,
+			FailTimeout:    failTimeout,
+			MaxConnections: maxConnections,
 		})
 	}
 

--- a/internal/configs/version2/nginx-plus.transportserver.tmpl
+++ b/internal/configs/version2/nginx-plus.transportserver.tmpl
@@ -5,7 +5,7 @@ upstream {{ $u.Name }} {
     random two least_conn;
 
     {{ range $s := $u.Servers }}
-    server {{ $s.Address }} max_fails={{ $s.MaxFails }} fail_timeout={{ $s.FailTimeout }};
+    server {{ $s.Address }} max_fails={{ $s.MaxFails }} fail_timeout={{ $s.FailTimeout }} {{ if $s.MaxConnections }} max_conns=$s.MaxConnections {{ end }};
     {{ end }}
 }
 {{ end }}

--- a/internal/configs/version2/nginx.transportserver.tmpl
+++ b/internal/configs/version2/nginx.transportserver.tmpl
@@ -5,7 +5,7 @@ upstream {{ $u.Name }} {
     random two least_conn;
 
     {{ range $s := $u.Servers }}
-    server {{ $s.Address }} max_fails={{ $s.MaxFails }} fail_timeout={{ $s.FailTimeout }};
+    server {{ $s.Address }} max_fails={{ $s.MaxFails }} fail_timeout={{ $s.FailTimeout }} max_conns=$s.MaxConnections;
     {{ end }}
 }
 {{ end }}

--- a/internal/configs/version2/stream.go
+++ b/internal/configs/version2/stream.go
@@ -15,9 +15,10 @@ type StreamUpstream struct {
 
 // StreamUpstreamServer defines a stream upstream server.
 type StreamUpstreamServer struct {
-	Address     string
-	MaxFails    int
-	FailTimeout string
+	Address        string
+	MaxFails       int
+	FailTimeout    string
+	MaxConnections int
 }
 
 // StreamServer defines a server in the stream module.

--- a/pkg/apis/configuration/v1alpha1/types.go
+++ b/pkg/apis/configuration/v1alpha1/types.go
@@ -84,12 +84,13 @@ type TransportServerListener struct {
 
 // Upstream defines an upstream.
 type Upstream struct {
-	Name        string       `json:"name"`
-	Service     string       `json:"service"`
-	Port        int          `json:"port"`
-	FailTimeout string       `json:"failTimeout"`
-	MaxFails    *int         `json:"maxFails"`
-	HealthCheck *HealthCheck `json:"healthCheck"`
+	Name           string       `json:"name"`
+	Service        string       `json:"service"`
+	Port           int          `json:"port"`
+	FailTimeout    string       `json:"failTimeout"`
+	MaxFails       *int         `json:"maxFails"`
+	MaxConnections *int         `json:"maxConnections"`
+	HealthCheck    *HealthCheck `json:"healthCheck"`
 }
 
 // HealthCheck defines the parameters for active Upstream HealthChecks.

--- a/pkg/apis/configuration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/configuration/v1alpha1/zz_generated.deepcopy.go
@@ -293,6 +293,11 @@ func (in *Upstream) DeepCopyInto(out *Upstream) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.MaxConnections != nil {
+		in, out := &in.MaxConnections, &out.MaxConnections
+		*out = new(int)
+		**out = **in
+	}
 	if in.HealthCheck != nil {
 		in, out := &in.HealthCheck, &out.HealthCheck
 		*out = new(HealthCheck)

--- a/pkg/apis/configuration/validation/transportserver.go
+++ b/pkg/apis/configuration/validation/transportserver.go
@@ -162,7 +162,8 @@ func validateTransportServerUpstreams(upstreams []v1alpha1.Upstream, fieldPath *
 
 		allErrs = append(allErrs, validateServiceName(u.Service, idxPath.Child("service"))...)
 		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.MaxFails, idxPath.Child("maxFails"))...)
-		allErrs = append(allErrs, validateTime((u.FailTimeout), idxPath.Child("failTimeout"))...)
+		allErrs = append(allErrs, validatePositiveIntOrZeroFromPointer(u.MaxFails, idxPath.Child("maxConnections"))...)
+		allErrs = append(allErrs, validateTime(u.FailTimeout, idxPath.Child("failTimeout"))...)
 
 		for _, msg := range validation.IsValidPortNum(u.Port) {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("port"), u.Port, msg))


### PR DESCRIPTION
### Proposed changes
This change allows users to specify the max number of connections to the proxied server. https://nginx.org/en/docs/stream/ngx_stream_upstream_module.html#max_conns



### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
