### PR TITLE
chore: add k8s 1.21 to the matrix and bump the patch versions

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -30,7 +30,7 @@ defaults:
 
 env:
   DOCKER_BUILDKIT: 1
-  K8S_VERSION: 1.20.2
+  K8S_VERSION: 1.21.1
   K8S_TIMEOUT: 75s
   HELM_CHART_DIR: deployments/helm-chart
   HELM_CHART_VERSION: 0.0.0-edge

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,7 +121,7 @@ jobs:
     needs: [build, binary, unit-tests]
     strategy:
       matrix:
-        k8s: [1.20.2, 1.19.1, 1.18.8, 1.17.11, 1.16.15]
+        k8s: [1.21.1, 1.20.7, 1.19.11, 1.18.19, 1.17.17, 1.16.15]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
### Proposed changes
add k8s 1.21 to the nightly matrix and bump the patch numbers for the other versions, where appropriate

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
