### PR TITLE
Chore: Don't notify on cancelled edge pipeline

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -576,8 +576,7 @@ jobs:
       - name: Send Notification
         uses: 8398a7/action-slack@v3
         if:
-          steps.check.outputs.status == 'failure' ||
-          steps.check.outputs.status == 'cancelled'
+          steps.check.outputs.status == 'failure'
         with:
           status: custom
           custom_payload: |


### PR DESCRIPTION
### Proposed changes
Now that we have a workflow to auto-cancel redundant pipelines, we don't need to notify on cancelled edge pipelines.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
