### PR TITLE
Change policy update handler to only reload on spec change

### DIFF
--- a/internal/k8s/handlers.go
+++ b/internal/k8s/handlers.go
@@ -445,7 +445,8 @@ func createPolicyHandlers(lbc *LoadBalancerController) cache.ResourceEventHandle
 		},
 		UpdateFunc: func(old, cur interface{}) {
 			curPol := cur.(*conf_v1.Policy)
-			if !reflect.DeepEqual(old, cur) {
+			oldPol := old.(*conf_v1.Policy)
+			if !reflect.DeepEqual(oldPol.Spec, curPol.Spec) {
 				glog.V(3).Infof("Policy %v changed, syncing", curPol.Name)
 				lbc.AddSyncQueue(curPol)
 			}


### PR DESCRIPTION
### Proposed changes
At the moment, the update handler for Policy resources uses a 'DeepEquals()' for comparing the old and new Policy, however the scope fo which is too broad, so minor changes such as resource version and status result in an Nginx reload.

This change compares just the 'Spec' of each Policy, so it only causes a reload if config data changes.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
