### PR TITLE
Remove patch version from Docker image for tests

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.3-slim
+FROM python:3.9-slim
 
 RUN mkdir /workspace
 


### PR DESCRIPTION
Removing patch version from base image, this will reduce noise from dependabot.