### PR TITLE
Add GoReleaser

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -36,7 +36,6 @@ env:
   HELM_CHART_VERSION: 0.0.0-edge
   GIT_NAME: NGINX Kubernetes Team
   GIT_MAIL: kubernetes@nginx.com
-  VERSION: edge
 
 jobs:
 
@@ -46,6 +45,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Output Variables
         id: commit
         run: |
@@ -56,24 +57,26 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+      - name: Determine GOPATH
+        run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
       - name: Check if CRDs changed
         run: |
           make update-crds && git diff --name-only --exit-code deployments/common/crds*
       - name: Check if Codegen changed
         run: |
           make update-codegen && git diff --name-only --exit-code pkg/**/zz_generated.deepcopy.go
-      - name: Build Binary
-        run: >
-          make build
-          VERSION=${{ env.VERSION }}
-          IC_VERSION=${{ env.VERSION }}-${{ steps.commit.outputs.sha }}
-          GIT_COMMIT=${{ steps.commit.outputs.sha }}
+      - name: Build binaries
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: --rm-dist --debug --skip-publish --snapshot
         env:
-          GOFLAGS: '-gcflags=-trimpath=${{ github.workspace }} -asmflags=-trimpath=${{ github.workspace }}'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOPATH: ${{ env.GOPATH }}
       - name: Store Artifacts in Cache
         uses: actions/cache@v2.1.5
         with:
-          path: ${{ github.workspace }}/nginx-ingress
+          path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
 
   unit-tests:
@@ -171,7 +174,7 @@ jobs:
       - name: Fetch Cached Artifacts
         uses: actions/cache@v2.1.5
         with:
-          path: ${{ github.workspace }}/nginx-ingress
+          path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -191,7 +194,7 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           build-args: |
@@ -204,7 +207,7 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           secrets: |
@@ -219,7 +222,7 @@ jobs:
         with:
           file: build/Dockerfile
           context: '.'
-          target: local
+          target: goreleaser
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           secrets: |
@@ -296,7 +299,7 @@ jobs:
       - name: Fetch Cached Artifacts
         uses: actions/cache@v2.1.5
         with:
-          path: ${{ github.workspace }}/nginx-ingress
+          path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -316,7 +319,7 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: nginx-plus-ingress-ap-openshift:${{ github.sha }}
           secrets: |
             "nginx-repo.crt=${{ secrets.KIC_NGINX_AP_CRT }}"
@@ -353,7 +356,7 @@ jobs:
       - name: Fetch Cached Artifacts
         uses: actions/cache@v2.1.5
         with:
-          path: ${{ github.workspace }}/nginx-ingress
+          path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -373,7 +376,7 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           build-args: |
@@ -385,7 +388,7 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           secrets: |
@@ -463,10 +466,11 @@ jobs:
         id: commit
         run: |
           echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
+          echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"
       - name: Fetch Cached Artifacts
         uses: actions/cache@v2.1.5
         with:
-          path: ${{ github.workspace }}/nginx-ingress
+          path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -491,12 +495,13 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: nginx/${{ matrix.image }}:${{ matrix.tag }}
+          platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
           push: true
           build-args: |
             BUILD_OS=${{ matrix.type }}
-            IC_VERSION=${{ env.VERSION }}-${{ steps.commit.outputs.sha }}
+            IC_VERSION=${{ steps.commit.outputs.tag }}-SNAPSHOT-${{ steps.commit.outputs.sha }}
 
   package-helm:
     name: Package Helm Chart

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Output Variables
         id: commit
         run: |
@@ -78,55 +80,55 @@ jobs:
           - os: ubuntu-20.04
             file: build/Dockerfile
             context: '.'
-            target: local
+            target: goreleaser
             image: debian
             type: oss
           - os: ubuntu-20.04
             file: build/Dockerfile
             context: '.'
-            target: local
+            target: goreleaser
             image: alpine
             type: oss
           - os: ubuntu-20.04
             file: build/Dockerfile
             context: '.'
-            target: local
+            target: goreleaser
             image: debian-plus
             type: plus
           - os: ubuntu-20.04
             file: build/Dockerfile
             context: '.'
-            target: local
+            target: goreleaser
             image: opentracing
             type: oss
           - os: ubuntu-20.04
             file: build/Dockerfile
             context: '.'
-            target: local
+            target: goreleaser
             image: opentracing-plus
             type: plus
           - os: ubuntu-20.04
             file: build/Dockerfile
             context: '.'
-            target: local
+            target: goreleaser
             image: openshift
             type: oss
           - os: ubuntu-20.04
             file: build/Dockerfile
             context: '.'
-            target: local
+            target: goreleaser
             image: openshift-plus
             type: plus
           - os: ubuntu-20.04
             file: build/Dockerfile
             context: '.'
-            target: local
+            target: goreleaser
             image: debian-plus-ap
             type: plus-ap
           - os: ubuntu-20.04
             file: build/DockerfileWithAppProtectForPlusForOpenShift
             context: '.'
-            target: local
+            target: goreleaser
             image: nginx-plus-ingress-ap-openshift
             type: plus-ap-openshift
     steps:
@@ -135,7 +137,7 @@ jobs:
       - name: Fetch Cached Artifacts
         uses: actions/cache@v2.1.5
         with:
-          path: ${{ github.workspace }}/nginx-ingress
+          path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -317,7 +319,7 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           build-args: |
@@ -330,7 +332,7 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           secrets: |
@@ -347,7 +349,7 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           secrets: |
@@ -456,7 +458,7 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           build-args: |
@@ -468,7 +470,7 @@ jobs:
           context: '.'
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          target: local
+          target: goreleaser
           tags: ${{ matrix.image }}:${{ matrix.tag }}
           load: true
           secrets: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,24 +29,30 @@ jobs:
           echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
       - name: Determine Go version from go.mod
         run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
+      - name: Setup Golang Environment
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Determine GOPATH
+        run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
       - name: Check if CRDs changed
         run: |
           make update-crds && git diff --name-only --exit-code deployments/common/crds*
       - name: Check if Codegen changed
         run: |
           make update-codegen && git diff --name-only --exit-code pkg/**/zz_generated.deepcopy.go
-      - name: Build Binary
-        run: >
-          make build
-          VERSION=${{ env.VERSION }}
-          IC_VERSION=${{ env.VERSION }}-${{ steps.commit.outputs.sha }}
-          GIT_COMMIT=${{ steps.commit.outputs.sha }}
+      - name: Build binaries
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: --rm-dist --debug --skip-publish --snapshot
         env:
-          GOFLAGS: '-gcflags=-trimpath=${{ github.workspace }} -asmflags=-trimpath=${{ github.workspace }}'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOPATH: ${{ env.GOPATH }}
       - name: Store Artifacts in Cache
         uses: actions/cache@v2.1.5
         with:
-          path: ${{ github.workspace }}/nginx-ingress
+          path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
 
   unit-tests:
@@ -291,7 +297,7 @@ jobs:
       - name: Fetch Cached Artifacts
         uses: actions/cache@v2.1.5
         with:
-          path: ${{ github.workspace }}/nginx-ingress
+          path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -430,7 +436,7 @@ jobs:
       - name: Fetch Cached Artifacts
         uses: actions/cache@v2.1.5
         with:
-          path: ${{ github.workspace }}/nginx-ingress
+          path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ hack/controller-gen-*
 docs-web/.netlify/state.json
 site/
 venv/
+
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,7 @@ env:
   - GO111MODULE=on
 before:
   hooks:
+    - make clean
     - go mod tidy
     - go mod verify
 builds:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,31 @@
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod tidy
+    - go mod verify
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - ppc64le
+      - s390x
+    goarm:
+      - 7
+    flags:
+      - -trimpath
+    gcflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    asmflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    main: ./cmd/nginx-ingress/main.go
+    binary: nginx-ingress
+archives:
+- format: binary
+changelog:
+  skip: true

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ push: ## Docker push to $PREFIX and $TAG
 .PHONY: clean
 clean:  ## Remove nginx-ingress binary
 	-rm nginx-ingress
+	-rm -r dist
 
 .PHONY: deps
 deps: ## Add missing and remove unused modules, verify deps and dowload them to local cache

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-VERSION = 1.11.1
-TAG = $(VERSION)
 PREFIX = nginx/nginx-ingress
+GIT_COMMIT = $(shell git rev-parse HEAD)
+GIT_COMMIT_SHORT = $(shell echo ${GIT_COMMIT} | cut -c1-7)
+GIT_TAG = $(shell git describe --tags --abbrev=0)
+DATE = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+VERSION = $(GIT_TAG)-SNAPSHOT-$(GIT_COMMIT_SHORT)
+TAG = $(VERSION)
 TARGET ?= local
 
-override DOCKER_BUILD_OPTIONS += --build-arg IC_VERSION=$(VERSION)-$(GIT_COMMIT) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg VERSION=$(VERSION)
+override DOCKER_BUILD_OPTIONS += --build-arg IC_VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg DATE=$(DATE)
 DOCKER_CMD = docker build $(DOCKER_BUILD_OPTIONS) --target $(TARGET) -f build/Dockerfile -t $(PREFIX):$(TAG) .
 PLUS_ARGS = --build-arg PLUS=-plus --secret id=nginx-repo.crt,src=nginx-repo.crt --secret id=nginx-repo.key,src=nginx-repo.key
-
-GIT_COMMIT = $(shell git rev-parse --short HEAD)
 
 export DOCKER_BUILDKIT = 1
 
@@ -50,7 +52,7 @@ build: ## Build Ingress Controller binary
 	@docker -v || (code=$$?; printf "\033[0;31mError\033[0m: there was a problem with Docker\n"; exit $$code)
 ifeq (${TARGET},local)
 	@go version || (code=$$?; printf "\033[0;31mError\033[0m: unable to build locally, try using the parameter TARGET=container\n"; exit $$code)
-	CGO_ENABLED=0 GO111MODULE=on GOFLAGS='$(GOFLAGS)' GOOS=linux go build -ldflags "-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o nginx-ingress github.com/nginxinc/kubernetes-ingress/cmd/nginx-ingress
+	CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=$(DATE)" -o nginx-ingress github.com/nginxinc/kubernetes-ingress/cmd/nginx-ingress
 endif
 
 .PHONY: debian-image

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.0-experimental
+# syntax=docker/dockerfile:1.2
 ARG BUILD_OS=debian
 
 ############################################# Base image for Debian #############################################
@@ -263,7 +263,7 @@ COPY --from=tracer-downloader /usr/local/lib/libjaegertracing_plugin.so /usr/loc
 
 
 ############################################# Create common files, permissions and setcap #############################################
-FROM $BUILD_OS as files
+FROM $BUILD_OS as common
 
 ARG PLUS
 
@@ -272,7 +272,7 @@ RUN mkdir -p /var/lib/nginx /etc/nginx/secrets /etc/nginx/stream-conf.d \
 	&& chown -R nginx:0 /etc/nginx /var/cache/nginx /var/lib/nginx \
 	&& rm -f /etc/nginx/conf.d/* /etc/apt/apt.conf.d/90nginx /etc/apt/sources.list.d/nginx-plus.list
 
-COPY internal/configs/version1/nginx$PLUS.ingress.tmpl \
+COPY --chown=nginx:0 internal/configs/version1/nginx$PLUS.ingress.tmpl \
 	internal/configs/version1/nginx$PLUS.tmpl \
 	internal/configs/version2/nginx$PLUS.virtualserver.tmpl \
 	internal/configs/version2/nginx$PLUS.transportserver.tmpl /
@@ -284,28 +284,36 @@ COPY internal/configs/version1/nginx$PLUS.ingress.tmpl \
 EXPOSE 80 443
 
 ENTRYPOINT ["/nginx-ingress"]
+USER nginx
 
 
 ############################################# Build nginx-ingress in golang container #############################################
 FROM golang:1.16-alpine AS builder
-ARG VERSION
+ARG IC_VERSION
 ARG GIT_COMMIT
+ARG DATE
+ARG TARGETARCH
+
 WORKDIR /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/cmd/nginx-ingress
 COPY go.mod go.sum /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
 RUN go mod download
 COPY . /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
-RUN CGO_ENABLED=0 GO111MODULE=on go build -ldflags "-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /nginx-ingress
+RUN CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=$TARGETARCH go build -trimpath -ldflags "-s -w -X main.version=${IC_VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o /nginx-ingress
 
 
 ############################################# Create image with nginx-ingress built in container #############################################
-FROM files AS container
+FROM common AS container
 COPY --chown=nginx:0 --from=builder /nginx-ingress /
-
-USER nginx
 
 
 ############################################# Create image with nginx-ingress built locally #############################################
-FROM files AS local
+FROM common AS local
 COPY --chown=nginx:0 nginx-ingress /
 
-USER nginx
+
+############################################# Create image with nginx-ingress built by GoReleaser #############################################
+FROM common AS goreleaser
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+COPY --chown=nginx:0 dist/kubernetes-ingress_linux_$TARGETARCH${TARGETVARIANT:+_7}/nginx-ingress /

--- a/build/DockerfileWithAppProtectForPlusForOpenShift
+++ b/build/DockerfileWithAppProtectForPlusForOpenShift
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.0-experimental
+# syntax=docker/dockerfile:1.2
 FROM registry.access.redhat.com/ubi7/ubi AS base
 
 LABEL name="NGINX Ingress Controller" \
@@ -96,7 +96,7 @@ COPY --chown=nginx:0 build/log-default.json /etc/nginx
 
 EXPOSE 80 443
 
-COPY internal/configs/version1/nginx-plus.ingress.tmpl \
+COPY --chown=nginx:0 internal/configs/version1/nginx-plus.ingress.tmpl \
 	internal/configs/version1/nginx-plus.tmpl \
 	internal/configs/version2/nginx-plus.virtualserver.tmpl \
 	internal/configs/version2/nginx-plus.transportserver.tmpl /
@@ -123,14 +123,24 @@ COPY nginx-ingress /
 
 
 FROM golang:1.16-alpine AS builder
-ARG VERSION
+ARG IC_VERSION
 ARG GIT_COMMIT
+ARG DATE
+ARG TARGETARCH
+
 WORKDIR /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/cmd/nginx-ingress
 COPY go.mod go.sum /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
 RUN go mod download
 COPY . /go/src/github.com/nginxinc/kubernetes-ingress/nginx-ingress/
-RUN CGO_ENABLED=0 GO111MODULE=on go build -ldflags "-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o /tmp/nginx-ingress
+RUN CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=$TARGETARCH go build -trimpath -ldflags "-s -w -X main.version=${IC_VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o /tmp/nginx-ingress
 
 
 FROM base AS container
-COPY --from=builder /tmp/nginx-ingress /
+COPY --chown=nginx:0 --from=builder /tmp/nginx-ingress /
+
+
+FROM base AS goreleaser
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+COPY --chown=nginx:0 dist/kubernetes-ingress_linux_$TARGETARCH${TARGETVARIANT:+_7}/nginx-ingress /

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -97,7 +97,7 @@ var (
 	If a secret is set, but the Ingress controller is not able to fetch it from Kubernetes API or it is not set and the Ingress Controller
 	fails to read the file "/etc/nginx/secrets/default", the Ingress controller will fail to start.`)
 
-	versionFlag = flag.Bool("version", false, "Print the version and git-commit hash and exit")
+	versionFlag = flag.Bool("version", false, "Print the version, git-commit hash and build date and exit")
 
 	mainTemplatePath = flag.String("main-template-path", "",
 		`Path to the main NGINX configuration template. (default for NGINX "nginx.tmpl"; default for NGINX Plus "nginx-plus.tmpl")`)
@@ -195,8 +195,9 @@ func main() {
 		glog.Fatalf("Error setting logtostderr to true: %v", err)
 	}
 
+	versionInfo := fmt.Sprintf("Version=%v GitCommit=%v Date=%v", version, commit, date)
 	if *versionFlag {
-		fmt.Printf("Version=%v GitCommit=%v Date=%v\n", version, commit, date)
+		fmt.Println(versionInfo)
 		os.Exit(0)
 	}
 
@@ -255,7 +256,7 @@ func main() {
 		glog.Fatal("ingresslink and external-service cannot both be set")
 	}
 
-	glog.Infof("Starting NGINX Ingress controller Version=%v GitCommit=%v Date=%v PlusFlag=%v\n", version, commit, date, *nginxPlus)
+	glog.Infof("Starting NGINX Ingress controller %v PlusFlag=%v", versionInfo, *nginxPlus)
 
 	var config *rest.Config
 	if *proxyURL != "" {

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -43,8 +43,9 @@ import (
 var (
 
 	// Set during build
-	version   string
-	gitCommit string
+	version string
+	commit  string
+	date    string
 
 	healthStatus = flag.Bool("health-status", false,
 		`Add a location based on the value of health-status-uri to the default server. The location responds with the 200 status code for any request.
@@ -91,9 +92,9 @@ var (
 
 	defaultServerSecret = flag.String("default-server-tls-secret", "",
 		`A Secret with a TLS certificate and key for TLS termination of the default server. Format: <namespace>/<name>.
-	If not set, than the certificate and key in the file "/etc/nginx/secrets/default" are used. 
+	If not set, than the certificate and key in the file "/etc/nginx/secrets/default" are used.
 	If "/etc/nginx/secrets/default" doesn't exist, the Ingress Controller will configure NGINX to reject TLS connections to the default server.
-	If a secret is set, but the Ingress controller is not able to fetch it from Kubernetes API or it is not set and the Ingress Controller 
+	If a secret is set, but the Ingress controller is not able to fetch it from Kubernetes API or it is not set and the Ingress Controller
 	fails to read the file "/etc/nginx/secrets/default", the Ingress controller will fail to start.`)
 
 	versionFlag = flag.Bool("version", false, "Print the version and git-commit hash and exit")
@@ -195,7 +196,7 @@ func main() {
 	}
 
 	if *versionFlag {
-		fmt.Printf("Version=%v GitCommit=%v\n", version, gitCommit)
+		fmt.Printf("Version=%v GitCommit=%v Date=%v\n", version, commit, date)
 		os.Exit(0)
 	}
 
@@ -254,7 +255,7 @@ func main() {
 		glog.Fatal("ingresslink and external-service cannot both be set")
 	}
 
-	glog.Infof("Starting NGINX Ingress controller Version=%v GitCommit=%v PlusFlag=%v\n", version, gitCommit, *nginxPlus)
+	glog.Infof("Starting NGINX Ingress controller Version=%v GitCommit=%v Date=%v PlusFlag=%v\n", version, commit, date, *nginxPlus)
 
 	var config *rest.Config
 	if *proxyURL != "" {

--- a/docs-web/configuration/global-configuration/command-line-arguments.md
+++ b/docs-web/configuration/global-configuration/command-line-arguments.md
@@ -2,7 +2,7 @@
 
 The Ingress Controller supports several command-line arguments. Setting the arguments depends on how you install the Ingress Controller:
 * If you're using *Kubernetes manifests* (Deployment or DaemonSet) to install the Ingress Controller, to set the command-line arguments, modify those manifests accordingly. See the [Installation with Manifests](/nginx-ingress-controller/installation/installation-with-manifests) doc.
-* If you're using *Helm* to install the Ingress Controller, modify the parameters of the Helm chart that correspond to the command-line arguments. See the [Installation with Helm](/nginx-ingress-controller/installation/installation-with-helm) doc. 
+* If you're using *Helm* to install the Ingress Controller, modify the parameters of the Helm chart that correspond to the command-line arguments. See the [Installation with Helm](/nginx-ingress-controller/installation/installation-with-helm) doc.
 
 Below we describe the available command-line arguments:
 ```eval_rst
@@ -48,7 +48,7 @@ Below we describe the available command-line arguments:
 
 	Enable TLS Passthrough on port 443.
 
-	Requires :option:`-enable-custom-resources`.	
+	Requires :option:`-enable-custom-resources`.
 
 .. option:: -external-service <string>
 
@@ -65,7 +65,7 @@ Below we describe the available command-line arguments:
 .. option:: -global-configuration <string>
 
 	A GlobalConfiguration resource for global configuration of the Ingress Controller.
-	
+
 	Format: ``<namespace>/<name>``
 
 	Requires :option:`-enable-custom-resources`.
@@ -174,7 +174,7 @@ Below we describe the available command-line arguments:
 
 .. option:: -version
 
-	Print the version and git-commit hash and exit
+	Print the version, git-commit hash and build date and exit
 
 .. option:: -virtualserver-template-path <string>
 


### PR DESCRIPTION
~This will get the wrong `tag` until #1544 is merged.~

Removed `edge` from the version name in the Makefile, it will now be something like `v1.11.1-SNAPSHOT-00f0053` for local builds (same that GoReleaser uses for `edge`), so it will remove the need to update the version in the Makefile.
(When we make a stable release, GoReleaser will use `v1.11.1`)

GoReleaser builds binaries for:
- amd64
- arm
- arm64
- ppc64le
- s390x

and we push Docker images for the same architectures.


Addresses https://github.com/nginxinc/kubernetes-ingress/issues/944, https://github.com/nginxinc/kubernetes-ingress/issues/974 and https://github.com/nginxinc/kubernetes-ingress/issues/1310 