### PR TITLE
Fix ensure connections

### DIFF
--- a/tests/suite/resources_utils.py
+++ b/tests/suite/resources_utils.py
@@ -1047,9 +1047,9 @@ def ensure_connection(request_url, expected_code=404) -> None:
     :param expected_code: response code
     :return:
     """
-    for _ in range(4):
+    for _ in range(10):
         try:
-            resp = requests.get(request_url, verify=False)
+            resp = requests.get(request_url, verify=False, timeout=5)
             if resp.status_code == expected_code:
                 return
         except Exception as ex:

--- a/tests/suite/test_tls.py
+++ b/tests/suite/test_tls.py
@@ -1,7 +1,7 @@
 import pytest
 
 from suite.resources_utils import create_ingress_from_yaml, delete_items_from_yaml, wait_before_test, \
-    create_secret_from_yaml, delete_secret, replace_secret, is_secret_present
+    create_secret_from_yaml, delete_secret, replace_secret, is_secret_present, ensure_connection_to_public_endpoint
 from suite.yaml_utils import get_first_ingress_host_from_yaml, get_name_from_yaml
 from suite.ssl_utils import get_server_certificate_subject
 from settings import TEST_DATA
@@ -57,6 +57,9 @@ def tls_setup(request, kube_apis, ingress_controller_prerequisites, ingress_cont
 
     ingress_host = get_first_ingress_host_from_yaml(ingress_path)
     secret_name = get_name_from_yaml(f"{test_data_path}/tls-secret.yaml")
+
+    ensure_connection_to_public_endpoint(ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port,
+                                         ingress_controller_endpoint.port_ssl)
 
     def fin():
         print("Clean up TLS setup")


### PR DESCRIPTION
### Proposed changes
* Add timeout for establishing a connection to prevent potential
"hangs" of the test runs. The problem was noticeable when running
tests in kind.
* Increase the number of tries to make sure the Ingress Controller
pod has enough time to get ready. When running tests in kind
locally the number of tries sometimes was not enough.
* Ensure connection to NGINX before running tests.
Without ensuring, sometimes the first connection to NGINX would
hang (timeout). The problem is noticeable when running tests in
kind.