### PR TITLE
Don't require default server TLS secret

### DIFF
--- a/docs-web/configuration/global-configuration/command-line-arguments.md
+++ b/docs-web/configuration/global-configuration/command-line-arguments.md
@@ -15,7 +15,8 @@ Below we describe the available command-line arguments:
 	Secret with a TLS certificate and key for TLS termination of the default server.
 
 	- If not set, certificate and key in the file "/etc/nginx/secrets/default" are used.
-	- If a secret is set, but the Ingress controller is not able to fetch it from Kubernetes API, or if a secret is not set and the file "/etc/nginx/secrets/  default" does not exist, the Ingress controller will fail to start.
+	- If "/etc/nginx/secrets/default" doesn't exist, the Ingress Controller will configure NGINX to reject TLS connections to the default server.
+	- If a secret is set, but the Ingress controller is not able to fetch it from Kubernetes API, or it is not set and the Ingress Controller fails to read the file "/etc/nginx/secrets/default", the Ingress controller will fail to start.
 
 	Format: ``<namespace>/<name>``
 

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -116,6 +116,7 @@ type StaticConfigParams struct {
 	PodName                        string
 	EnableLatencyMetrics           bool
 	EnablePreviewPolicies          bool
+	SSLRejectHandshake             bool
 }
 
 // GlobalConfigParams holds global configuration parameters. For now, it only holds listeners.

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -534,6 +534,7 @@ func GenerateNginxMainConfig(staticCfgParams *StaticConfigParams, config *Config
 		SSLDHParam:                         config.MainServerSSLDHParam,
 		SSLPreferServerCiphers:             config.MainServerSSLPreferServerCiphers,
 		SSLProtocols:                       config.MainServerSSLProtocols,
+		SSLRejectHandshake:                 staticCfgParams.SSLRejectHandshake,
 		TLSPassthrough:                     staticCfgParams.TLSPassthrough,
 		StreamLogFormat:                    config.MainStreamLogFormat,
 		StreamLogFormatEscaping:            config.MainStreamLogFormatEscaping,

--- a/internal/configs/configurator.go
+++ b/internal/configs/configurator.go
@@ -40,6 +40,9 @@ const (
 	appProtectUserSigIndex          = "/etc/nginx/waf/nac-usersigs/index.conf"
 )
 
+// DefaultServerSecretPath is the full path to the Secret with a TLS cert and a key for the default server.
+const DefaultServerSecretPath = "/etc/nginx/secrets/default"
+
 // DefaultServerSecretName is the filename of the Secret with a TLS cert and a key for the default server.
 const DefaultServerSecretName = "default"
 

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -174,6 +174,7 @@ type MainConfig struct {
 	ServerNamesHashBucketSize          string
 	ServerNamesHashMaxSize             string
 	ServerTokens                       string
+	SSLRejectHandshake                 bool
 	SSLCiphers                         string
 	SSLDHParam                         string
 	SSLPreferServerCiphers             bool

--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -130,8 +130,12 @@ http {
         listen 443 ssl default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};
         {{end}}
 
+        {{if .SSLRejectHandshake}}
+        ssl_reject_handshake on;
+        {{else}}
         ssl_certificate /etc/nginx/secrets/default;
         ssl_certificate_key /etc/nginx/secrets/default;
+        {{end}}
 
         {{range $setRealIPFrom := .SetRealIPFrom}}
         set_real_ip_from {{$setRealIPFrom}};{{end}}

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -107,8 +107,12 @@ http {
         listen 443 ssl default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};
         {{end}}
 
+        {{if .SSLRejectHandshake}}
+        ssl_reject_handshake on;
+        {{else}}
         ssl_certificate /etc/nginx/secrets/default;
         ssl_certificate_key /etc/nginx/secrets/default;
+        {{end}}
 
         {{range $setRealIPFrom := .SetRealIPFrom}}
         set_real_ip_from {{$setRealIPFrom}};{{end}}


### PR DESCRIPTION
### Proposed changes

If the default server TLS secret is not configured via -default-server-tls-secret cli arg or it is not present on the filesystem at /etc/nginx/secrets/default, the Ingress Controller will configure NGINX to reject TLS connections to the default server.

Note: The default server is used in NGINX configuration to handle HTTP and HTTPS request to hosts that are not configured by any Ingress, VirtualServer or TransportServer resources. The default server simply returns 404 responses.

Also note: because currently handling missing/invalid TLS secret relies on the default server TLS secret being present on the file system, this PR https://github.com/nginxinc/kubernetes-ingress/pull/1500 (which changes the handling) needs to be merged first.
