### PR TITLE
Test all images

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -100,60 +100,89 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            image: nginx-ingress
+            file: build/Dockerfile
+            image: debian
             tag: ${{ github.sha }}
             marker: 'ingresses'
             type: oss
+            ic-type: nginx-ingress
           - os: ubuntu-20.04
-            image: nginx-ingress
+            file: build/Dockerfile
+            image: alpine
             tag: ${{ github.sha }}
             marker: 'vsr'
             type: oss
+            ic-type: nginx-ingress
           - os: ubuntu-20.04
-            image: nginx-ingress
+            file: build/Dockerfile
+            image: opentracing
             tag: ${{ github.sha }}
             marker: 'vs'
             type: oss
+            ic-type: nginx-ingress
           - os: ubuntu-20.04
-            image: nginx-ingress
+            file: build/Dockerfile
+            image: openshift
             tag: ${{ github.sha }}
             marker: 'ts'
             type: oss
+            ic-type: nginx-ingress
           - os: ubuntu-20.04
-            image: nginx-ingress
+            file: build/Dockerfile
+            image: debian
             tag: ${{ github.sha }}
             marker: 'policies'
             type: oss
+            ic-type: nginx-ingress
           - os: ubuntu-20.04
-            image: nginx-plus-ingress
+            file: build/Dockerfile
+            image: openshift-plus
             tag: ${{ github.sha }}
             marker: 'ingresses'
             type: plus
+            ic-type: nginx-plus-ingress
           - os: ubuntu-20.04
-            image: nginx-plus-ingress
+            file: build/Dockerfile
+            image: debian-plus
             tag: ${{ github.sha }}
             marker: 'vsr'
             type: plus
+            ic-type: nginx-plus-ingress
           - os: ubuntu-20.04
-            image: nginx-plus-ingress
+            file: build/Dockerfile
+            image: debian-plus
             tag: ${{ github.sha }}
             marker: 'vs'
             type: plus
+            ic-type: nginx-plus-ingress
           - os: ubuntu-20.04
-            image: nginx-plus-ingress
+            file: build/Dockerfile
+            image: opentracing-plus
             tag: ${{ github.sha }}
             marker: 'ts'
             type: plus
+            ic-type: nginx-plus-ingress
           - os: ubuntu-20.04
-            image: nginx-plus-ingress
+            file: build/Dockerfile
+            image: debian-plus
             tag: ${{ github.sha }}
             marker: 'policies'
             type: plus
+            ic-type: nginx-plus-ingress
           - os: ubuntu-20.04
-            image: nginx-plus-ingress
+            file: build/Dockerfile
+            image: debian-plus-ap
             tag: ${{ github.sha }}-ap
             marker: 'appprotect'
             type: plus-ap
+            ic-type: nginx-plus-ingress
+          - os: ubuntu-20.04
+            file: build/DockerfileWithAppProtectForPlusForOpenShift
+            image: nginx-plus-ingress-ap-openshift
+            tag: ${{ github.sha }}-ap
+            marker: 'appprotect'
+            type: plus-ap
+            ic-type: nginx-plus-ingress
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -176,7 +205,7 @@ jobs:
       - name: Build ${{ matrix.image }} Container
         uses: docker/build-push-action@v2
         with:
-          file: build/Dockerfile
+          file: ${{ matrix.file }}
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -184,12 +213,12 @@ jobs:
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           build-args: |
-            BUILD_OS=debian
+            BUILD_OS=${{ matrix.image }}
         if: matrix.type == 'oss'
       - name: Build Plus Docker Image ${{ matrix.image }}
         uses: docker/build-push-action@v2
         with:
-          file: build/Dockerfile
+          file: ${{ matrix.file }}
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -200,24 +229,23 @@ jobs:
             "nginx-repo.crt=${{ secrets.KIC_NGINX_CRT }}"
             "nginx-repo.key=${{ secrets.KIC_NGINX_KEY }}"
           build-args: |
-            BUILD_OS=debian-plus
+            BUILD_OS=${{ matrix.image }}
             PLUS=-plus
         if: matrix.type == 'plus'
       - name: Build AP Docker Image ${{ matrix.image }}
         uses: docker/build-push-action@v2
         with:
-          file: build/Dockerfile
+          file: ${{ matrix.file }}
           context: '.'
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
           target: local
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           secrets: |
             "nginx-repo.crt=${{ secrets.KIC_NGINX_AP_CRT }}"
             "nginx-repo.key=${{ secrets.KIC_NGINX_AP_KEY }}"
+            "rhel_license=${{ secrets.KIC_RHEL_LICENSE }}"
           build-args: |
-            BUILD_OS=debian-plus-ap
+            BUILD_OS=${{ matrix.image }}
             PLUS=-plus
         if: matrix.type == 'plus-ap'
       - name: Build Test-Runner Container
@@ -259,7 +287,7 @@ jobs:
           --context=kind-${{ github.run_id }} \
           --image=${{ matrix.image }}:${{ matrix.tag }} \
           --image-pull-policy=Never \
-          --ic-type=${{ matrix.image }} \
+          --ic-type=${{ matrix.ic-type }} \
           --service=nodeport --node-ip=${{ steps.k8s.outputs.cluster_ip }} \
           --html=tests-${{ steps.k8s.outputs.cluster }}.html \
           --self-contained-html \

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -100,85 +100,67 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: debian
             tag: ${{ github.sha }}
             marker: 'ingresses'
             type: oss
             ic-type: nginx-ingress
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: alpine
             tag: ${{ github.sha }}
             marker: 'vsr'
             type: oss
             ic-type: nginx-ingress
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: opentracing
             tag: ${{ github.sha }}
             marker: 'vs'
             type: oss
             ic-type: nginx-ingress
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: openshift
             tag: ${{ github.sha }}
             marker: 'ts'
             type: oss
             ic-type: nginx-ingress
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: debian
             tag: ${{ github.sha }}
             marker: 'policies'
             type: oss
             ic-type: nginx-ingress
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: openshift-plus
             tag: ${{ github.sha }}
             marker: 'ingresses'
             type: plus
             ic-type: nginx-plus-ingress
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: debian-plus
             tag: ${{ github.sha }}
             marker: 'vsr'
             type: plus
             ic-type: nginx-plus-ingress
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: debian-plus
             tag: ${{ github.sha }}
             marker: 'vs'
             type: plus
             ic-type: nginx-plus-ingress
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: opentracing-plus
             tag: ${{ github.sha }}
             marker: 'ts'
             type: plus
             ic-type: nginx-plus-ingress
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: debian-plus
             tag: ${{ github.sha }}
             marker: 'policies'
             type: plus
             ic-type: nginx-plus-ingress
           - os: ubuntu-20.04
-            file: build/Dockerfile
             image: debian-plus-ap
-            tag: ${{ github.sha }}-ap
-            marker: 'appprotect'
-            type: plus-ap
-            ic-type: nginx-plus-ingress
-          - os: ubuntu-20.04
-            file: build/DockerfileWithAppProtectForPlusForOpenShift
-            image: nginx-plus-ingress-ap-openshift
             tag: ${{ github.sha }}-ap
             marker: 'appprotect'
             type: plus-ap
@@ -205,7 +187,7 @@ jobs:
       - name: Build ${{ matrix.image }} Container
         uses: docker/build-push-action@v2
         with:
-          file: ${{ matrix.file }}
+          file: build/Dockerfile
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -218,7 +200,7 @@ jobs:
       - name: Build Plus Docker Image ${{ matrix.image }}
         uses: docker/build-push-action@v2
         with:
-          file: ${{ matrix.file }}
+          file: build/Dockerfile
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -235,7 +217,7 @@ jobs:
       - name: Build AP Docker Image ${{ matrix.image }}
         uses: docker/build-push-action@v2
         with:
-          file: ${{ matrix.file }}
+          file: build/Dockerfile
           context: '.'
           target: local
           tags: ${{ matrix.image }}:${{ matrix.tag }}
@@ -272,7 +254,7 @@ jobs:
           kind create cluster --name ${{ github.run_id }} --image=kindest/node:v${{ env.K8S_VERSION }} --config kind-config.yaml --kubeconfig kube-${{ github.run_id }} --wait ${{ env.K8S_TIMEOUT }}
           kind load docker-image ${{ matrix.image }}:${{ matrix.tag }} --name ${{ github.run_id }}
           echo ::set-output name=cluster_ip::$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${{ github.run_id }}-control-plane)
-          echo ::set-output name=cluster::$(echo 'nginx-${{ matrix.type }}-${{ matrix.marker }}')
+          echo ::set-output name=cluster::$(echo 'nginx-${{ matrix.image }}-${{ matrix.marker }}')
       - name: Setup Kubeconfig
         run: |
           sed -i 's|server:.*|server: https://${{ steps.k8s.outputs.cluster_ip }}:6443|' kube-${{ github.run_id }}
@@ -300,6 +282,48 @@ jobs:
           name: test-results-${{ steps.k8s.outputs.cluster }}
           path: ${{ github.workspace }}/tests/tests-${{ steps.k8s.outputs.cluster }}.html
         if: always()
+
+  build:
+    name: Build Docker Images
+    runs-on: ubuntu-20.04
+    needs: [binary, unit-tests]
+    if:
+      github.event.pull_request.head.repo.full_name == 'nginxinc/kubernetes-ingress' ||
+      github.event_name == 'push'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Fetch Cached Artifacts
+        uses: actions/cache@v2.1.4
+        with:
+          path: ${{ github.workspace }}/nginx-ingress
+          key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
+      - name: Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+      - name: Cache Docker layers
+        uses: actions/cache@v2.1.4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Build AP Docker Image ${{ matrix.image }}
+        uses: docker/build-push-action@v2
+        with:
+          file: build/DockerfileWithAppProtectForPlusForOpenShift
+          context: '.'
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          target: local
+          tags: nginx-plus-ingress-ap-openshift:${{ github.sha }}
+          secrets: |
+            "nginx-repo.crt=${{ secrets.KIC_NGINX_AP_CRT }}"
+            "nginx-repo.key=${{ secrets.KIC_NGINX_AP_KEY }}"
+            "rhel_license=${{ secrets.KIC_RHEL_LICENSE }}"
+          build-args: |
+            PLUS=-plus
 
   helm-tests:
     name: Helm Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -178,6 +178,24 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+      - name: Determine which image to build
+        run: |
+          DOW=$(date +%u)
+          if [ ${TYPE} == "oss" ]; then
+            [[ $DOW -lt 5 ]] && build_os="debian"
+            [[ $DOW -eq 5 ]] && build_os="openshift"
+            [[ $DOW -eq 6 ]] && build_os="alpine"
+            [[ $DOW -eq 7 ]] && build_os="opentracing"
+          elif [ ${TYPE} == "plus" ]; then
+            [[ $DOW -lt 6 ]] && build_os="debian-plus"
+            [[ $DOW -eq 6 ]] && build_os="opentracing-plus"
+            [[ $DOW -eq 7 ]] && build_os="openshift-plus"
+          elif [ ${TYPE} == "plus-ap" ]; then
+            [[ $DOW -lt 5 || $DOW -eq 7 ]] && read -r build_os build_dockerfile <<< "debian-plus build/Dockerfile"
+            [[ $DOW -eq 6 ]] && read -r build_os build_dockerfile <<< "opentracing-plus build/DockerfileWithAppProtectForPlusForOpenShift"
+          fi
+          echo "BUILD_OS=${build_os}" >> $GITHUB_ENV
+          echo "BUILD_DOCKERFILE=${build_dockerfile}" >> $GITHUB_ENV
       - name: Build ${{ matrix.image }} Container
         uses: docker/build-push-action@v2
         with:
@@ -189,7 +207,7 @@ jobs:
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           build-args: |
-            BUILD_OS=debian
+            BUILD_OS=${BUILD_OS}
         if: matrix.type == 'oss'
       - name: Build Plus Docker Image ${{ matrix.image }}
         uses: docker/build-push-action@v2
@@ -205,13 +223,13 @@ jobs:
             "nginx-repo.crt=${{ secrets.KIC_NGINX_CRT }}"
             "nginx-repo.key=${{ secrets.KIC_NGINX_KEY }}"
           build-args: |
-            BUILD_OS=debian-plus
+            BUILD_OS=${BUILD_OS}
             PLUS=-plus
         if: matrix.type == 'plus'
       - name: Build AP Docker Image ${{ matrix.image }}
         uses: docker/build-push-action@v2
         with:
-          file: build/Dockerfile
+          file: ${BUILD_DOCKERFILE}
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -222,7 +240,7 @@ jobs:
             "nginx-repo.crt=${{ secrets.KIC_NGINX_AP_CRT }}"
             "nginx-repo.key=${{ secrets.KIC_NGINX_AP_KEY }}"
           build-args: |
-            BUILD_OS=debian-plus-ap
+            BUILD_OS=${BUILD_OS}
             PLUS=-plus
         if: matrix.type == 'plus-ap'
       - name: Build Test-Runner Container

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -191,8 +191,8 @@ jobs:
             [[ $DOW -eq 6 ]] && build_os="opentracing-plus"
             [[ $DOW -eq 7 ]] && build_os="openshift-plus"
           elif [ ${TYPE} == "plus-ap" ]; then
-            [[ $DOW -lt 5 || $DOW -eq 7 ]] && read -r build_os build_dockerfile <<< "debian-plus build/Dockerfile"
-            [[ $DOW -eq 6 ]] && read -r build_os build_dockerfile <<< "opentracing-plus build/DockerfileWithAppProtectForPlusForOpenShift"
+            [[ $DOW -lt 5 || $DOW -eq 7 ]] && read -r build_os build_dockerfile <<< "debian-plus-ap build/Dockerfile"
+            [[ $DOW -eq 6 ]] && build_dockerfile="build/DockerfileWithAppProtectForPlusForOpenShift"
           fi
           echo "BUILD_OS=${build_os}" >> $GITHUB_ENV
           echo "BUILD_DOCKERFILE=${build_dockerfile}" >> $GITHUB_ENV


### PR DESCRIPTION
### Proposed changes
Currently, we only run smoke tests against the Debian based image. This commit:
- Updates the edge workflow to use all the different images at least once in the smoke tests matrix
- Updates the nightly workflow to run the full suite of smoke tests against each of the images at least once a week on the following schedule: 
       oss: Debian M-T; Openshift Friday; Alpine Saturday; Opentracing Sunday
       plus: Debian M-F; Opentracing Saturday; Openshift Sunday
       AppProtect: Debian M-F + Sunday; Openshift Saturday

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
