### PR TITLE
Add errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     enable:
     - deadcode
     - errcheck
+    - errorlint
     - gofmt
     - goimports
     - gosec

--- a/cmd/nginx-ingress/aws.go
+++ b/cmd/nginx-ingress/aws.go
@@ -40,7 +40,7 @@ func checkAWSEntitlement() error {
 
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
-		return fmt.Errorf("error loading AWS configuration: %v", err)
+		return fmt.Errorf("error loading AWS configuration: %w", err)
 	}
 
 	mpm := marketplacemetering.New(marketplacemetering.Options{Region: cfg.Region, Credentials: cfg.Credentials})
@@ -56,16 +56,16 @@ func checkAWSEntitlement() error {
 
 	pk, err := base64.StdEncoding.DecodeString(pubKeyString)
 	if err != nil {
-		return fmt.Errorf("error decoding Public Key string: %v", err)
+		return fmt.Errorf("error decoding Public Key string: %w", err)
 	}
 	pubKey, err := jwt.ParseRSAPublicKeyFromPEM(pk)
 	if err != nil {
-		return fmt.Errorf("error parsing Public Key: %v", err)
+		return fmt.Errorf("error parsing Public Key: %w", err)
 	}
 
 	token, err := jwt.ParseWithClaims(*out.Signature, &claims{}, jwt.KnownKeyfunc(jwt.SigningMethodPS256, pubKey))
 	if err != nil {
-		return fmt.Errorf("error parsing the JWT token: %v", err)
+		return fmt.Errorf("error parsing the JWT token: %w", err)
 	}
 
 	if claims, ok := token.Claims.(*claims); ok && token.Valid {

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -796,15 +796,15 @@ func validateCIDRorIP(cidr string) error {
 func getAndValidateSecret(kubeClient *kubernetes.Clientset, secretNsName string) (secret *api_v1.Secret, err error) {
 	ns, name, err := k8s.ParseNamespaceName(secretNsName)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse the %v argument: %v", secretNsName, err)
+		return nil, fmt.Errorf("could not parse the %v argument: %w", secretNsName, err)
 	}
 	secret, err = kubeClient.CoreV1().Secrets(ns).Get(context.TODO(), name, meta_v1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not get %v: %v", secretNsName, err)
+		return nil, fmt.Errorf("could not get %v: %w", secretNsName, err)
 	}
 	err = secrets.ValidateTLSSecret(secret)
 	if err != nil {
-		return nil, fmt.Errorf("%v is invalid: %v", secretNsName, err)
+		return nil, fmt.Errorf("%v is invalid: %w", secretNsName, err)
 	}
 	return secret, nil
 }

--- a/internal/configs/configurator.go
+++ b/internal/configs/configurator.go
@@ -245,11 +245,11 @@ func (cnf *Configurator) deleteIngressMetricsLabels(key string) {
 func (cnf *Configurator) AddOrUpdateIngress(ingEx *IngressEx) (Warnings, error) {
 	warnings, err := cnf.addOrUpdateIngress(ingEx)
 	if err != nil {
-		return warnings, fmt.Errorf("Error adding or updating ingress %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+		return warnings, fmt.Errorf("Error adding or updating ingress %v/%v: %w", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return warnings, fmt.Errorf("Error reloading NGINX for %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+		return warnings, fmt.Errorf("Error reloading NGINX for %v/%v: %w", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
 	}
 
 	return warnings, nil
@@ -271,7 +271,7 @@ func (cnf *Configurator) addOrUpdateIngress(ingEx *IngressEx) (Warnings, error) 
 	name := objectMetaToFileName(&ingEx.Ingress.ObjectMeta)
 	content, err := cnf.templateExecutor.ExecuteIngressConfigTemplate(&nginxCfg)
 	if err != nil {
-		return warnings, fmt.Errorf("Error generating Ingress Config %v: %v", name, err)
+		return warnings, fmt.Errorf("Error generating Ingress Config %v: %w", name, err)
 	}
 	cnf.nginxManager.CreateConfig(name, content)
 
@@ -286,11 +286,11 @@ func (cnf *Configurator) addOrUpdateIngress(ingEx *IngressEx) (Warnings, error) 
 func (cnf *Configurator) AddOrUpdateMergeableIngress(mergeableIngs *MergeableIngresses) (Warnings, error) {
 	warnings, err := cnf.addOrUpdateMergeableIngress(mergeableIngs)
 	if err != nil {
-		return warnings, fmt.Errorf("Error when adding or updating ingress %v/%v: %v", mergeableIngs.Master.Ingress.Namespace, mergeableIngs.Master.Ingress.Name, err)
+		return warnings, fmt.Errorf("Error when adding or updating ingress %v/%v: %w", mergeableIngs.Master.Ingress.Namespace, mergeableIngs.Master.Ingress.Name, err)
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return warnings, fmt.Errorf("Error reloading NGINX for %v/%v: %v", mergeableIngs.Master.Ingress.Namespace, mergeableIngs.Master.Ingress.Name, err)
+		return warnings, fmt.Errorf("Error reloading NGINX for %v/%v: %w", mergeableIngs.Master.Ingress.Namespace, mergeableIngs.Master.Ingress.Name, err)
 	}
 
 	return warnings, nil
@@ -317,7 +317,7 @@ func (cnf *Configurator) addOrUpdateMergeableIngress(mergeableIngs *MergeableIng
 	name := objectMetaToFileName(&mergeableIngs.Master.Ingress.ObjectMeta)
 	content, err := cnf.templateExecutor.ExecuteIngressConfigTemplate(&nginxCfg)
 	if err != nil {
-		return warnings, fmt.Errorf("Error generating Ingress Config %v: %v", name, err)
+		return warnings, fmt.Errorf("Error generating Ingress Config %v: %w", name, err)
 	}
 	cnf.nginxManager.CreateConfig(name, content)
 
@@ -417,11 +417,11 @@ func (cnf *Configurator) deleteVirtualServerMetricsLabels(key string) {
 func (cnf *Configurator) AddOrUpdateVirtualServer(virtualServerEx *VirtualServerEx) (Warnings, error) {
 	warnings, err := cnf.addOrUpdateVirtualServer(virtualServerEx)
 	if err != nil {
-		return warnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %v", virtualServerEx.VirtualServer.Namespace, virtualServerEx.VirtualServer.Name, err)
+		return warnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %w", virtualServerEx.VirtualServer.Namespace, virtualServerEx.VirtualServer.Name, err)
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return warnings, fmt.Errorf("Error reloading NGINX for VirtualServer %v/%v: %v", virtualServerEx.VirtualServer.Namespace, virtualServerEx.VirtualServer.Name, err)
+		return warnings, fmt.Errorf("Error reloading NGINX for VirtualServer %v/%v: %w", virtualServerEx.VirtualServer.Namespace, virtualServerEx.VirtualServer.Name, err)
 	}
 
 	return warnings, nil
@@ -441,7 +441,7 @@ func (cnf *Configurator) addOrUpdateVirtualServer(virtualServerEx *VirtualServer
 	vsCfg, warnings := vsc.GenerateVirtualServerConfig(virtualServerEx, apResources)
 	content, err := cnf.templateExecutorV2.ExecuteVirtualServerTemplate(&vsCfg)
 	if err != nil {
-		return warnings, fmt.Errorf("Error generating VirtualServer config: %v: %v", name, err)
+		return warnings, fmt.Errorf("Error generating VirtualServer config: %v: %w", name, err)
 	}
 	cnf.nginxManager.CreateConfig(name, content)
 
@@ -466,7 +466,7 @@ func (cnf *Configurator) AddOrUpdateVirtualServers(virtualServerExes []*VirtualS
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return allWarnings, fmt.Errorf("Error when reloading NGINX when updating Policy: %v", err)
+		return allWarnings, fmt.Errorf("Error when reloading NGINX when updating Policy: %w", err)
 	}
 
 	return allWarnings, nil
@@ -544,11 +544,11 @@ func (cnf *Configurator) deleteTransportServerMetricsLabels(key string) {
 func (cnf *Configurator) AddOrUpdateTransportServer(transportServerEx *TransportServerEx) error {
 	err := cnf.addOrUpdateTransportServer(transportServerEx)
 	if err != nil {
-		return fmt.Errorf("Error adding or updating TransportServer %v/%v: %v", transportServerEx.TransportServer.Namespace, transportServerEx.TransportServer.Name, err)
+		return fmt.Errorf("Error adding or updating TransportServer %v/%v: %w", transportServerEx.TransportServer.Namespace, transportServerEx.TransportServer.Name, err)
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return fmt.Errorf("Error reloading NGINX for TransportServer %v/%v: %v", transportServerEx.TransportServer.Namespace, transportServerEx.TransportServer.Name, err)
+		return fmt.Errorf("Error reloading NGINX for TransportServer %v/%v: %w", transportServerEx.TransportServer.Namespace, transportServerEx.TransportServer.Name, err)
 	}
 
 	return nil
@@ -561,7 +561,7 @@ func (cnf *Configurator) addOrUpdateTransportServer(transportServerEx *Transport
 
 	content, err := cnf.templateExecutorV2.ExecuteTransportServerTemplate(tsCfg)
 	if err != nil {
-		return fmt.Errorf("Error generating TransportServer config %v: %v", name, err)
+		return fmt.Errorf("Error generating TransportServer config %v: %w", name, err)
 	}
 
 	if cnf.isPlus && cnf.isPrometheusEnabled {
@@ -600,7 +600,7 @@ func (cnf *Configurator) updateTLSPassthroughHostsConfig() error {
 
 	content, err := cnf.templateExecutorV2.ExecuteTLSPassthroughHostsTemplate(cfg)
 	if err != nil {
-		return fmt.Errorf("Error generating config for TLS Passthrough Unix Sockets map: %v", err)
+		return fmt.Errorf("Error generating config for TLS Passthrough Unix Sockets map: %w", err)
 	}
 
 	cnf.nginxManager.CreateTLSPassthroughHostsConfig(content)
@@ -637,7 +637,7 @@ func (cnf *Configurator) AddOrUpdateResources(resources ExtendedResources) (Warn
 	for _, ingEx := range resources.IngressExes {
 		warnings, err := cnf.addOrUpdateIngress(ingEx)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating ingress %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating ingress %v/%v: %w", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -645,7 +645,7 @@ func (cnf *Configurator) AddOrUpdateResources(resources ExtendedResources) (Warn
 	for _, m := range resources.MergeableIngresses {
 		warnings, err := cnf.addOrUpdateMergeableIngress(m)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %v", m.Master.Ingress.Namespace, m.Master.Ingress.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %w", m.Master.Ingress.Namespace, m.Master.Ingress.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -653,7 +653,7 @@ func (cnf *Configurator) AddOrUpdateResources(resources ExtendedResources) (Warn
 	for _, vsEx := range resources.VirtualServerExes {
 		warnings, err := cnf.addOrUpdateVirtualServer(vsEx)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %v", vsEx.VirtualServer.Namespace, vsEx.VirtualServer.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %w", vsEx.VirtualServer.Namespace, vsEx.VirtualServer.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -661,12 +661,12 @@ func (cnf *Configurator) AddOrUpdateResources(resources ExtendedResources) (Warn
 	for _, tsEx := range resources.TransportServerExes {
 		err := cnf.addOrUpdateTransportServer(tsEx)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating TransportServer %v/%v: %v", tsEx.TransportServer.Namespace, tsEx.TransportServer.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating TransportServer %v/%v: %w", tsEx.TransportServer.Namespace, tsEx.TransportServer.Name, err)
 		}
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return allWarnings, fmt.Errorf("Error when reloading NGINX when updating resources: %v", err)
+		return allWarnings, fmt.Errorf("Error when reloading NGINX when updating resources: %w", err)
 	}
 
 	return allWarnings, nil
@@ -687,7 +687,7 @@ func (cnf *Configurator) AddOrUpdateSpecialTLSSecrets(secret *api_v1.Secret, sec
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return fmt.Errorf("Error when reloading NGINX when updating the special Secrets: %v", err)
+		return fmt.Errorf("Error when reloading NGINX when updating the special Secrets: %w", err)
 	}
 
 	return nil
@@ -726,7 +726,7 @@ func (cnf *Configurator) DeleteIngress(key string) error {
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return fmt.Errorf("Error when removing ingress %v: %v", key, err)
+		return fmt.Errorf("Error when removing ingress %v: %w", key, err)
 	}
 
 	return nil
@@ -743,7 +743,7 @@ func (cnf *Configurator) DeleteVirtualServer(key string) error {
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return fmt.Errorf("Error when removing VirtualServer %v: %v", key, err)
+		return fmt.Errorf("Error when removing VirtualServer %v: %w", key, err)
 	}
 
 	return nil
@@ -757,12 +757,12 @@ func (cnf *Configurator) DeleteTransportServer(key string) error {
 
 	err := cnf.deleteTransportServer(key)
 	if err != nil {
-		return fmt.Errorf("Error when removing TransportServer %v: %v", key, err)
+		return fmt.Errorf("Error when removing TransportServer %v: %w", key, err)
 	}
 
 	err = cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate)
 	if err != nil {
-		return fmt.Errorf("Error when removing TransportServer %v: %v", key, err)
+		return fmt.Errorf("Error when removing TransportServer %v: %w", key, err)
 	}
 
 	return nil
@@ -790,7 +790,7 @@ func (cnf *Configurator) UpdateEndpoints(ingExes []*IngressEx) error {
 		// It is safe to ignore warnings here as no new warnings should appear when updating Endpoints for Ingresses
 		_, err := cnf.addOrUpdateIngress(ingEx)
 		if err != nil {
-			return fmt.Errorf("Error adding or updating ingress %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+			return fmt.Errorf("Error adding or updating ingress %v/%v: %w", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
 		}
 
 		if cnf.isPlus {
@@ -808,7 +808,7 @@ func (cnf *Configurator) UpdateEndpoints(ingExes []*IngressEx) error {
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForEndpointsUpdate); err != nil {
-		return fmt.Errorf("Error reloading NGINX when updating endpoints: %v", err)
+		return fmt.Errorf("Error reloading NGINX when updating endpoints: %w", err)
 	}
 
 	return nil
@@ -822,7 +822,7 @@ func (cnf *Configurator) UpdateEndpointsMergeableIngress(mergeableIngresses []*M
 		// It is safe to ignore warnings here as no new warnings should appear when updating Endpoints for Ingresses
 		_, err := cnf.addOrUpdateMergeableIngress(mergeableIngresses[i])
 		if err != nil {
-			return fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %v", mergeableIngresses[i].Master.Ingress.Namespace, mergeableIngresses[i].Master.Ingress.Name, err)
+			return fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %w", mergeableIngresses[i].Master.Ingress.Namespace, mergeableIngresses[i].Master.Ingress.Name, err)
 		}
 
 		if cnf.isPlus {
@@ -842,7 +842,7 @@ func (cnf *Configurator) UpdateEndpointsMergeableIngress(mergeableIngresses []*M
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForEndpointsUpdate); err != nil {
-		return fmt.Errorf("Error reloading NGINX when updating endpoints for %v: %v", mergeableIngresses, err)
+		return fmt.Errorf("Error reloading NGINX when updating endpoints for %v: %w", mergeableIngresses, err)
 	}
 
 	return nil
@@ -856,7 +856,7 @@ func (cnf *Configurator) UpdateEndpointsForVirtualServers(virtualServerExes []*V
 		// It is safe to ignore warnings here as no new warnings should appear when updating Endpoints for VirtualServers
 		_, err := cnf.addOrUpdateVirtualServer(vs)
 		if err != nil {
-			return fmt.Errorf("Error adding or updating VirtualServer %v/%v: %v", vs.VirtualServer.Namespace, vs.VirtualServer.Name, err)
+			return fmt.Errorf("Error adding or updating VirtualServer %v/%v: %w", vs.VirtualServer.Namespace, vs.VirtualServer.Name, err)
 		}
 
 		if cnf.isPlus {
@@ -874,7 +874,7 @@ func (cnf *Configurator) UpdateEndpointsForVirtualServers(virtualServerExes []*V
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForEndpointsUpdate); err != nil {
-		return fmt.Errorf("Error reloading NGINX when updating endpoints: %v", err)
+		return fmt.Errorf("Error reloading NGINX when updating endpoints: %w", err)
 	}
 
 	return nil
@@ -889,7 +889,7 @@ func (cnf *Configurator) updatePlusEndpointsForVirtualServer(virtualServerEx *Vi
 
 		err := cnf.nginxManager.UpdateServersInPlus(upstream.Name, endpoints, serverCfg)
 		if err != nil {
-			return fmt.Errorf("Couldn't update the endpoints for %v: %v", upstream.Name, err)
+			return fmt.Errorf("Couldn't update the endpoints for %v: %w", upstream.Name, err)
 		}
 	}
 
@@ -903,7 +903,7 @@ func (cnf *Configurator) UpdateEndpointsForTransportServers(transportServerExes 
 	for _, tsEx := range transportServerExes {
 		err := cnf.addOrUpdateTransportServer(tsEx)
 		if err != nil {
-			return fmt.Errorf("Error adding or updating TransportServer %v/%v: %v", tsEx.TransportServer.Namespace, tsEx.TransportServer.Name, err)
+			return fmt.Errorf("Error adding or updating TransportServer %v/%v: %w", tsEx.TransportServer.Namespace, tsEx.TransportServer.Name, err)
 		}
 
 		if cnf.isPlus {
@@ -921,7 +921,7 @@ func (cnf *Configurator) UpdateEndpointsForTransportServers(transportServerExes 
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForEndpointsUpdate); err != nil {
-		return fmt.Errorf("Error reloading NGINX when updating endpoints: %v", err)
+		return fmt.Errorf("Error reloading NGINX when updating endpoints: %w", err)
 	}
 
 	return nil
@@ -939,7 +939,7 @@ func (cnf *Configurator) updatePlusEndpointsForTransportServer(transportServerEx
 
 		err := cnf.nginxManager.UpdateStreamServersInPlus(name, endpoints)
 		if err != nil {
-			return fmt.Errorf("Couldn't update the endpoints for %v: %v", u.Name, err)
+			return fmt.Errorf("Couldn't update the endpoints for %v: %w", u.Name, err)
 		}
 	}
 
@@ -965,7 +965,7 @@ func (cnf *Configurator) updatePlusEndpoints(ingEx *IngressEx) error {
 				name := getNameForUpstream(ingEx.Ingress, emptyHost, ingEx.Ingress.Spec.Backend)
 				err := cnf.nginxManager.UpdateServersInPlus(name, endps, cfg)
 				if err != nil {
-					return fmt.Errorf("Couldn't update the endpoints for %v: %v", name, err)
+					return fmt.Errorf("Couldn't update the endpoints for %v: %w", name, err)
 				}
 			}
 		}
@@ -987,7 +987,7 @@ func (cnf *Configurator) updatePlusEndpoints(ingEx *IngressEx) error {
 				name := getNameForUpstream(ingEx.Ingress, rule.Host, &path.Backend)
 				err := cnf.nginxManager.UpdateServersInPlus(name, endps, cfg)
 				if err != nil {
-					return fmt.Errorf("Couldn't update the endpoints for %v: %v", name, err)
+					return fmt.Errorf("Couldn't update the endpoints for %v: %w", name, err)
 				}
 			}
 		}
@@ -1004,7 +1004,7 @@ func (cnf *Configurator) UpdateConfig(cfgParams *ConfigParams, ingExes []*Ingres
 	if cnf.cfgParams.MainServerSSLDHParamFileContent != nil {
 		fileName, err := cnf.nginxManager.CreateDHParam(*cnf.cfgParams.MainServerSSLDHParamFileContent)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error when updating dhparams: %v", err)
+			return allWarnings, fmt.Errorf("Error when updating dhparams: %w", err)
 		}
 		cfgParams.MainServerSSLDHParam = fileName
 	}
@@ -1012,21 +1012,21 @@ func (cnf *Configurator) UpdateConfig(cfgParams *ConfigParams, ingExes []*Ingres
 	if cfgParams.MainTemplate != nil {
 		err := cnf.templateExecutor.UpdateMainTemplate(cfgParams.MainTemplate)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error when parsing the main template: %v", err)
+			return allWarnings, fmt.Errorf("Error when parsing the main template: %w", err)
 		}
 	}
 
 	if cfgParams.IngressTemplate != nil {
 		err := cnf.templateExecutor.UpdateIngressTemplate(cfgParams.IngressTemplate)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error when parsing the ingress template: %v", err)
+			return allWarnings, fmt.Errorf("Error when parsing the ingress template: %w", err)
 		}
 	}
 
 	if cfgParams.VirtualServerTemplate != nil {
 		err := cnf.templateExecutorV2.UpdateVirtualServerTemplate(cfgParams.VirtualServerTemplate)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error when parsing the VirtualServer template: %v", err)
+			return allWarnings, fmt.Errorf("Error when parsing the VirtualServer template: %w", err)
 		}
 	}
 
@@ -1061,13 +1061,13 @@ func (cnf *Configurator) UpdateConfig(cfgParams *ConfigParams, ingExes []*Ingres
 
 	if mainCfg.OpenTracingLoadModule {
 		if err := cnf.addOrUpdateOpenTracingTracerConfig(mainCfg.OpenTracingTracerConfig); err != nil {
-			return allWarnings, fmt.Errorf("Error when updating OpenTracing tracer config: %v", err)
+			return allWarnings, fmt.Errorf("Error when updating OpenTracing tracer config: %w", err)
 		}
 	}
 
 	cnf.nginxManager.SetOpenTracing(mainCfg.OpenTracingLoadModule)
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return allWarnings, fmt.Errorf("Error when updating config from ConfigMap: %v", err)
+		return allWarnings, fmt.Errorf("Error when updating config from ConfigMap: %w", err)
 	}
 
 	return allWarnings, nil
@@ -1078,19 +1078,19 @@ func (cnf *Configurator) UpdateTransportServers(updatedTSExes []*TransportServer
 	for _, tsEx := range updatedTSExes {
 		err := cnf.addOrUpdateTransportServer(tsEx)
 		if err != nil {
-			return fmt.Errorf("Error adding or updating TransportServer %v/%v: %v", tsEx.TransportServer.Namespace, tsEx.TransportServer.Name, err)
+			return fmt.Errorf("Error adding or updating TransportServer %v/%v: %w", tsEx.TransportServer.Namespace, tsEx.TransportServer.Name, err)
 		}
 	}
 
 	for _, key := range deletedKeys {
 		err := cnf.deleteTransportServer(key)
 		if err != nil {
-			return fmt.Errorf("Error when removing TransportServer %v: %v", key, err)
+			return fmt.Errorf("Error when removing TransportServer %v: %w", key, err)
 		}
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return fmt.Errorf("Error when updating TransportServers: %v", err)
+		return fmt.Errorf("Error when updating TransportServers: %w", err)
 	}
 
 	return nil
@@ -1188,7 +1188,7 @@ func (cnf *Configurator) AddOrUpdateSpiffeCerts(svidResponse *workload.X509SVIDs
 	svid := svidResponse.Default()
 	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(svid.PrivateKey.(crypto.PrivateKey))
 	if err != nil {
-		return fmt.Errorf("error when marshaling private key: %v", err)
+		return fmt.Errorf("error when marshaling private key: %w", err)
 	}
 
 	cnf.nginxManager.CreateSecret(spiffeKeyFileName, createSpiffeKey(privateKeyBytes), spiffeKeyFileMode)
@@ -1197,7 +1197,7 @@ func (cnf *Configurator) AddOrUpdateSpiffeCerts(svidResponse *workload.X509SVIDs
 
 	err = cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate)
 	if err != nil {
-		return fmt.Errorf("error when reloading NGINX when updating the SPIFFE Certs: %v", err)
+		return fmt.Errorf("error when reloading NGINX when updating the SPIFFE Certs: %w", err)
 	}
 	return nil
 }
@@ -1289,7 +1289,7 @@ func (cnf *Configurator) AddOrUpdateAppProtectResource(resource *unstructured.Un
 	for _, ingEx := range ingExes {
 		warnings, err := cnf.addOrUpdateIngress(ingEx)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating ingress %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating ingress %v/%v: %w", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -1297,7 +1297,7 @@ func (cnf *Configurator) AddOrUpdateAppProtectResource(resource *unstructured.Un
 	for _, m := range mergeableIngresses {
 		warnings, err := cnf.addOrUpdateMergeableIngress(m)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %v", m.Master.Ingress.Namespace, m.Master.Ingress.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %w", m.Master.Ingress.Namespace, m.Master.Ingress.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -1305,13 +1305,13 @@ func (cnf *Configurator) AddOrUpdateAppProtectResource(resource *unstructured.Un
 	for _, vs := range vsExes {
 		warnings, err := cnf.addOrUpdateVirtualServer(vs)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %v", vs.VirtualServer.Namespace, vs.VirtualServer.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %w", vs.VirtualServer.Namespace, vs.VirtualServer.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return allWarnings, fmt.Errorf("Error when reloading NGINX when updating %v: %v", resource.GetKind(), err)
+		return allWarnings, fmt.Errorf("Error when reloading NGINX when updating %v: %w", resource.GetKind(), err)
 	}
 
 	return allWarnings, nil
@@ -1330,7 +1330,7 @@ func (cnf *Configurator) DeleteAppProtectPolicy(polNamespaceName string, ingExes
 	for _, ingEx := range ingExes {
 		warnings, err := cnf.addOrUpdateIngress(ingEx)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating ingress %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating ingress %v/%v: %w", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -1338,7 +1338,7 @@ func (cnf *Configurator) DeleteAppProtectPolicy(polNamespaceName string, ingExes
 	for _, m := range mergeableIngresses {
 		warnings, err := cnf.addOrUpdateMergeableIngress(m)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %v", m.Master.Ingress.Namespace, m.Master.Ingress.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %w", m.Master.Ingress.Namespace, m.Master.Ingress.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -1346,13 +1346,13 @@ func (cnf *Configurator) DeleteAppProtectPolicy(polNamespaceName string, ingExes
 	for _, v := range vsExes {
 		warnings, err := cnf.addOrUpdateVirtualServer(v)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %v", v.VirtualServer.Namespace, v.VirtualServer.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %w", v.VirtualServer.Namespace, v.VirtualServer.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return allWarnings, fmt.Errorf("Error when reloading NGINX when removing App Protect Policy: %v", err)
+		return allWarnings, fmt.Errorf("Error when reloading NGINX when removing App Protect Policy: %w", err)
 	}
 
 	return allWarnings, nil
@@ -1370,7 +1370,7 @@ func (cnf *Configurator) DeleteAppProtectLogConf(logConfNamespaceName string, in
 	for _, ingEx := range ingExes {
 		warnings, err := cnf.addOrUpdateIngress(ingEx)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating ingress %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating ingress %v/%v: %w", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -1378,7 +1378,7 @@ func (cnf *Configurator) DeleteAppProtectLogConf(logConfNamespaceName string, in
 	for _, m := range mergeableIngresses {
 		warnings, err := cnf.addOrUpdateMergeableIngress(m)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %v", m.Master.Ingress.Namespace, m.Master.Ingress.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %w", m.Master.Ingress.Namespace, m.Master.Ingress.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -1386,13 +1386,13 @@ func (cnf *Configurator) DeleteAppProtectLogConf(logConfNamespaceName string, in
 	for _, v := range vsExes {
 		warnings, err := cnf.addOrUpdateVirtualServer(v)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %v", v.VirtualServer.Namespace, v.VirtualServer.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %w", v.VirtualServer.Namespace, v.VirtualServer.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
 
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return allWarnings, fmt.Errorf("Error when reloading NGINX when removing App Protect Log Configuration: %v", err)
+		return allWarnings, fmt.Errorf("Error when reloading NGINX when removing App Protect Log Configuration: %w", err)
 	}
 
 	return allWarnings, nil
@@ -1406,7 +1406,7 @@ func (cnf *Configurator) RefreshAppProtectUserSigs(
 	for _, ingEx := range ingExes {
 		warnings, err := cnf.addOrUpdateIngress(ingEx)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating ingress %v/%v: %v", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating ingress %v/%v: %w", ingEx.Ingress.Namespace, ingEx.Ingress.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -1414,7 +1414,7 @@ func (cnf *Configurator) RefreshAppProtectUserSigs(
 	for _, m := range mergeableIngresses {
 		warnings, err := cnf.addOrUpdateMergeableIngress(m)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %v", m.Master.Ingress.Namespace, m.Master.Ingress.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating mergeableIngress %v/%v: %w", m.Master.Ingress.Namespace, m.Master.Ingress.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -1422,7 +1422,7 @@ func (cnf *Configurator) RefreshAppProtectUserSigs(
 	for _, v := range vsExes {
 		warnings, err := cnf.addOrUpdateVirtualServer(v)
 		if err != nil {
-			return allWarnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %v", v.VirtualServer.Namespace, v.VirtualServer.Name, err)
+			return allWarnings, fmt.Errorf("Error adding or updating VirtualServer %v/%v: %w", v.VirtualServer.Namespace, v.VirtualServer.Name, err)
 		}
 		allWarnings.Add(warnings)
 	}
@@ -1450,11 +1450,11 @@ func (cnf *Configurator) AddInternalRouteConfig() error {
 	mainCfg := GenerateNginxMainConfig(cnf.staticCfgParams, cnf.cfgParams)
 	mainCfgContent, err := cnf.templateExecutor.ExecuteMainConfigTemplate(mainCfg)
 	if err != nil {
-		return fmt.Errorf("Error when writing main Config: %v", err)
+		return fmt.Errorf("Error when writing main Config: %w", err)
 	}
 	cnf.nginxManager.CreateMainConfig(mainCfgContent)
 	if err := cnf.nginxManager.Reload(nginx.ReloadForOtherUpdate); err != nil {
-		return fmt.Errorf("Error when reloading nginx: %v", err)
+		return fmt.Errorf("Error when reloading nginx: %w", err)
 	}
 	return nil
 }

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -23,7 +23,7 @@ func GetMapKeyAsBool(m map[string]string, key string, context apiObject) (bool, 
 	if str, exists := m[key]; exists {
 		b, err := ParseBool(str)
 		if err != nil {
-			return false, exists, fmt.Errorf("%s %v/%v '%s' contains invalid bool: %v, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key, err)
+			return false, exists, fmt.Errorf("%s %v/%v '%s' contains invalid bool: %w, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key, err)
 		}
 
 		return b, exists, nil
@@ -37,7 +37,7 @@ func GetMapKeyAsInt(m map[string]string, key string, context apiObject) (int, bo
 	if str, exists := m[key]; exists {
 		i, err := ParseInt(str)
 		if err != nil {
-			return 0, exists, fmt.Errorf("%s %v/%v '%s' contains invalid integer: %v, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key, err)
+			return 0, exists, fmt.Errorf("%s %v/%v '%s' contains invalid integer: %w, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key, err)
 		}
 
 		return i, exists, nil
@@ -51,7 +51,7 @@ func GetMapKeyAsInt64(m map[string]string, key string, context apiObject) (int64
 	if str, exists := m[key]; exists {
 		i, err := ParseInt64(str)
 		if err != nil {
-			return 0, exists, fmt.Errorf("%s %v/%v '%s' contains invalid integer: %v, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key, err)
+			return 0, exists, fmt.Errorf("%s %v/%v '%s' contains invalid integer: %w, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key, err)
 		}
 
 		return i, exists, nil
@@ -65,7 +65,7 @@ func GetMapKeyAsUint64(m map[string]string, key string, context apiObject, nonZe
 	if str, exists := m[key]; exists {
 		i, err := ParseUint64(str)
 		if err != nil {
-			return 0, exists, fmt.Errorf("%s %v/%v '%s' contains invalid uint64: %v, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key, err)
+			return 0, exists, fmt.Errorf("%s %v/%v '%s' contains invalid uint64: %w, ignoring", context.GetObjectKind().GroupVersionKind().Kind, context.GetNamespace(), context.GetName(), key, err)
 		}
 
 		if nonZero && i == 0 {
@@ -264,7 +264,7 @@ func ParsePortList(s string) ([]int, error) {
 func parsePort(value string) (int, error) {
 	port, err := strconv.ParseInt(value, 10, 16)
 	if err != nil {
-		return 0, fmt.Errorf("Unable to parse port as integer: %s", err)
+		return 0, fmt.Errorf("Unable to parse port as integer: %w", err)
 	}
 
 	if port <= 0 {
@@ -344,8 +344,10 @@ func parseRewrites(service string) (serviceName string, rewrite string, err erro
 	return svcNameParts[1], rwPathParts[1], nil
 }
 
-var threshEx = regexp.MustCompile(`high=([1-9]|[1-9][0-9]|100) low=([1-9]|[1-9][0-9]|100)\b`)
-var threshExR = regexp.MustCompile(`low=([1-9]|[1-9][0-9]|100) high=([1-9]|[1-9][0-9]|100)\b`)
+var (
+	threshEx  = regexp.MustCompile(`high=([1-9]|[1-9][0-9]|100) low=([1-9]|[1-9][0-9]|100)\b`)
+	threshExR = regexp.MustCompile(`low=([1-9]|[1-9][0-9]|100) high=([1-9]|[1-9][0-9]|100)\b`)
+)
 
 // VerifyAppProtectThresholds ensures that threshold values are set correctly
 func VerifyAppProtectThresholds(value string) bool {

--- a/internal/k8s/appprotect/app_protect_resources.go
+++ b/internal/k8s/appprotect/app_protect_resources.go
@@ -27,7 +27,7 @@ func validateRequiredFields(obj *unstructured.Unstructured, fieldsList [][]strin
 	for _, fields := range fieldsList {
 		field, found, err := unstructured.NestedMap(obj.Object, fields...)
 		if err != nil {
-			return fmt.Errorf("Error checking for required field %v: %v", field, err)
+			return fmt.Errorf("Error checking for required field %v: %w", field, err)
 		}
 		if !found {
 			return fmt.Errorf("Required field %v not found", field)
@@ -40,7 +40,7 @@ func validateRequiredSlices(obj *unstructured.Unstructured, fieldsList [][]strin
 	for _, fields := range fieldsList {
 		field, found, err := unstructured.NestedSlice(obj.Object, fields...)
 		if err != nil {
-			return fmt.Errorf("Error checking for required field %v: %v", field, err)
+			return fmt.Errorf("Error checking for required field %v: %w", field, err)
 		}
 		if !found {
 			return fmt.Errorf("Required field %v not found", field)
@@ -55,7 +55,7 @@ func validateAppProtectPolicy(policy *unstructured.Unstructured) error {
 
 	err := validateRequiredFields(policy, appProtectPolicyRequiredFields)
 	if err != nil {
-		return fmt.Errorf("Error validating App Protect Policy %v: %v", polName, err)
+		return fmt.Errorf("Error validating App Protect Policy %v: %w", polName, err)
 	}
 
 	return nil
@@ -66,14 +66,16 @@ func validateAppProtectLogConf(logConf *unstructured.Unstructured) error {
 	lcName := logConf.GetName()
 	err := validateRequiredFields(logConf, appProtectLogConfRequiredFields)
 	if err != nil {
-		return fmt.Errorf("Error validating App Protect Log Configuration %v: %v", lcName, err)
+		return fmt.Errorf("Error validating App Protect Log Configuration %v: %w", lcName, err)
 	}
 
 	return nil
 }
 
-var logDstEx = regexp.MustCompile(`(?:syslog:server=((?:\d{1,3}\.){3}\d{1,3}|localhost):\d{1,5})|stderr|(?:\/[\S]+)+`)
-var logDstFileEx = regexp.MustCompile(`(?:\/[\S]+)+`)
+var (
+	logDstEx     = regexp.MustCompile(`(?:syslog:server=((?:\d{1,3}\.){3}\d{1,3}|localhost):\d{1,5})|stderr|(?:\/[\S]+)+`)
+	logDstFileEx = regexp.MustCompile(`(?:\/[\S]+)+`)
+)
 
 // ValidateAppProtectLogDestination validates destination for log configuration
 func ValidateAppProtectLogDestination(dstAntn string) error {
@@ -131,7 +133,7 @@ func validateAppProtectUserSig(userSig *unstructured.Unstructured) error {
 	sigName := userSig.GetName()
 	err := validateRequiredSlices(userSig, appProtectUserSigRequiredSlices)
 	if err != nil {
-		return fmt.Errorf("Error validating App Protect User Signature %v: %v", sigName, err)
+		return fmt.Errorf("Error validating App Protect User Signature %v: %w", sigName, err)
 	}
 
 	return nil

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1866,7 +1866,7 @@ func (lbc *LoadBalancerController) updateVirtualServersStatusFromEvents() error 
 		events, err := lbc.client.CoreV1().Events(vs.Namespace).List(context.TODO(),
 			meta_v1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%v,involvedObject.uid=%v", vs.Name, vs.UID)})
 		if err != nil {
-			allErrs = append(allErrs, fmt.Errorf("error trying to get events for VirtualServer %v/%v: %v", vs.Namespace, vs.Name, err))
+			allErrs = append(allErrs, fmt.Errorf("error trying to get events for VirtualServer %v/%v: %w", vs.Namespace, vs.Name, err))
 			break
 		}
 
@@ -1908,7 +1908,7 @@ func (lbc *LoadBalancerController) updateVirtualServerRoutesStatusFromEvents() e
 		events, err := lbc.client.CoreV1().Events(vsr.Namespace).List(context.TODO(),
 			meta_v1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%v,involvedObject.uid=%v", vsr.Name, vsr.UID)})
 		if err != nil {
-			allErrs = append(allErrs, fmt.Errorf("error trying to get events for VirtualServerRoute %v/%v: %v", vsr.Namespace, vsr.Name, err))
+			allErrs = append(allErrs, fmt.Errorf("error trying to get events for VirtualServerRoute %v/%v: %w", vsr.Namespace, vsr.Name, err))
 			break
 		}
 
@@ -1973,7 +1973,7 @@ func (lbc *LoadBalancerController) updateTransportServersStatusFromEvents() erro
 		events, err := lbc.client.CoreV1().Events(ts.Namespace).List(context.TODO(),
 			meta_v1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%v,involvedObject.uid=%v", ts.Name, ts.UID)})
 		if err != nil {
-			allErrs = append(allErrs, fmt.Errorf("error trying to get events for TransportServer %v/%v: %v", ts.Namespace, ts.Name, err))
+			allErrs = append(allErrs, fmt.Errorf("error trying to get events for TransportServer %v/%v: %w", ts.Namespace, ts.Name, err))
 			break
 		}
 
@@ -2199,14 +2199,14 @@ func (lbc *LoadBalancerController) getAppProtectLogConfAndDst(ing *networking.In
 	for _, logDst := range logDsts {
 		err := appprotect.ValidateAppProtectLogDestination(logDst)
 		if err != nil {
-			return apLogs, fmt.Errorf("Error Validating App Protect Destination Config for Ingress %v: %v", ing.Name, err)
+			return apLogs, fmt.Errorf("Error Validating App Protect Destination Config for Ingress %v: %w", ing.Name, err)
 		}
 	}
 
 	for i, logConfNsN := range logConfNsNs {
 		logConf, err := lbc.appProtectConfiguration.GetAppResource(appprotect.LogConfGVK.Kind, logConfNsN)
 		if err != nil {
-			return apLogs, fmt.Errorf("Error retrieving App Protect Log Config for Ingress %v: %v", ing.Name, err)
+			return apLogs, fmt.Errorf("Error retrieving App Protect Log Config for Ingress %v: %w", ing.Name, err)
 		}
 		apLogs = append(apLogs, configs.AppProtectLog{
 			LogConf: logConf,
@@ -2222,7 +2222,7 @@ func (lbc *LoadBalancerController) getAppProtectPolicy(ing *networking.Ingress) 
 
 	apPolicy, err = lbc.appProtectConfiguration.GetAppResource(appprotect.PolicyGVK.Kind, polNsN)
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving App Protect Policy for Ingress %v: %v ", ing.Name, err)
+		return nil, fmt.Errorf("Error retrieving App Protect Policy for Ingress %v: %w", ing.Name, err)
 	}
 
 	return apPolicy, nil
@@ -2476,7 +2476,7 @@ func (lbc *LoadBalancerController) getPolicies(policies []conf_v1.PolicyReferenc
 
 		policyObj, exists, err := lbc.policyLister.GetByKey(policyKey)
 		if err != nil {
-			errors = append(errors, fmt.Errorf("Failed to get policy %s: %v", policyKey, err))
+			errors = append(errors, fmt.Errorf("Failed to get policy %s: %w", policyKey, err))
 			continue
 		}
 
@@ -2489,7 +2489,7 @@ func (lbc *LoadBalancerController) getPolicies(policies []conf_v1.PolicyReferenc
 
 		err = validation.ValidatePolicy(policy, lbc.isNginxPlus, lbc.enablePreviewPolicies, lbc.appProtectEnabled)
 		if err != nil {
-			errors = append(errors, fmt.Errorf("Policy %s is invalid: %v", policyKey, err))
+			errors = append(errors, fmt.Errorf("Policy %s is invalid: %w", policyKey, err))
 			continue
 		}
 
@@ -2601,7 +2601,7 @@ func (lbc *LoadBalancerController) addWAFPolicyRefs(
 
 			apPolicy, err := lbc.appProtectConfiguration.GetAppResource(appprotect.PolicyGVK.Kind, apPolKey)
 			if err != nil {
-				return fmt.Errorf("WAF policy %q is invalid: %v", apPolKey, err)
+				return fmt.Errorf("WAF policy %q is invalid: %w", apPolKey, err)
 			}
 			apPolRef[apPolKey] = apPolicy
 		}
@@ -2614,7 +2614,7 @@ func (lbc *LoadBalancerController) addWAFPolicyRefs(
 
 			logConf, err := lbc.appProtectConfiguration.GetAppResource(appprotect.LogConfGVK.Kind, logConfKey)
 			if err != nil {
-				return fmt.Errorf("WAF policy %q is invalid: %v", logConfKey, err)
+				return fmt.Errorf("WAF policy %q is invalid: %w", logConfKey, err)
 			}
 			logConfRef[logConfKey] = logConf
 		}
@@ -2717,7 +2717,7 @@ func (lbc *LoadBalancerController) createTransportServerEx(transportServer *conf
 func (lbc *LoadBalancerController) getEndpointsForUpstream(namespace string, upstreamService string, upstreamPort uint16) (endps []podEndpoint, isExternal bool, err error) {
 	svc, err := lbc.getServiceForUpstream(namespace, upstreamService, upstreamPort)
 	if err != nil {
-		return nil, false, fmt.Errorf("Error getting service %v: %v", upstreamService, err)
+		return nil, false, fmt.Errorf("Error getting service %v: %w", upstreamService, err)
 	}
 
 	backend := &networking.IngressBackend{
@@ -2727,7 +2727,7 @@ func (lbc *LoadBalancerController) getEndpointsForUpstream(namespace string, ups
 
 	endps, isExternal, err = lbc.getEndpointsForIngressBackend(backend, svc)
 	if err != nil {
-		return nil, false, fmt.Errorf("Error retrieving endpoints for the service %v: %v", upstreamService, err)
+		return nil, false, fmt.Errorf("Error retrieving endpoints for the service %v: %w", upstreamService, err)
 	}
 
 	return endps, isExternal, err
@@ -2736,7 +2736,7 @@ func (lbc *LoadBalancerController) getEndpointsForUpstream(namespace string, ups
 func (lbc *LoadBalancerController) getEndpointsForSubselector(namespace string, upstream conf_v1.Upstream) (endps []podEndpoint, err error) {
 	svc, err := lbc.getServiceForUpstream(namespace, upstream.Service, upstream.Port)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting service %v: %v", upstream.Service, err)
+		return nil, fmt.Errorf("Error getting service %v: %w", upstream.Service, err)
 	}
 
 	var targetPort int32
@@ -2745,7 +2745,7 @@ func (lbc *LoadBalancerController) getEndpointsForSubselector(namespace string, 
 		if port.Port == int32(upstream.Port) {
 			targetPort, err = lbc.getTargetPort(port, svc)
 			if err != nil {
-				return nil, fmt.Errorf("Error determining target port for port %v in service %v: %v", upstream.Port, svc.Name, err)
+				return nil, fmt.Errorf("Error determining target port for port %v in service %v: %w", upstream.Port, svc.Name, err)
 			}
 			break
 		}
@@ -2757,7 +2757,7 @@ func (lbc *LoadBalancerController) getEndpointsForSubselector(namespace string, 
 
 	endps, err = lbc.getEndpointsForServiceWithSubselector(targetPort, upstream.Subselector, svc)
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving endpoints for the service %v: %v", upstream.Service, err)
+		return nil, fmt.Errorf("Error retrieving endpoints for the service %v: %w", upstream.Service, err)
 	}
 
 	return endps, err
@@ -2766,7 +2766,7 @@ func (lbc *LoadBalancerController) getEndpointsForSubselector(namespace string, 
 func (lbc *LoadBalancerController) getEndpointsForServiceWithSubselector(targetPort int32, subselector map[string]string, svc *api_v1.Service) (endps []podEndpoint, err error) {
 	pods, err := lbc.podLister.ListByNamespace(svc.Namespace, labels.Merge(svc.Spec.Selector, subselector).AsSelector())
 	if err != nil {
-		return nil, fmt.Errorf("Error getting pods in namespace %v that match the selector %v: %v", svc.Namespace, labels.Merge(svc.Spec.Selector, subselector), err)
+		return nil, fmt.Errorf("Error getting pods in namespace %v that match the selector %v: %w", svc.Namespace, labels.Merge(svc.Spec.Selector, subselector), err)
 	}
 
 	svcEps, err := lbc.endpointLister.GetServiceEndpoints(svc)
@@ -2904,7 +2904,7 @@ func (lbc *LoadBalancerController) getEndpointsForPort(endps api_v1.Endpoints, i
 		if (ingSvcPort.Type == intstr.Int && port.Port == int32(ingSvcPort.IntValue())) || (ingSvcPort.Type == intstr.String && port.Name == ingSvcPort.String()) {
 			targetPort, err = lbc.getTargetPort(port, svc)
 			if err != nil {
-				return nil, fmt.Errorf("Error determining target port for port %v in Ingress: %v", ingSvcPort, err)
+				return nil, fmt.Errorf("Error determining target port for port %v in Ingress: %w", ingSvcPort, err)
 			}
 			break
 		}
@@ -2988,7 +2988,7 @@ func (lbc *LoadBalancerController) getTargetPort(svcPort api_v1.ServicePort, svc
 
 	pods, err := lbc.podLister.ListByNamespace(svc.Namespace, labels.Set(svc.Spec.Selector).AsSelector())
 	if err != nil {
-		return 0, fmt.Errorf("Error getting pod information: %v", err)
+		return 0, fmt.Errorf("Error getting pod information: %w", err)
 	}
 
 	if len(pods) == 0 {
@@ -2999,7 +2999,7 @@ func (lbc *LoadBalancerController) getTargetPort(svcPort api_v1.ServicePort, svc
 
 	portNum, err := findPort(pod, svcPort)
 	if err != nil {
-		return 0, fmt.Errorf("Error finding named port %v in pod %s: %v", svcPort, pod.Name, err)
+		return 0, fmt.Errorf("Error finding named port %v in pod %s: %w", svcPort, pod.Name, err)
 	}
 
 	return portNum, nil

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -767,8 +767,8 @@ func TestGetPolicies(t *testing.T) {
 	if !reflect.DeepEqual(result, expectedPolicies) {
 		t.Errorf("lbc.getPolicies() returned \n%v but \nexpected %v", result, expectedPolicies)
 	}
-	if !reflect.DeepEqual(errors, expectedErrors) {
-		t.Errorf("lbc.getPolicies() returned \n%v but expected \n%v", errors, expectedErrors)
+	if diff := cmp.Diff(expectedErrors, errors, cmp.Comparer(errorComparer)); diff != "" {
+		t.Errorf("lbc.getPolicies() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1173,7 +1173,7 @@ func TestFindPoliciesForSecret(t *testing.T) {
 
 func errorComparer(e1, e2 error) bool {
 	if e1 == nil || e2 == nil {
-		return e1 == e2
+		return errors.Is(e1, e2)
 	}
 
 	return e1.Error() == e2.Error()

--- a/internal/k8s/secrets/store_test.go
+++ b/internal/k8s/secrets/store_test.go
@@ -55,7 +55,7 @@ var (
 
 func errorComparer(e1, e2 error) bool {
 	if e1 == nil || e2 == nil {
-		return e1 == e2
+		return errors.Is(e1, e2)
 	}
 
 	return e1.Error() == e2.Error()

--- a/internal/k8s/secrets/validation.go
+++ b/internal/k8s/secrets/validation.go
@@ -38,7 +38,7 @@ func ValidateTLSSecret(secret *api_v1.Secret) error {
 
 	_, err := tls.X509KeyPair(secret.Data[api_v1.TLSCertKey], secret.Data[api_v1.TLSPrivateKeyKey])
 	if err != nil {
-		return fmt.Errorf("Failed to validate TLS cert and key: %v", err)
+		return fmt.Errorf("Failed to validate TLS cert and key: %w", err)
 	}
 
 	return nil
@@ -80,7 +80,7 @@ func ValidateCASecret(secret *api_v1.Secret) error {
 
 	_, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return fmt.Errorf("Failed to validate certificate: %v", err)
+		return fmt.Errorf("Failed to validate certificate: %w", err)
 	}
 
 	return nil

--- a/internal/k8s/spiffe.go
+++ b/internal/k8s/spiffe.go
@@ -21,7 +21,7 @@ func NewSpiffeController(sync func(*workload.X509SVIDs), spireAgentAddr string) 
 	watcher := &spiffeWatcher{sync: sync}
 	client, err := workload.NewX509SVIDClient(watcher, workload.WithAddr("unix://"+spireAgentAddr))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Spiffe Workload API Client: %v", err)
+		return nil, fmt.Errorf("failed to create Spiffe Workload API Client: %w", err)
 	}
 	sc := &spiffeController{
 		watcher: watcher,
@@ -37,7 +37,7 @@ func (sc *spiffeController) Start(stopCh <-chan struct{}, onStart func()) error 
 	glog.V(3).Info("Starting SPIFFE Workload API Client")
 	err := sc.client.Start()
 	if err != nil {
-		return fmt.Errorf("failed to start Spiffe Workload API Client: %v", err)
+		return fmt.Errorf("failed to start Spiffe Workload API Client: %w", err)
 	}
 	timeout := time.After(30 * time.Second)
 	duration := 100 * time.Millisecond

--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -188,7 +188,7 @@ func GetK8sVersion(client kubernetes.Interface) (v *version.Version, err error) 
 
 	runningVersion, err := version.ParseGeneric(serverVersion.String())
 	if err != nil {
-		return nil, fmt.Errorf("unexpected error parsing running Kubernetes version: %v", err)
+		return nil, fmt.Errorf("unexpected error parsing running Kubernetes version: %w", err)
 	}
 	glog.V(3).Infof("Kubernetes version: %v", runningVersion)
 

--- a/internal/metrics/collectors/latency.go
+++ b/internal/metrics/collectors/latency.go
@@ -253,7 +253,7 @@ func parseMessage(msg string) (latencyMetric, error) {
 	var sm syslogMsg
 	info := msgParts[1]
 	if err := json.Unmarshal([]byte(info), &sm); err != nil {
-		return latencyMetric{}, fmt.Errorf("could not unmarshal %s: %v", msg, err)
+		return latencyMetric{}, fmt.Errorf("could not unmarshal %s: %w", msg, err)
 	}
 	if sm.UpstreamAddr == sm.ProxyHost {
 		// no upstream connected so don't publish a metric
@@ -262,7 +262,7 @@ func parseMessage(msg string) (latencyMetric, error) {
 	server := parseMultipartResponse(sm.UpstreamAddr)
 	latency, err := strconv.ParseFloat(parseMultipartResponse(sm.UpstreamResponseTime), 64)
 	if err != nil {
-		return latencyMetric{}, fmt.Errorf("could not parse float from upstream response time %s: %v", sm.UpstreamResponseTime, err)
+		return latencyMetric{}, fmt.Errorf("could not parse float from upstream response time %s: %w", sm.UpstreamResponseTime, err)
 	}
 	code := parseMultipartResponse(sm.UpstreamStatus)
 	lm := latencyMetric{

--- a/internal/metrics/collectors/processes.go
+++ b/internal/metrics/collectors/processes.go
@@ -47,7 +47,7 @@ func getWorkerProcesses() (int, int, error) {
 
 	procFolders, err := ioutil.ReadDir("/proc")
 	if err != nil {
-		return 0, 0, fmt.Errorf("unable to read directory /proc : %v", err)
+		return 0, 0, fmt.Errorf("unable to read directory /proc : %w", err)
 	}
 
 	for _, folder := range procFolders {
@@ -59,7 +59,7 @@ func getWorkerProcesses() (int, int, error) {
 		cmdlineFile := fmt.Sprintf("/proc/%v/cmdline", folder.Name())
 		content, err := ioutil.ReadFile(cmdlineFile)
 		if err != nil {
-			return 0, 0, fmt.Errorf("unable to read file %v: %v", cmdlineFile, err)
+			return 0, 0, fmt.Errorf("unable to read file %v: %w", cmdlineFile, err)
 		}
 
 		text := string(bytes.TrimRight(content, "\x00"))

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -82,7 +82,7 @@ func writeTempFile(data []byte, name string) (*os.File, error) {
 
 	err = f.Chmod(nginx.TLSSecretFileMode)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't change the mode of the temp file %v: %v", f.Name(), err)
+		return nil, fmt.Errorf("couldn't change the mode of the temp file %v: %w", f.Name(), err)
 	}
 
 	_, err = f.Write(data)

--- a/internal/metrics/syslog_listener.go
+++ b/internal/metrics/syslog_listener.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"errors"
 	"net"
 
 	"github.com/golang/glog"
@@ -61,7 +62,8 @@ func (l LatencyMetricsListener) Stop() {
 }
 
 func isErrorRecoverable(err error) bool {
-	if nerr, ok := err.(*net.OpError); ok && nerr.Temporary() {
+	var nerr *net.OpError
+	if errors.As(err, &nerr) && nerr.Temporary() {
 		return true
 	} else {
 		return false

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -226,7 +226,7 @@ func (lm *LocalManager) CreateDHParam(content string) (string, error) {
 
 	err := createFileAndWrite(lm.dhparamFilename, []byte(content))
 	if err != nil {
-		return lm.dhparamFilename, fmt.Errorf("Failed to write dhparam file from %v: %v", lm.dhparamFilename, err)
+		return lm.dhparamFilename, fmt.Errorf("Failed to write dhparam file from %v: %w", lm.dhparamFilename, err)
 	}
 
 	return lm.dhparamFilename, nil
@@ -296,12 +296,12 @@ func (lm *LocalManager) Reload(isEndpointsUpdate bool) error {
 	binaryFilename := getBinaryFileName(lm.debug)
 	if err := shellOut(fmt.Sprintf("%v -s %v", binaryFilename, "reload")); err != nil {
 		lm.metricsCollector.IncNginxReloadErrors()
-		return fmt.Errorf("nginx reload failed: %v", err)
+		return fmt.Errorf("nginx reload failed: %w", err)
 	}
 	err := lm.verifyClient.WaitForCorrectVersion(lm.configVersion)
 	if err != nil {
 		lm.metricsCollector.IncNginxReloadErrors()
-		return fmt.Errorf("could not get newest config version: %v", err)
+		return fmt.Errorf("could not get newest config version: %w", err)
 	}
 
 	lm.metricsCollector.IncNginxReloadCount(isEndpointsUpdate)
@@ -355,7 +355,7 @@ func (lm *LocalManager) SetPlusClients(plusClient *client.NginxClient, plusConfi
 func (lm *LocalManager) UpdateServersInPlus(upstream string, servers []string, config ServerConfig) error {
 	err := verifyConfigVersion(lm.plusConfigVersionCheckClient, lm.configVersion)
 	if err != nil {
-		return fmt.Errorf("error verifying config version: %v", err)
+		return fmt.Errorf("error verifying config version: %w", err)
 	}
 
 	glog.V(3).Infof("API has the correct config version: %v.", lm.configVersion)
@@ -374,7 +374,7 @@ func (lm *LocalManager) UpdateServersInPlus(upstream string, servers []string, c
 	added, removed, updated, err := lm.plusClient.UpdateHTTPServers(upstream, upsServers)
 	if err != nil {
 		glog.V(3).Infof("Couldn't update servers of %v upstream: %v", upstream, err)
-		return fmt.Errorf("error updating servers of %v upstream: %v", upstream, err)
+		return fmt.Errorf("error updating servers of %v upstream: %w", upstream, err)
 	}
 
 	glog.V(3).Infof("Updated servers of %v; Added: %v, Removed: %v, Updated: %v", upstream, added, removed, updated)
@@ -386,7 +386,7 @@ func (lm *LocalManager) UpdateServersInPlus(upstream string, servers []string, c
 func (lm *LocalManager) UpdateStreamServersInPlus(upstream string, servers []string) error {
 	err := verifyConfigVersion(lm.plusConfigVersionCheckClient, lm.configVersion)
 	if err != nil {
-		return fmt.Errorf("error verifying config version: %v", err)
+		return fmt.Errorf("error verifying config version: %w", err)
 	}
 
 	glog.V(3).Infof("API has the correct config version: %v.", lm.configVersion)
@@ -401,7 +401,7 @@ func (lm *LocalManager) UpdateStreamServersInPlus(upstream string, servers []str
 	added, removed, updated, err := lm.plusClient.UpdateStreamServers(upstream, upsServers)
 	if err != nil {
 		glog.V(3).Infof("Couldn't update stream servers of %v upstream: %v", upstream, err)
-		return fmt.Errorf("error updating stream servers of %v upstream: %v", upstream, err)
+		return fmt.Errorf("error updating stream servers of %v upstream: %w", upstream, err)
 	}
 
 	glog.V(3).Infof("Updated stream servers of %v; Added: %v, Removed: %v, Updated: %v", upstream, added, removed, updated)
@@ -414,7 +414,7 @@ func (lm *LocalManager) CreateOpenTracingTracerConfig(content string) error {
 	glog.V(3).Infof("Writing OpenTracing tracer config file to %v", jsonFileForOpenTracingTracer)
 	err := createFileAndWrite(jsonFileForOpenTracingTracer, []byte(content))
 	if err != nil {
-		return fmt.Errorf("Failed to write config file: %v", err)
+		return fmt.Errorf("Failed to write config file: %w", err)
 	}
 
 	return nil
@@ -426,14 +426,14 @@ func (lm *LocalManager) CreateOpenTracingTracerConfig(content string) error {
 func verifyConfigVersion(httpClient *http.Client, configVersion int) error {
 	req, err := http.NewRequest("GET", "http://nginx-plus-api/configVersionCheck", nil)
 	if err != nil {
-		return fmt.Errorf("error creating request: %v", err)
+		return fmt.Errorf("error creating request: %w", err)
 	}
 
 	req.Header.Set("x-expected-config-version", fmt.Sprintf("%v", configVersion))
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("error doing request: %v", err)
+		return fmt.Errorf("error doing request: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/nginx/utils.go
+++ b/internal/nginx/utils.go
@@ -23,12 +23,12 @@ func shellOut(cmd string) (err error) {
 
 	err = command.Start()
 	if err != nil {
-		return fmt.Errorf("Failed to execute %v, err: %v", cmd, err)
+		return fmt.Errorf("Failed to execute %v, err: %w", cmd, err)
 	}
 
 	err = command.Wait()
 	if err != nil {
-		return fmt.Errorf("Command %v stdout: %q\nstderr: %q\nfinished with error: %v", cmd,
+		return fmt.Errorf("Command %v stdout: %q\nstderr: %q\nfinished with error: %w", cmd,
 			stdout.String(), stderr.String(), err)
 	}
 	return nil
@@ -37,14 +37,14 @@ func shellOut(cmd string) (err error) {
 func createFileAndWrite(name string, b []byte) error {
 	w, err := os.Create(name)
 	if err != nil {
-		return fmt.Errorf("Failed to open %v: %v", name, err)
+		return fmt.Errorf("Failed to open %v: %w", name, err)
 	}
 
 	defer w.Close()
 
 	_, err = w.Write(b)
 	if err != nil {
-		return fmt.Errorf("Failed to write to %v: %v", name, err)
+		return fmt.Errorf("Failed to write to %v: %w", name, err)
 	}
 
 	return nil

--- a/internal/nginx/verify.go
+++ b/internal/nginx/verify.go
@@ -39,7 +39,7 @@ func newVerifyClient(timeout time.Duration) *verifyClient {
 func (c *verifyClient) GetConfigVersion() (int, error) {
 	resp, err := c.client.Get("http://config-version/configVersion")
 	if err != nil {
-		return 0, fmt.Errorf("error getting client: %v", err)
+		return 0, fmt.Errorf("error getting client: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -49,11 +49,11 @@ func (c *verifyClient) GetConfigVersion() (int, error) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read the response body: %v", err)
+		return 0, fmt.Errorf("failed to read the response body: %w", err)
 	}
 	v, err := strconv.Atoi(string(body))
 	if err != nil {
-		return 0, fmt.Errorf("error converting string to int: %v", err)
+		return 0, fmt.Errorf("error converting string to int: %w", err)
 	}
 	return v, nil
 }
@@ -84,7 +84,7 @@ func (c *verifyClient) WaitForCorrectVersion(expectedVersion int) error {
 const configVersionTemplateString = `server {
     listen unix:/var/lib/nginx/nginx-config-version.sock;
 	access_log off;
-	
+
 	{{if .OpenTracingLoadModule}}
 	opentracing off;
 	{{end}}

--- a/pkg/apis/configuration/validation/transportserver.go
+++ b/pkg/apis/configuration/validation/transportserver.go
@@ -355,7 +355,7 @@ func validateHexString(s string) error {
 
 		_, err := hex.DecodeString(digits)
 		if err != nil {
-			return fmt.Errorf("hex literal '%s' must contain two hex digits: %v", lit, err)
+			return fmt.Errorf("hex literal '%s' must contain two hex digits: %w", lit, err)
 		}
 	}
 


### PR DESCRIPTION
Adding errorlint https://github.com/polyfloyd/go-errorlint

> go-errorlint is a source code linter for Go software that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.