### PR TITLE
Cancel redundant pipelines and remove redundant build jobs

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,35 @@
+name: Cancel
+on: 
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'docs-web/**'
+      - 'examples/**'
+      - 'examples-of-custom-resources/**'
+      - '**.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'docs-web/**'
+      - 'examples/**'
+      - 'examples-of-custom-resources/**'
+      - '**.md'
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          workflow_id: 2012221,5339701,7611535
+          access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -89,139 +89,10 @@ jobs:
       - name: Run Tests
         run: go test ./...
 
-  build:
-    name: Build Docker Images
-    runs-on: ${{ matrix.os }}
-    needs: [binary, unit-tests]
-    if:
-      github.event.pull_request.head.repo.full_name == 'nginxinc/kubernetes-ingress' ||
-      github.event_name == 'push'
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: debian
-            type: oss
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: alpine
-            type: oss
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: debian-plus
-            type: plus
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: opentracing
-            type: oss
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: opentracing-plus
-            type: plus
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: openshift
-            type: oss
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: openshift-plus
-            type: plus
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: debian-plus-ap
-            type: plus-ap
-          - os: ubuntu-20.04
-            file: build/DockerfileWithAppProtectForPlusForOpenShift
-            context: '.'
-            target: local
-            image: nginx-plus-ingress-ap-openshift
-            type: plus-ap-openshift
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.4
-        with:
-          path: ${{ github.workspace }}/nginx-ingress
-          key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
-      - name: Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
-      - name: Cache Docker layers
-        uses: actions/cache@v2.1.4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Build Docker Image ${{ matrix.image }}
-        uses: docker/build-push-action@v2
-        with:
-          file: ${{ matrix.file }}
-          context: ${{ matrix.context }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          target: ${{ matrix.target }}
-          tags: ${{ matrix.image }}:${{ github.sha }}
-          build-args: |
-            BUILD_OS=${{ matrix.image }}
-        if: matrix.type == 'oss'
-      - name: Build Plus Docker Image ${{ matrix.image }}
-        uses: docker/build-push-action@v2
-        with:
-          file: ${{ matrix.file }}
-          context: ${{ matrix.context }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          target: ${{ matrix.target }}
-          tags: ${{ matrix.image }}:${{ github.sha }}
-          secrets: |
-            "nginx-repo.crt=${{ secrets.KIC_NGINX_CRT }}"
-            "nginx-repo.key=${{ secrets.KIC_NGINX_KEY }}"
-          build-args: |
-            BUILD_OS=${{ matrix.image }}
-            PLUS=-plus
-        if: matrix.type == 'plus'
-      - name: Build AP Docker Image ${{ matrix.image }}
-        uses: docker/build-push-action@v2
-        with:
-          file: ${{ matrix.file }}
-          context: ${{ matrix.context }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          target: ${{ matrix.target }}
-          tags: ${{ matrix.image }}:${{ github.sha }}
-          secrets: |
-            "nginx-repo.crt=${{ secrets.KIC_NGINX_AP_CRT }}"
-            "nginx-repo.key=${{ secrets.KIC_NGINX_AP_KEY }}"
-            "rhel_license=${{ secrets.KIC_RHEL_LICENSE }}"
-          build-args: |
-            BUILD_OS=${{ matrix.image }}
-            PLUS=-plus
-        if: matrix.type == 'plus-ap' || matrix.type == 'plus-ap-openshift'
-
   smoke-tests:
     name: Smoke Tests
     runs-on: ${{ matrix.os }}
-    needs: [build, binary, unit-tests]
+    needs: [binary, unit-tests]
     if:
       github.event.pull_request.head.repo.full_name == 'nginxinc/kubernetes-ingress' ||
       github.event_name == 'push'
@@ -395,7 +266,7 @@ jobs:
   helm-tests:
     name: Helm Tests
     runs-on: ${{ matrix.os }}
-    needs: [build, binary, unit-tests]
+    needs: [binary, unit-tests]
     env:
       NGINX_HTTP_PORT: 8080
       NGINX_HTTPS_PORT: 8443

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,136 +62,10 @@ jobs:
       - name: Run Tests
         run: go test ./...
 
-  build:
-    name: Build Docker Images
-    runs-on: ${{ matrix.os }}
-    needs: [binary, unit-tests]
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: debian
-            type: oss
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: alpine
-            type: oss
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: debian-plus
-            type: plus
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: opentracing
-            type: oss
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: opentracing-plus
-            type: plus
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: openshift
-            type: oss
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: openshift-plus
-            type: plus
-          - os: ubuntu-20.04
-            file: build/Dockerfile
-            context: '.'
-            target: local
-            image: debian-plus-ap
-            type: plus-ap
-          - os: ubuntu-20.04
-            file: build/DockerfileWithAppProtectForPlusForOpenShift
-            context: '.'
-            target: local
-            image: nginx-plus-ingress-ap-openshift
-            type: plus-ap-openshift
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.4
-        with:
-          path: ${{ github.workspace }}/nginx-ingress
-          key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
-      - name: Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
-      - name: Cache Docker layers
-        uses: actions/cache@v2.1.4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Build Docker Image ${{ matrix.image }}
-        uses: docker/build-push-action@v2
-        with:
-          file: ${{ matrix.file }}
-          context: ${{ matrix.context }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          target: ${{ matrix.target }}
-          tags: ${{ matrix.image }}:${{ github.sha }}
-          build-args: |
-            BUILD_OS=${{ matrix.image }}
-        if: matrix.type == 'oss'
-      - name: Build Plus Docker Image ${{ matrix.image }}
-        uses: docker/build-push-action@v2
-        with:
-          file: ${{ matrix.file }}
-          context: ${{ matrix.context }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          target: ${{ matrix.target }}
-          tags: ${{ matrix.image }}:${{ github.sha }}
-          secrets: |
-            "nginx-repo.crt=${{ secrets.KIC_NGINX_CRT }}"
-            "nginx-repo.key=${{ secrets.KIC_NGINX_KEY }}"
-          build-args: |
-            BUILD_OS=${{ matrix.image }}
-            PLUS=-plus
-        if: matrix.type == 'plus'
-      - name: Build AP Docker Image ${{ matrix.image }}
-        uses: docker/build-push-action@v2
-        with:
-          file: ${{ matrix.file }}
-          context: ${{ matrix.context }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          target: ${{ matrix.target }}
-          tags: ${{ matrix.image }}:${{ github.sha }}
-          secrets: |
-            "nginx-repo.crt=${{ secrets.KIC_NGINX_AP_CRT }}"
-            "nginx-repo.key=${{ secrets.KIC_NGINX_AP_KEY }}"
-            "rhel_license=${{ secrets.KIC_RHEL_LICENSE }}"
-          build-args: |
-            BUILD_OS=${{ matrix.image }}
-            PLUS=-plus
-        if: matrix.type == 'plus-ap' || matrix.type == 'plus-ap-openshift'
-
   smoke-tests:
     name: Smoke Tests
     runs-on: ${{ matrix.os }}
-    needs: [build, binary, unit-tests]
+    needs: [binary, unit-tests]
     strategy:
       matrix:
         include:
@@ -408,7 +282,7 @@ jobs:
   helm-tests:
     name: Helm Tests
     runs-on: ${{ matrix.os }}
-    needs: [build, binary, unit-tests]
+    needs: [binary, unit-tests]
     env:
       NGINX_HTTP_PORT: 8080
       NGINX_HTTPS_PORT: 8443


### PR DESCRIPTION
### Proposed changes
This commit creates a 'cancel' action which will cancel any redundant pipelines running for a PR or for master (i.e. after pushing a new commit). It also removes the 'build' step from the edge and nightly pipelines as it is unnecessary - we have to build again for the smoke tests and for the release step anyway. 

-> see https://github.com/nginxinc/kubernetes-ingress/runs/2305289060?check_suite_focus=true to see it in action

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
