### PR TITLE
Update NGINX Plus to R24

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.2
 ARG BUILD_OS=debian
+ARG NGINX_PLUS_VERSION=r24
 
 ############################################# Base image for Debian #############################################
 FROM nginx:1.21.0 AS debian
@@ -33,8 +34,7 @@ COPY --chown=nginx:0 internal/configs/oidc/* /etc/nginx/oidc/
 ############################################# Base image for Debian with NGINX Plus #############################################
 FROM debian:buster-slim AS debian-plus
 ARG IC_VERSION
-ENV NGINX_PLUS_VERSION 23-1~buster
-ENV NGINX_NJS_VERSION 23+0.5.0-1~buster
+ARG NGINX_PLUS_VERSION
 
 RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
@@ -46,9 +46,10 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	&& gpg --no-default-keyring --keyring nginx_keyring.gpg --export > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& wget -P /etc/apt/apt.conf.d https://cs.nginx.com/static/files/90pkgs-nginx \
 	&& echo "Acquire::https::pkgs.nginx.com::User-Agent  \"k8s-ic-$IC_VERSION-apt\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
-	&& printf "deb https://pkgs.nginx.com/plus/debian buster nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
-	&& apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
-	nginx-plus=${NGINX_PLUS_VERSION} nginx-plus-module-njs=${NGINX_NJS_VERSION} \
+	&& printf "%s\n" "deb https://pkgs.nginx.com/plus/debian buster nginx-plus" > /etc/apt/sources.list.d/nginx-plus.list \
+	&& apt-get update \
+	&& apt-get install --no-install-recommends --no-install-suggests -y \
+	nginx-plus-${NGINX_PLUS_VERSION} nginx-plus-module-njs-${NGINX_PLUS_VERSION} \
 	&& apt-get purge --auto-remove -y apt-transport-https gnupg wget \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -58,13 +59,7 @@ COPY --chown=nginx:0 internal/configs/oidc/* /etc/nginx/oidc/
 ############################################# Base image for Debian with NGINX Plus and App Protect #############################################
 FROM debian-plus as debian-plus-nap
 ARG IC_VERSION
-
-ENV APPPROTECT_MODULE_VERSION 23+3.462.0-1~buster
-ENV APPPROTECT_PLUGIN_VERSION 3.462.0-1~buster
-ENV APPPROTECT_ENGINE_VERSION 6.53.1-1~buster
-ENV APPPROTECT_COMPILER_VERSION 6.53.1-1~buster
-ENV APPPROTECT_SIG_VERSION 2021.02.26-1~buster
-ENV APPPROTECT_THREAT_CAMPAIGNS_VERSION 2021.03.02-1~buster
+ARG NGINX_PLUS_VERSION
 
 RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
@@ -76,16 +71,21 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	&& gpg --no-default-keyring --keyring app_protect_keyring.gpg --export > /etc/apt/trusted.gpg.d/nginx_app_signing.gpg \
 	&& sed -i '$ d' /etc/apt/apt.conf.d/90pkgs-nginx \
 	&& echo "Acquire::https::pkgs.nginx.com::User-Agent  \"k8s-ic-$IC_VERSION-nap-$APPPROTECT_MODULE_VERSION-apt\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
-	&& printf "deb https://pkgs.nginx.com/app-protect/debian buster nginx-plus\n" | tee /etc/apt/sources.list.d/nginx-app-protect.list \
-	&& printf "deb https://pkgs.nginx.com/app-protect-security-updates/debian buster nginx-plus\n" | tee -a /etc/apt/sources.list.d/nginx-app-protect.list \
-	&& apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
-	nginx-plus-module-appprotect=$APPPROTECT_MODULE_VERSION \
-	app-protect-plugin=$APPPROTECT_PLUGIN_VERSION \
-	app-protect-engine=$APPPROTECT_ENGINE_VERSION \
-	app-protect-compiler=$APPPROTECT_COMPILER_VERSION \
-	app-protect=$APPPROTECT_MODULE_VERSION \
-	&& apt-get install -y app-protect-attack-signatures${APPPROTECT_SIG_VERSION:+=$APPPROTECT_SIG_VERSION} \
-	&& apt-get install -y app-protect-threat-campaigns${APPPROTECT_THREAT_CAMPAIGNS_VERSION:+=$APPPROTECT_THREAT_CAMPAIGNS_VERSION} \
+	&& printf "%s\n" "deb https://pkgs.nginx.com/app-protect/debian buster nginx-plus" \
+	"deb https://pkgs.nginx.com/app-protect-security-updates/debian buster nginx-plus" > /etc/apt/sources.list.d/nginx-app-protect.list \
+	&& apt-get update \
+	# searching apt-cache for the latest version of NAP packages compatible with the $NGINX_PLUS_VERSION
+	&& module_version=$(apt-cache showpkg nginx-plus-module-appprotect | awk -v ver="nginx-plus-$NGINX_PLUS_VERSION" '{ if ($6 == ver) {print $1; exit}}') \
+	engine_version=$(apt-cache showpkg app-protect | awk -v ver="$module_version" '{ if ($1 == ver && $3 == "nginx-plus-module-appprotect") {print substr($NF, 1, length($NF)-1); exit}}') \
+	plugin=$(apt-cache showpkg nginx-plus-module-appprotect | awk -v ver="nginx-plus-$NGINX_PLUS_VERSION" '{ if ($6 == ver) {print substr($NF, 1, length($NF)-1); exit}}') \
+	&& apt-get install --no-install-recommends --no-install-suggests -y \
+	nginx-plus-module-appprotect=${module_version} \
+	app-protect-plugin=${plugin} \
+	app-protect-engine=${engine_version} \
+	app-protect-compiler=${engine_version} \
+	app-protect=${module_version} \
+	&& apt-get install -y app-protect-attack-signatures \
+	&& apt-get install -y app-protect-threat-campaigns \
 	&& apt-get purge --auto-remove -y apt-transport-https gnupg wget \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm /etc/apt/sources.list.d/nginx-app-protect.list
@@ -144,8 +144,7 @@ RUN rpm --import https://nginx.org/keys/nginx_signing.key \
 
 ############################################# Base image for UBI with NGINX Plus #############################################
 FROM ubi-base AS ubi-plus
-
-ENV NGINX_PLUS_VERSION r23
+ARG NGINX_PLUS_VERSION
 
 RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
@@ -223,14 +222,13 @@ RUN ldconfig
 
 ############################################# Build image for Opentracing with NGINX Plus #############################################
 FROM debian-plus as opentracing-plus
-
-ENV NGINX_OPENTRACING_MODULE_VERSION 23+0.9.0-1~buster
+ARG NGINX_PLUS_VERSION
 
 RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
-	apt-get update && \
-	apt-get install --no-install-recommends --no-install-suggests -y nginx-plus-module-opentracing=${NGINX_OPENTRACING_MODULE_VERSION} && \
-	rm -rf /var/lib/apt/lists/*
+	apt-get update \
+	&& apt-get install --no-install-recommends --no-install-suggests -y nginx-plus-module-opentracing-${NGINX_PLUS_VERSION} \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=tracer-downloader /usr/local/lib/libjaegertracing_plugin.so /usr/local/lib/libjaegertracing_plugin.so
 

--- a/docs-web/app-protect/installation.md
+++ b/docs-web/app-protect/installation.md
@@ -23,6 +23,8 @@ Take the steps below to create the Docker image that you'll use to deploy NGINX 
     In order to do so, place the `*.crt` file in the build folder and uncomment the lines that follow this comment:
     `#Uncomment the lines below if you want to install a custom CA certificate`
 
+    **Note**: In the event of a patch version of NGINX Plus being [released](/nginx/releases/), make sure to rebuild your image to get the latest version. The Dockerfile will use the latest available version of the [Attack Signatures](/nginx-app-protect/configuration/#attack-signatures) and [Threat Campaigns](/nginx-app-protect/configuration/#threat-campaigns) packages at the time of build. If your system is caching the Docker layers and not updating the packages, add `DOCKER_BUILD_OPTIONS="--no-cache"` to the `make` command.
+
 - [Push the image to your local Docker registry](/nginx-ingress-controller/installation/building-ingress-controller-image/#building-the-image-and-pushing-it-to-the-private-registry).
 
 ## Install the Ingress Controller

--- a/docs-web/installation/building-ingress-controller-image.md
+++ b/docs-web/installation/building-ingress-controller-image.md
@@ -55,6 +55,8 @@ We build the image using the make utility and the provided `Makefile`. Let’s c
 
       As a result, the image **myregistry.example.com/nginx-plus-ingress:1.11.3** is built. Note that the tag `1.11.3` comes from the `VERSION` variable, defined in the Makefile.
 
+      **Note**: In the event of a patch version of NGINX Plus being [released](/nginx/releases/), make sure to rebuild your image to get the latest version. If your system is caching the Docker layers, add `DOCKER_BUILD_OPTIONS="--no-cache"` to the `make` command.
+
 1. Push the image:
     ```
     $ make push PREFIX=myregistry.example.com/nginx-ingress

--- a/docs-web/installation/building-ingress-controller-image.md
+++ b/docs-web/installation/building-ingress-controller-image.md
@@ -55,7 +55,7 @@ We build the image using the make utility and the provided `Makefile`. Let’s c
 
       As a result, the image **myregistry.example.com/nginx-plus-ingress:1.11.3** is built. Note that the tag `1.11.3` comes from the `VERSION` variable, defined in the Makefile.
 
-      **Note**: In the event of a patch version of NGINX Plus being [released](/nginx/releases/), make sure to rebuild your image to get the latest version. If your system is caching the Docker layers, add `DOCKER_BUILD_OPTIONS="--no-cache"` to the `make` command.
+      **Note**: In the event of a patch version of NGINX Plus being [released](/nginx/releases/), make sure to rebuild your image to get the latest version. If your system is caching the Docker layers and not updating the packages, add `DOCKER_BUILD_OPTIONS="--no-cache"` to the `make` command.
 
 1. Push the image:
     ```


### PR DESCRIPTION
- Updated to R24
- Simplified updating to a new version

For Debian there's a virtual package named with the R version, for example `nginx-plus-r24`, form there we can figure out the latest version of the actual NGINX package for that version and the modules.
