### PR TITLE
Add container scanning for OSS images

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -92,6 +92,64 @@ jobs:
       - name: Run Tests
         run: go test ./...
 
+  container-scan:
+    name: Container Scanning
+    runs-on: ubuntu-20.04
+    needs: binary
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Fetch Cached Artifacts
+        uses: actions/cache@v2.1.5
+        with:
+          path: ${{ github.workspace }}/dist
+          key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
+      - name: Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+      - name: Cache Docker layers
+        uses: actions/cache@v2.1.5
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Build ${{ matrix.image }} Container
+        uses: docker/build-push-action@v2
+        with:
+          file: build/Dockerfile
+          context: '.'
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          target: goreleaser
+          tags: ${{ matrix.image }}:${{ github.sha }}
+          load: true
+          build-args: |
+            BUILD_OS=${{ matrix.image }}
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ matrix.image }}:${{ github.sha }}'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results-${{ matrix.image }}.sarif'
+          ignore-unfixed: 'true'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results-${{ matrix.image }}.sarif'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      - name: Upload Scan Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'trivy-results-${{ matrix.image }}.sarif'
+          path: 'trivy-results-${{ matrix.image }}.sarif'
+        if: always()
+    strategy:
+      matrix:
+        image: [debian, alpine, opentracing, openshift]
+
   smoke-tests:
     name: Smoke Tests
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Proposed changes
Add trivy container scanning for OSS images. Scanning of the Plus and App Protect images will be done separately in GitLab.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have rebased my branch onto master
