### PR TITLE
Fix config and warnings about secrets at IC start

### DIFF
--- a/internal/k8s/secrets/store.go
+++ b/internal/k8s/secrets/store.go
@@ -117,7 +117,7 @@ func NewFakeSecretsStore(secrets map[string]*SecretReference) *FakeSecretStore {
 	}
 }
 
-// NewFakeSecretsStore creates a new empty FakeSecretStore.
+// NewEmptyFakeSecretsStore creates a new empty FakeSecretStore.
 func NewEmptyFakeSecretsStore() *FakeSecretStore {
 	return &FakeSecretStore{
 		secrets: make(map[string]*SecretReference),

--- a/internal/k8s/secrets/store.go
+++ b/internal/k8s/secrets/store.go
@@ -111,14 +111,28 @@ type FakeSecretStore struct {
 }
 
 // NewFakeSecretsStore creates a new FakeSecretStore.
-func NewFakeSecretsStore(secrets map[string]*SecretReference) SecretStore {
+func NewFakeSecretsStore(secrets map[string]*SecretReference) *FakeSecretStore {
 	return &FakeSecretStore{
 		secrets: secrets,
 	}
 }
 
+// NewFakeSecretsStore creates a new empty FakeSecretStore.
+func NewEmptyFakeSecretsStore() *FakeSecretStore {
+	return &FakeSecretStore{
+		secrets: make(map[string]*SecretReference),
+	}
+}
+
 // AddOrUpdateSecret is a fake implementation of AddOrUpdateSecret.
 func (s *FakeSecretStore) AddOrUpdateSecret(secret *api_v1.Secret) {
+	secretRef, exists := s.secrets[getResourceKey(&secret.ObjectMeta)]
+	if !exists {
+		secretRef = &SecretReference{Secret: secret}
+	} else {
+		secretRef.Secret = secret
+	}
+	s.secrets[getResourceKey(&secret.ObjectMeta)] = secretRef
 }
 
 // DeleteSecret is a fake implementation of DeleteSecret.


### PR DESCRIPTION
### Proposed changes
This PR ensures that during the Ingress Controller start, Secret resources are processed before any of the resources that reference those Secrets. This prevents the IC from generating incorrect config and reporting warnings about missing Secrets.

Note that the incorrect config and warnings were temporary and only occurred at the Ingress Controller start before the IC pod was considered ready (passed the readiness probe).

Fixes https://github.com/nginxinc/kubernetes-ingress/issues/1448