### PR TITLE
Rename read_crds to read_custom_resource

### DIFF
--- a/tests/suite/custom_resources_utils.py
+++ b/tests/suite/custom_resources_utils.py
@@ -65,7 +65,7 @@ def delete_crd(api_extensions_v1_beta1: ApiextensionsV1beta1Api, name) -> None:
     print(f"CRD was removed with name '{name}'")
 
 
-def read_crd(custom_objects: CustomObjectsApi, namespace, plural, name) -> object:
+def read_custom_resource(custom_objects: CustomObjectsApi, namespace, plural, name) -> object:
     """
     Get CRD information (kubectl describe output)
 

--- a/tests/suite/test_ac_policies.py
+++ b/tests/suite/test_ac_policies.py
@@ -2,7 +2,7 @@ import pytest, requests
 from kubernetes.client.rest import ApiException
 from suite.resources_utils import wait_before_test, replace_configmap_from_yaml
 from suite.custom_resources_utils import (
-    read_crd,
+    read_custom_resource,
     delete_virtual_server,
     create_virtual_server_from_yaml,
     patch_virtual_server_from_yaml,
@@ -122,7 +122,7 @@ class TestAccessControlPoliciesVs:
         )
         wait_before_test()
 
-        policy_info = read_crd(kube_apis.custom_objects, test_namespace, "policies", pol_name)
+        policy_info = read_custom_resource(kube_apis.custom_objects, test_namespace, "policies", pol_name)
         print(f"\nUse IP listed in deny block: 10.0.0.1")
         resp1 = requests.get(
             virtual_server_setup.backend_1_url,
@@ -183,7 +183,7 @@ class TestAccessControlPoliciesVs:
         )
         wait_before_test()
 
-        policy_info = read_crd(kube_apis.custom_objects, test_namespace, "policies", pol_name)
+        policy_info = read_custom_resource(kube_apis.custom_objects, test_namespace, "policies", pol_name)
         print(f"\nUse IP listed in allow block: 10.0.0.1")
         resp1 = requests.get(
             virtual_server_setup.backend_1_url,
@@ -300,13 +300,13 @@ class TestAccessControlPoliciesVs:
         )
         print(f"Response: {resp.status_code}\n{resp.text}")
 
-        vs_info = read_crd(
+        vs_info = read_custom_resource(
             kube_apis.custom_objects,
             virtual_server_setup.namespace,
             "virtualservers",
             virtual_server_setup.vs_name,
         )
-        policy_info = read_crd(
+        policy_info = read_custom_resource(
             kube_apis.custom_objects, test_namespace, "policies", invalid_pol_name
         )
         delete_policy(kube_apis.custom_objects, invalid_pol_name, test_namespace)
@@ -353,7 +353,7 @@ class TestAccessControlPoliciesVs:
         )
 
         wait_before_test()
-        vs_info = read_crd(
+        vs_info = read_custom_resource(
             kube_apis.custom_objects,
             virtual_server_setup.namespace,
             "virtualservers",
@@ -369,7 +369,7 @@ class TestAccessControlPoliciesVs:
         )
         print(f"Response: {resp.status_code}\n{resp.text}")
 
-        vs_info = read_crd(
+        vs_info = read_custom_resource(
             kube_apis.custom_objects,
             virtual_server_setup.namespace,
             "virtualservers",

--- a/tests/suite/test_ac_policies_vsr.py
+++ b/tests/suite/test_ac_policies_vsr.py
@@ -2,7 +2,7 @@ import pytest, requests
 from kubernetes.client.rest import ApiException
 from suite.resources_utils import wait_before_test, replace_configmap_from_yaml
 from suite.custom_resources_utils import (
-    read_crd,
+    read_custom_resource,
     delete_virtual_server,
     create_virtual_server_from_yaml,
     patch_virtual_server_from_yaml,
@@ -123,7 +123,7 @@ class TestAccessControlPoliciesVsr:
             v_s_route_setup.route_m.namespace,
         )
         wait_before_test()
-        policy_info = read_crd(
+        policy_info = read_custom_resource(
             kube_apis.custom_objects, v_s_route_setup.route_m.namespace, "policies", pol_name
         )
 
@@ -185,7 +185,7 @@ class TestAccessControlPoliciesVsr:
             v_s_route_setup.route_m.namespace,
         )
         wait_before_test()
-        policy_info = read_crd(
+        policy_info = read_custom_resource(
             kube_apis.custom_objects, v_s_route_setup.route_m.namespace, "policies", pol_name
         )
 
@@ -306,7 +306,7 @@ class TestAccessControlPoliciesVsr:
             v_s_route_setup.route_m.namespace,
         )
         wait_before_test()
-        policy_info = read_crd(
+        policy_info = read_custom_resource(
             kube_apis.custom_objects, v_s_route_setup.route_m.namespace, "policies", pol_name
         )
 
@@ -316,7 +316,7 @@ class TestAccessControlPoliciesVsr:
             headers={"host": v_s_route_setup.vs_host, "X-Real-IP": "10.0.0.1"},
         )
         print(f"Response: {resp.status_code}\n{resp.text}")
-        vsr_info = read_crd(
+        vsr_info = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",

--- a/tests/suite/test_jwt_policies.py
+++ b/tests/suite/test_jwt_policies.py
@@ -8,7 +8,7 @@ from suite.resources_utils import (
     replace_secret,
 )
 from suite.custom_resources_utils import (
-    read_crd,
+    read_custom_resource,
     delete_virtual_server,
     create_virtual_server_from_yaml,
     delete_and_create_vs_from_yaml,
@@ -181,7 +181,7 @@ class TestJWTPolicies:
         resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
         print(resp.status_code)
 
-        crd_info = read_crd(
+        crd_info = read_custom_resource(
             kube_apis.custom_objects,
             virtual_server_setup.namespace,
             "virtualservers",
@@ -226,7 +226,7 @@ class TestJWTPolicies:
         )
 
         print(f"Patch vs with policy: {policy}")
-        policy_info = read_crd(kube_apis.custom_objects, test_namespace, "policies", pol_name)
+        policy_info = read_custom_resource(kube_apis.custom_objects, test_namespace, "policies", pol_name)
         if policy == jwt_pol_valid_src:
             vs_src = jwt_vs_single_src
             assert (
@@ -253,7 +253,7 @@ class TestJWTPolicies:
         wait_before_test()
         resp = requests.get(virtual_server_setup.backend_1_url, headers=headers)
         print(resp.status_code)
-        crd_info = read_crd(
+        crd_info = read_custom_resource(
             kube_apis.custom_objects,
             virtual_server_setup.namespace,
             "virtualservers",

--- a/tests/suite/test_jwt_policies_vsr.py
+++ b/tests/suite/test_jwt_policies_vsr.py
@@ -8,7 +8,7 @@ from suite.resources_utils import (
     replace_secret,
 )
 from suite.custom_resources_utils import (
-    read_crd,
+    read_custom_resource,
     delete_virtual_server,
     patch_virtual_server_from_yaml,
     patch_v_s_route_from_yaml,
@@ -208,7 +208,7 @@ class TestJWTPoliciesVsr:
         resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers,)
         print(resp.status_code)
 
-        crd_info = read_crd(
+        crd_info = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",
@@ -277,10 +277,10 @@ class TestJWTPoliciesVsr:
 
         resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers,)
         print(resp.status_code)
-        policy_info = read_crd(
+        policy_info = read_custom_resource(
             kube_apis.custom_objects, v_s_route_setup.route_m.namespace, "policies", pol_name
         )
-        crd_info = read_crd(
+        crd_info = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",
@@ -353,7 +353,7 @@ class TestJWTPoliciesVsr:
         delete_secret(kube_apis.v1, secret, v_s_route_setup.route_m.namespace)
         resp2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers,)
         print(resp2.status_code)
-        crd_info = read_crd(
+        crd_info = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",
@@ -413,7 +413,7 @@ class TestJWTPoliciesVsr:
 
         resp2 = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers,)
         print(resp2.status_code)
-        crd_info = read_crd(
+        crd_info = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",
@@ -472,7 +472,7 @@ class TestJWTPoliciesVsr:
         resp = requests.get(f"{req_url}{v_s_route_setup.route_m.paths[0]}", headers=headers,)
         print(resp.status_code)
 
-        crd_info = read_crd(
+        crd_info = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",

--- a/tests/suite/test_rl_policies.py
+++ b/tests/suite/test_rl_policies.py
@@ -2,7 +2,7 @@ import pytest, requests, time
 from kubernetes.client.rest import ApiException
 from suite.resources_utils import wait_before_test, replace_configmap_from_yaml
 from suite.custom_resources_utils import (
-    read_crd,
+    read_custom_resource,
     delete_virtual_server,
     create_virtual_server_from_yaml,
     patch_virtual_server_from_yaml,
@@ -76,7 +76,7 @@ class TestRateLimitingPolicies:
         )
 
         wait_before_test()
-        policy_info = read_crd(kube_apis.custom_objects, test_namespace, "policies", pol_name)
+        policy_info = read_custom_resource(kube_apis.custom_objects, test_namespace, "policies", pol_name)
         occur = []
         t_end = time.perf_counter() + 1
         resp = requests.get(
@@ -117,7 +117,7 @@ class TestRateLimitingPolicies:
         )
 
         wait_before_test()
-        policy_info = read_crd(kube_apis.custom_objects, test_namespace, "policies", pol_name)
+        policy_info = read_custom_resource(kube_apis.custom_objects, test_namespace, "policies", pol_name)
         occur = []
         t_end = time.perf_counter() + 1
         resp = requests.get(
@@ -158,7 +158,7 @@ class TestRateLimitingPolicies:
         )
 
         wait_before_test()
-        policy_info = read_crd(
+        policy_info = read_custom_resource(
             kube_apis.custom_objects, test_namespace, "policies", invalid_pol_name
         )
         resp = requests.get(

--- a/tests/suite/test_rl_policies_vsr.py
+++ b/tests/suite/test_rl_policies_vsr.py
@@ -2,7 +2,7 @@ import pytest, requests, time
 from kubernetes.client.rest import ApiException
 from suite.resources_utils import wait_before_test, replace_configmap_from_yaml
 from suite.custom_resources_utils import (
-    read_crd,
+    read_custom_resource,
     delete_virtual_server,
     create_virtual_server_from_yaml,
     patch_virtual_server_from_yaml,
@@ -94,7 +94,7 @@ class TestRateLimitingPoliciesVsr:
         )
 
         wait_before_test()
-        policy_info = read_crd(
+        policy_info = read_custom_resource(
             kube_apis.custom_objects, v_s_route_setup.route_m.namespace, "policies", pol_name
         )
         occur = []
@@ -148,7 +148,7 @@ class TestRateLimitingPoliciesVsr:
         )
 
         wait_before_test()
-        policy_info = read_crd(
+        policy_info = read_custom_resource(
             kube_apis.custom_objects, v_s_route_setup.route_m.namespace, "policies", pol_name
         )
         occur = []
@@ -292,7 +292,7 @@ class TestRateLimitingPoliciesVsr:
         )
 
         wait_before_test()
-        policy_info = read_crd(
+        policy_info = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "policies",

--- a/tests/suite/test_v_s_route_rewrites.py
+++ b/tests/suite/test_v_s_route_rewrites.py
@@ -3,7 +3,7 @@ import requests
 from kubernetes.client.rest import ApiException
 from suite.resources_utils import wait_before_test
 from suite.custom_resources_utils import (
-    read_crd,
+    read_custom_resource,
     patch_virtual_server_from_yaml,
     patch_v_s_route_from_yaml,
     delete_virtual_server,

--- a/tests/suite/test_v_s_route_status.py
+++ b/tests/suite/test_v_s_route_status.py
@@ -2,7 +2,7 @@ import pytest
 from kubernetes.client.rest import ApiException
 from suite.resources_utils import wait_before_test
 from suite.custom_resources_utils import (
-    read_crd,
+    read_custom_resource,
     patch_virtual_server_from_yaml,
     patch_v_s_route_from_yaml,
     delete_virtual_server,
@@ -60,13 +60,13 @@ class TestVirtualServerRouteStatus:
         """
         Test VirtualServerRoute status with a valid fields in yaml
         """
-        response_m = read_crd(
+        response_m = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",
             v_s_route_setup.route_m.name,
         )
-        response_s = read_crd(
+        response_s = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_s.namespace,
             "virtualserverroutes",
@@ -109,13 +109,13 @@ class TestVirtualServerRouteStatus:
         )
         wait_before_test()
 
-        response_m = read_crd(
+        response_m = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",
             v_s_route_setup.route_m.name,
         )
-        response_s = read_crd(
+        response_s = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_s.namespace,
             "virtualserverroutes",
@@ -161,13 +161,13 @@ class TestVirtualServerRouteStatus:
         )
         wait_before_test()
 
-        response_m = read_crd(
+        response_m = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",
             v_s_route_setup.route_m.name,
         )
-        response_s = read_crd(
+        response_s = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_s.namespace,
             "virtualserverroutes",
@@ -202,13 +202,13 @@ class TestVirtualServerRouteStatus:
         )
         wait_before_test()
 
-        response_m = read_crd(
+        response_m = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",
             v_s_route_setup.route_m.name,
         )
-        response_s = read_crd(
+        response_s = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_s.namespace,
             "virtualserverroutes",
@@ -239,13 +239,13 @@ class TestVirtualServerRouteStatus:
             kube_apis.custom_objects, v_s_route_setup.vs_name, v_s_route_setup.namespace,
         )
 
-        response_m = read_crd(
+        response_m = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_m.namespace,
             "virtualserverroutes",
             v_s_route_setup.route_m.name,
         )
-        response_s = read_crd(
+        response_s = read_custom_resource(
             kube_apis.custom_objects,
             v_s_route_setup.route_s.namespace,
             "virtualserverroutes",

--- a/tests/suite/test_virtual_server_rewrites.py
+++ b/tests/suite/test_virtual_server_rewrites.py
@@ -3,7 +3,7 @@ import requests
 from kubernetes.client.rest import ApiException
 from suite.resources_utils import wait_before_test
 from suite.custom_resources_utils import (
-    read_crd,
+    read_custom_resource,
     patch_virtual_server_from_yaml,
 )
 from settings import TEST_DATA

--- a/tests/suite/test_virtual_server_status.py
+++ b/tests/suite/test_virtual_server_status.py
@@ -2,7 +2,7 @@ import pytest
 from kubernetes.client.rest import ApiException
 from suite.resources_utils import wait_before_test
 from suite.custom_resources_utils import (
-    read_crd,
+    read_custom_resource,
     patch_virtual_server_from_yaml,
 )
 from settings import TEST_DATA
@@ -39,7 +39,7 @@ class TestVirtualServerStatus:
         """
         Test VirtualServer status with a valid fields in yaml
         """
-        response = read_crd(
+        response = read_custom_resource(
             kube_apis.custom_objects,
             virtual_server_setup.namespace,
             "virtualservers",
@@ -65,7 +65,7 @@ class TestVirtualServerStatus:
             virtual_server_setup.namespace,
         )
         wait_before_test()
-        response = read_crd(
+        response = read_custom_resource(
             kube_apis.custom_objects,
             virtual_server_setup.namespace,
             "virtualservers",
@@ -94,7 +94,7 @@ class TestVirtualServerStatus:
             virtual_server_setup.namespace,
         )
         wait_before_test()
-        response = read_crd(
+        response = read_custom_resource(
             kube_apis.custom_objects,
             virtual_server_setup.namespace,
             "virtualservers",


### PR DESCRIPTION
### Proposed changes
read_crds actually reads any custom resource. This is just a name change to reflect this.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
