### PR TITLE
fix: allow make to build image when .git directory is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX = nginx/nginx-ingress
-GIT_COMMIT = $(shell git rev-parse HEAD)
+GIT_COMMIT = $(shell git rev-parse HEAD || echo unknown)
 GIT_COMMIT_SHORT = $(shell echo ${GIT_COMMIT} | cut -c1-7)
-GIT_TAG = $(shell git describe --tags --abbrev=0)
+GIT_TAG = $(shell git describe --tags --abbrev=0 || echo untagged)
 DATE = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 VERSION = $(GIT_TAG)-SNAPSHOT-$(GIT_COMMIT_SHORT)
 TAG = $(VERSION:v%=%)


### PR DESCRIPTION
This change fixes #1711.

When executing make and building from a downloaded source archive, there is no git history (.git directory) in the source directory. This condition causes the make build process to fail.

### Proposed changes
This change allows the build to continue despite that directory being missing. It does that by using dummy values for `GIT_COMMIT` and `GIT_TAG` within the `Makefile`. For `GIT_COMMIT` it uses the 7 character value `unknown` which aligns with the 7 character git hash typically used. For `GIT_TAG`, it uses a dummy value of `untagged` to indicate that there is no tag associated with the build.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
