### PR TITLE
Enable Docker scan result upload on PR

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -147,7 +147,6 @@ jobs:
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: 'trivy-results-${{ matrix.image }}.sarif'
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       - name: Upload Scan Results
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Enable scan upload so we can detect vulnerabilities early 
