### PR TITLE
Increase timeout for golangci-lint and add more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters-settings:
 
 linters:
     enable:
+    - asciicheck
     - deadcode
     - errcheck
     - errorlint
@@ -14,7 +15,11 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - makezero
     - misspell
+    - nilerr
+    - predeclared
+    - promlinter
     - staticcheck
     - structcheck
     - typecheck
@@ -22,7 +27,10 @@ linters:
     - unparam
     - unused
     - varcheck
+    - wastedassign
     disable-all: true
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+run:
+  timeout: 5m


### PR DESCRIPTION
Almost aligned with the other repos, the last two left are `revive` and `noctx` but they have a lot of issues.

The increased timeout should be useful mostly on the first run when the cache is still not present.