### PR TITLE
fix: Update openssl libs in UBI base image & update nginx version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.0-experimental
-ARG NGINX_VERSION=1.19.8
+ARG NGINX_VERSION=1.19.9
 ARG BUILD_OS=debian
 
 ############################################# Base image for Debian #############################################

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -129,7 +129,8 @@ LABEL name="NGINX Ingress Controller" \
 
 RUN set -x \
 	&& groupadd --system --gid 101 nginx \
-	&& useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx
+	&& useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx \
+	&& yum update -y openssl-libs
 
 
 RUN mkdir licenses

--- a/docs-web/technical-specifications.md
+++ b/docs-web/technical-specifications.md
@@ -14,7 +14,7 @@ We provide the following Docker images, which include NGINX/NGINX Plus bundled w
 
 ### Images with NGINX
 
-All images include NGINX 1.19.8.
+All images include NGINX 1.19.9.
 The supported architecture is x86-64.
 
 ```eval_rst
@@ -26,15 +26,15 @@ The supported architecture is x86-64.
       - Third-party modules
       - DockerHub image
     * - Debian-based image
-      - ``nginx:1.19.8``, which is based on ``debian:buster-slim``
+      - ``nginx:1.19.9``, which is based on ``debian:buster-slim``
       -
       - ``nginx/nginx-ingress:1.11.0``
     * - Alpine-based image
-      - ``nginx:1.19.8-alpine``, which is based on ``alpine:3.13``
+      - ``nginx:1.19.9-alpine``, which is based on ``alpine:3.13``
       -
       - ``nginx/nginx-ingress:1.11.0-alpine``
     * - Debian-based image with Opentracing
-      - ``nginx:1.19.8``, which is based on ``debian:buster-slim``
+      - ``nginx:1.19.9``, which is based on ``debian:buster-slim``
       - OpenTracing API for C++ 1.5.1, NGINX plugin for OpenTracing, C++ OpenTracing binding for Jaeger 0.4.2
       -
     * - Ubi-based image


### PR DESCRIPTION
### Proposed changes
- Run a yum update for the openssl libs in the base UBI images
- Update nginx version to 1.19.9

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [n/a] I have rebased my branch onto master
- [n/a] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
