### PR TITLE
Filter previous releases only on master branch

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -64,6 +64,7 @@ autolabeler:
       - 'vendor*'
     branch:
       - '/deps\/.+/'
+filter-by-commitish: true
 template: |
   *Help make the NGINX Ingress Controller better by participating in our [survey](https://forms.office.com/Pages/ResponsePage.aspx?id=L_093Ttq0UCb4L-DJ9gcUM6Dh1A0cORCorfgZAMdkwJUREhJUFAyM1ZHRzZLSzQyMUlCNFhXVkZENy4u)!*
 


### PR DESCRIPTION
Since we have bugfix tags that don't go in master, we need to filter and get only the one in master.
