### PR TITLE
Read Go version from go.mod in workflows

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -30,7 +30,6 @@ defaults:
 
 env:
   DOCKER_BUILDKIT: 1
-  GOLANG_VERSION: 1.16
   K8S_VERSION: 1.20.2
   K8S_TIMEOUT: 75s
   HELM_CHART_DIR: deployments/helm-chart
@@ -51,10 +50,12 @@ jobs:
         id: commit
         run: |
           echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
+      - name: Determine Go version from go.mod
+        run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
       - name: Setup Golang Environment
         uses: actions/setup-go@v2
         with:
-          go-version: '${{ env.GOLANG_VERSION }}'
+          go-version: ${{ env.GO_VERSION }}
       - name: Check if CRDs changed
         run: |
           make update-crds && git diff --name-only --exit-code deployments/common/crds*
@@ -81,7 +82,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@v2
         with:
-          go-version: '${{ env.GOLANG_VERSION }}'
+          go-version: ${{ env.GO_VERSION }}
       - name: Run Tests
         run: go test ./...
 

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -18,7 +18,6 @@ defaults:
 env:
   FOSSA_VER: 1.1.0
   FOSSA_URL: https://github.com/fossas/fossa-cli/releases/download
-  GOLANG_VERSION: 1.16
 
 jobs:
 
@@ -28,10 +27,12 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+      - name: Determine Go version from go.mod
+        run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
       - name: Setup Golang Environment
         uses: actions/setup-go@v2
         with:
-          go-version: '${{ env.GOLANG_VERSION }}'
+          go-version: '${{ env.GO_VERSION }}'
       - name: Configure Fossa CLI
         run: |
           wget ${{ env.FOSSA_URL }}/v${{ env.FOSSA_VER }}/fossa-cli_${{ env.FOSSA_VER }}_linux_amd64.tar.gz

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,6 @@ defaults:
 
 env:
   DOCKER_BUILDKIT: 1
-  GOLANG_VERSION: 1.16
   K8S_TIMEOUT: 90s
   HELM_CHART_DIR: deployments/helm-chart
   HELM_CHART_VERSION: 0.0.0-edge
@@ -28,6 +27,8 @@ jobs:
         id: commit
         run: |
           echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
+      - name: Determine Go version from go.mod
+        run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
       - name: Check if CRDs changed
         run: |
           make update-crds && git diff --name-only --exit-code deployments/common/crds*
@@ -54,7 +55,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@v2
         with:
-          go-version: '${{ env.GOLANG_VERSION }}'
+          go-version: ${{ env.GO_VERSION }}
       - name: Run Tests
         run: go test ./...
 


### PR DESCRIPTION
Remove the need to specify (and keep up to date) Go version in workflows.
