### PR TITLE
Workaround for bug in Dependabot for Docker

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update \
 
 
 ############################################# Base image for Alpine #############################################
-FROM nginx:1.19.9-alpine AS alpine
+# docker.io/library/nginx is a temporary workaround for Dependabot to see this as different from the one used in Debian
+FROM docker.io/library/nginx:1.19.9-alpine AS alpine
 
 RUN apk add --no-cache libcap \
 	&& rm -rf /var/cache/apk/*


### PR DESCRIPTION
This is the suggested workaround [here](https://github.com/dependabot/dependabot-core/issues/3261#issuecomment-838356468) so dependabot can see nginx and nginx-alpine as two different images 

Should fix the incorrect behavior in #1542 #1581 
