### PR TITLE
Fix ubi image name

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -150,7 +150,7 @@ jobs:
         if: always()
     strategy:
       matrix:
-        image: [debian, alpine, opentracing, openshift]
+        image: [debian, alpine, opentracing, ubi]
 
   smoke-tests:
     name: Smoke Tests


### PR DESCRIPTION
### Proposed changes
The container scanning PR wasn't rebased to master before merging, and now the Openshift image is failing because the image name has changed to `ubi`. This commit fixes the openshift image

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
