### PR TITLE
Revert dependabot to daily checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,40 +3,39 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
-      - "ciarams87"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
   - package-ecosystem: "docker"
     directory: "/build"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
   - package-ecosystem: "docker"
     directory: "/tests/docker"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
       - "vepatel"
   - package-ecosystem: "pip"
     directory: "/tests"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
       - "vepatel"
   - package-ecosystem: "pip"
     directory: "/perf-tests"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
       - "vepatel"

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -74,7 +74,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOPATH: ${{ env.GOPATH }}
       - name: Store Artifacts in Cache
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -106,7 +106,7 @@ jobs:
         run: |
           echo "::set-output name=nginx_version::$(cat build/Dockerfile | grep -m1 "FROM nginx:" | cut -d":" -f2 | cut -d" " -f1)"
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -115,7 +115,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Cache Docker layers
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -247,7 +247,7 @@ jobs:
         run: |
           echo "::set-output name=nginx_version::$(cat build/Dockerfile | grep -m1 "FROM nginx:" | cut -d":" -f2 | cut -d" " -f1)"
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -256,7 +256,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Cache Docker layers
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -373,7 +373,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -382,7 +382,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Cache Docker layers
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -430,7 +430,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -439,7 +439,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Docker build cache
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -548,7 +548,7 @@ jobs:
           echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"
           echo "::set-output name=nginx_version::$(cat build/Dockerfile | grep -m1 "FROM nginx:" | cut -d":" -f2 | cut -d" " -f1)"
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -561,7 +561,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Cache Docker layers
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Lint Code
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v2
         with:
           args: --timeout ${{ env.GOLANGCI_TIMEOUT }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOPATH: ${{ env.GOPATH }}
       - name: Store Artifacts in Cache
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -141,7 +141,7 @@ jobs:
         run: |
           echo "::set-output name=nginx_version::$(cat build/Dockerfile | grep -m1 "FROM nginx:" | cut -d":" -f2 | cut -d" " -f1)"
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -150,7 +150,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Cache Docker layers
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -304,7 +304,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -313,7 +313,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Cache Docker layers
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -443,7 +443,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/dist
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -452,7 +452,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Docker build cache
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,7 +455,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/nginx-ingress
           key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
@@ -464,7 +464,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Docker build cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,7 +19,7 @@ jobs:
           destination_branch: "master"
           ssh_private_key: ${{ secrets.SYNC_SSH_PRIVATE_KEY }}
 
-  # This job open a PR to sync the generated CRD files across to nginx-ingress-operator 
+  # This job open a PR to sync the generated CRD files across to nginx-ingress-operator
   # (see .github/sync.yml for config details)
   crds-sync:
     runs-on: ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Sync Labels
-        uses: micnncim/action-label-syncer@v1.2.0
+        uses: micnncim/action-label-syncer@v1
         with:
           repository: ${{ matrix.repo }}
           token: ${{ secrets.NGINX_PAT }}


### PR DESCRIPTION
- Revert back to daily checks now that we went through the initial updates
- Remove minor and patch version from actions to reduce noise