### PR TITLE
bug: add njs plus module to nap ubi image

### DIFF
--- a/build/DockerfileWithAppProtectForPlusForOpenShift
+++ b/build/DockerfileWithAppProtectForPlusForOpenShift
@@ -14,7 +14,8 @@ ENV APPPROTECT_ENGINE_VERSION 6.53.1-1.el7.ngx
 ENV APPPROTECT_COMPILER_VERSION 6.53.1-1.el7.ngx
 ENV APPPROTECT_SIG_VERSION 2021.02.26-1.el7.ngx
 ENV APPPROTECT_THREAT_CAMPAIGNS_VERSION 2021.03.02-1.el7.ngx
-ENV NGINX_PLUS_VERSION 23-1.el7.ngx
+ENV NGINX_PLUS_VERSION 23-2.el7.ngx
+ENV NGINX_NJS_VERSION 23+0.5.2-1.el7.ngx
 ARG IC_VERSION
 
 # Download certificate and key from the customer portal (https://cs.nginx.com)
@@ -48,6 +49,7 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	&& rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
 	&& yum clean all \
 	&& yum install -y nginx-plus-$NGINX_PLUS_VERSION \
+	    nginx-plus-module-njs-$NGINX_NJS_VERSION \
 	    nginx-plus-module-appprotect-$APPPROTECT_MODULE_VERSION \
 	    app-protect-plugin-$APPPROTECT_PLUGIN_VERSION \
 	    app-protect-engine-$APPPROTECT_ENGINE_VERSION \


### PR DESCRIPTION
### Proposed changes
If `-enable-preview-policies` is set, the `nginx-plus-module-njs` module is required on plus images. The NAP UBI image does not currently have this installed - this commit adds the required package.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
