### PR TITLE
Add smoke test for user defined browser AP policy

### DIFF
--- a/tests/data/appprotect/ap-user-def-browser.yaml
+++ b/tests/data/appprotect/ap-user-def-browser.yaml
@@ -1,0 +1,33 @@
+apiVersion: appprotect.f5.com/v1beta1
+kind: APPolicy
+metadata:
+  name: ap-user-def-browser
+spec:
+  policy:
+    applicationLanguage: utf-8
+    name: user_defrined_browser
+    template:
+      name: POLICY_TEMPLATE_NGINX_BASE
+    browser-definitions:
+    - name: CustomBrowser1
+      matchString: custombrowser1/0.1
+    - name: CustomBrowser2
+      matchRegex: custombrowser2/0.1
+    bot-defense:
+      mitigations:
+        classes:
+        - name: browser
+          action: block
+        - name: unknown
+          action: alarm
+        browsers:
+        - name: safari
+          action: alarm
+        - name: chrome
+          action: block
+        - name: firefox
+          action: alarm
+        - name: CustomBrowser1
+          action: block
+        - name: CustomBrowser2
+          action: alarm

--- a/tests/suite/test_app_protect.py
+++ b/tests/suite/test_app_protect.py
@@ -124,7 +124,9 @@ class TestAppProtect:
         print("------------- Run test for AP policy: dataguard-alarm --------------")
         print(f"Request URL: {backend_setup.req_url} and Host: {backend_setup.ingress_host}")
 
-        ensure_response_from_backend(backend_setup.req_url, backend_setup.ingress_host, check404=True)
+        ensure_response_from_backend(
+            backend_setup.req_url, backend_setup.ingress_host, check404=True
+        )
 
         print("----------------------- Send valid request ----------------------")
         resp_valid = requests.get(
@@ -156,7 +158,9 @@ class TestAppProtect:
         print("------------- Run test for AP policy: file-block --------------")
         print(f"Request URL: {backend_setup.req_url} and Host: {backend_setup.ingress_host}")
 
-        ensure_response_from_backend(backend_setup.req_url, backend_setup.ingress_host, check404=True)
+        ensure_response_from_backend(
+            backend_setup.req_url, backend_setup.ingress_host, check404=True
+        )
 
         print("----------------------- Send valid request ----------------------")
         resp_valid = requests.get(
@@ -188,7 +192,9 @@ class TestAppProtect:
         print("------------- Run test for AP policy: malformed-block --------------")
         print(f"Request URL: {backend_setup.req_url} and Host: {backend_setup.ingress_host}")
 
-        ensure_response_from_backend(backend_setup.req_url, backend_setup.ingress_host, check404=True)
+        ensure_response_from_backend(
+            backend_setup.req_url, backend_setup.ingress_host, check404=True
+        )
 
         print("----------------------- Send valid request with no body ----------------------")
         headers = {"host": backend_setup.ingress_host}
@@ -220,7 +226,12 @@ class TestAppProtect:
 
     @pytest.mark.parametrize("backend_setup", [{"policy": "csrf"}], indirect=True)
     def test_responses_csrf(
-        self, kube_apis, ingress_controller_endpoint, crd_ingress_controller_with_ap, backend_setup, test_namespace
+        self,
+        kube_apis,
+        ingress_controller_endpoint,
+        crd_ingress_controller_with_ap,
+        backend_setup,
+        test_namespace,
     ):
         """
         Test CSRF (Cross Site Request Forgery) AppProtect policy: Block requests with invalid/null/non-https origin-header
@@ -229,13 +240,19 @@ class TestAppProtect:
         print(f"Request URL without CSRF protection: {backend_setup.req_url}")
         print(f"Request URL with CSRF protection: {backend_setup.req_url_2}")
 
-        ensure_response_from_backend(backend_setup.req_url_2, backend_setup.ingress_host, check404=True)
+        ensure_response_from_backend(
+            backend_setup.req_url_2, backend_setup.ingress_host, check404=True
+        )
 
         print("----------------------- Send request with http origin header ----------------------")
 
         headers = {"host": backend_setup.ingress_host, "Origin": "http://appprotect.example.com"}
-        resp_valid = requests.post(backend_setup.req_url, headers=headers, verify=False, cookies={"flavor": "darkchoco"})
-        resp_invalid = requests.post(backend_setup.req_url_2, headers=headers, verify=False, cookies={"flavor": "whitechoco"})
+        resp_valid = requests.post(
+            backend_setup.req_url, headers=headers, verify=False, cookies={"flavor": "darkchoco"}
+        )
+        resp_invalid = requests.post(
+            backend_setup.req_url_2, headers=headers, verify=False, cookies={"flavor": "whitechoco"}
+        )
 
         print(resp_valid.text)
         print(resp_invalid.text)
@@ -246,3 +263,74 @@ class TestAppProtect:
         assert invalid_resp_title in resp_invalid.text
         assert invalid_resp_body in resp_invalid.text
         assert resp_invalid.status_code == 200
+
+    @pytest.mark.parametrize("backend_setup", [{"policy": "ap-user-def-browser"}], indirect=True)
+    def test_responses_user_def_browser(
+        self,
+        crd_ingress_controller_with_ap,
+        backend_setup,
+    ):
+        """
+        Test User defined browser AppProtect policy: Block requests from built-in and user-defined browser based on action in policy.
+        """
+        print("------------- Run test for AP policy: User Defined Browser --------------")
+        print(f"Request URL: {backend_setup.req_url}")
+
+        ensure_response_from_backend(
+            backend_setup.req_url, backend_setup.ingress_host, check404=True
+        )
+
+        print("----------------------- Send request with User-Agent: browser ----------------------")
+
+        headers_firefox = {
+            "host": backend_setup.ingress_host,
+            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/59.0",
+        }
+        resp_firefox = requests.get(backend_setup.req_url, headers=headers_firefox, verify=False)
+        headers_chrome = {
+            "host": backend_setup.ingress_host,
+            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Chrome/76.0.3809.100",
+        }
+        resp_chrome = requests.get(backend_setup.req_url_2, headers=headers_chrome, verify=False)
+        headers_safari = {
+            "host": backend_setup.ingress_host,
+            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Safari/537.36",
+        }
+        resp_safari = requests.get(backend_setup.req_url_2, headers=headers_safari, verify=False)
+        headers_custom1 = {
+            "host": backend_setup.ingress_host,
+            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 custombrowser1/0.1",
+        }
+        resp_custom1 = requests.get(backend_setup.req_url_2, headers=headers_custom1, verify=False)
+        headers_custom2 = {
+            "host": backend_setup.ingress_host,
+            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 custombrowser2/0.1",
+        }
+        resp_custom2 = requests.get(backend_setup.req_url_2, headers=headers_custom2, verify=False)
+
+        assert (
+            200
+            == resp_firefox.status_code
+            == resp_chrome.status_code
+            == resp_safari.status_code
+            == resp_custom1.status_code
+            == resp_custom2.status_code
+        )
+        assert (
+            valid_resp_addr in resp_firefox.text
+            and valid_resp_addr in resp_safari.text
+            and valid_resp_addr in resp_custom2.text
+        )
+        assert (
+            valid_resp_name in resp_firefox.text
+            and valid_resp_name in resp_safari.text
+            and valid_resp_name in resp_custom2.text
+        )
+        assert (
+            invalid_resp_title in resp_chrome.text and
+            invalid_resp_title in resp_custom1.text
+        )
+        assert (
+            invalid_resp_body in resp_chrome.text and
+            invalid_resp_body in resp_custom1.text
+        )


### PR DESCRIPTION
### Proposed changes
- Add smoke test for browser based blocking using AppProtect

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
