### PR TITLE
Condition jwt

### DIFF
--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -1484,26 +1484,26 @@ var validVariableNames = map[string]bool{
 
 func validateVariableName(name string, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	//original name of variable
+	// original name of variable
 	orgName := name
 
-	//Make sure it starts with $
+	// Make sure it starts with $
 	if !strings.HasPrefix(name, "$") {
 		return append(allErrs, field.Invalid(fieldPath, name, "must start with `$`"))
 	}
 
-	//split name
+	// split name
 	parts := strings.Split(name, "_")
 
-	//name to first part of the split to check for wildcards
+	// name to first part of the split to check for wildcards
 	if len(parts) > 1 {
 		name = parts[0]
 	}
 
-	//Check if it is a wildcard valid
+	// Check if it is a wildcard valid
 	if _, exists := validVariableNames[name+"_*"]; exists && len(parts) > 1 {
-		//NoOp: if wildcard is valid do nothing.
-	} else if _, exists := validVariableNames[orgName]; !exists { //orginal name validation if not wildcard variable
+		// NoOp: if wildcard is valid do nothing.
+	} else if _, exists := validVariableNames[orgName]; !exists { // orginal name validation if not wildcard variable
 		return append(allErrs, field.Invalid(fieldPath, name, "is not allowed or is not an NGINX variable"))
 	}
 

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -1503,7 +1503,7 @@ func validateVariableName(name string, fieldPath *field.Path) field.ErrorList {
 	// Check if it is a wildcard valid
 	if _, exists := validVariableNames[name+"_*"]; exists && len(parts) > 1 {
 		// NoOp: if wildcard is valid do nothing.
-	} else if _, exists := validVariableNames[orgName]; !exists { // orginal name validation if not wildcard variable
+	} else if _, exists := validVariableNames[orgName]; !exists { // original name validation if not wildcard variable
 		return append(allErrs, field.Invalid(fieldPath, name, "is not allowed or is not an NGINX variable"))
 	}
 

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -3923,6 +3923,7 @@ func TestValidateErrorPageReturn(t *testing.T) {
 	vsv := &VirtualServerValidator{isPlus: false}
 
 	for _, epr := range tests {
+		// FIXME #nosec G601
 		allErrs := vsv.validateErrorPageReturn(&epr, field.NewPath("return"))
 		if len(allErrs) != 0 {
 			t.Errorf("validateErrorPageReturn(%v) returned errors for valid input: %v", epr, allErrs)
@@ -4014,6 +4015,7 @@ func TestValidateErrorPageRedirect(t *testing.T) {
 	vsv := &VirtualServerValidator{isPlus: false}
 
 	for _, epr := range tests {
+		// FIXME #nosec G601
 		allErrs := vsv.validateErrorPageRedirect(&epr, field.NewPath("redirect"))
 		if len(allErrs) != 0 {
 			t.Errorf("validateErrorPageRedirect(%v) returned errors for valid input: %v", epr, allErrs)
@@ -4059,6 +4061,7 @@ func TestValidateErrorPageRedirectFails(t *testing.T) {
 	vsv := &VirtualServerValidator{isPlus: false}
 
 	for _, epr := range tests {
+		// FIXME #nosec G601
 		allErrs := vsv.validateErrorPageRedirect(&epr, field.NewPath("redirect"))
 		if len(allErrs) == 0 {
 			t.Errorf("validateErrorPageRedirect(%v) returned no errors for invalid input", epr)

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -1874,6 +1874,8 @@ func TestValidateVariableName(t *testing.T) {
 	t.Parallel()
 	validNames := []string{
 		"$request_method",
+		"$args",
+		"$jwt_foo",
 	}
 
 	for _, name := range validNames {
@@ -1886,6 +1888,7 @@ func TestValidateVariableName(t *testing.T) {
 	invalidNames := []string{
 		"request_method",
 		"$request_id",
+		"$jwt",
 	}
 
 	for _, name := range invalidNames {
@@ -3920,7 +3923,6 @@ func TestValidateErrorPageReturn(t *testing.T) {
 	vsv := &VirtualServerValidator{isPlus: false}
 
 	for _, epr := range tests {
-		// FIXME #nosec G601
 		allErrs := vsv.validateErrorPageReturn(&epr, field.NewPath("return"))
 		if len(allErrs) != 0 {
 			t.Errorf("validateErrorPageReturn(%v) returned errors for valid input: %v", epr, allErrs)
@@ -4012,7 +4014,6 @@ func TestValidateErrorPageRedirect(t *testing.T) {
 	vsv := &VirtualServerValidator{isPlus: false}
 
 	for _, epr := range tests {
-		// FIXME #nosec G601
 		allErrs := vsv.validateErrorPageRedirect(&epr, field.NewPath("redirect"))
 		if len(allErrs) != 0 {
 			t.Errorf("validateErrorPageRedirect(%v) returned errors for valid input: %v", epr, allErrs)
@@ -4058,7 +4059,6 @@ func TestValidateErrorPageRedirectFails(t *testing.T) {
 	vsv := &VirtualServerValidator{isPlus: false}
 
 	for _, epr := range tests {
-		// FIXME #nosec G601
 		allErrs := vsv.validateErrorPageRedirect(&epr, field.NewPath("redirect"))
 		if len(allErrs) == 0 {
 			t.Errorf("validateErrorPageRedirect(%v) returned no errors for invalid input", epr)


### PR DESCRIPTION
Adding validation for jwt variables for conditionals. this will also allow for other variables group (wildcard) to be added quickly.

### Proposed changes
Added wildcard logic to condition variable validation to allow for quick validation of variable groups. The primary use case is for jwt variables.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ x ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have checked that all unit tests pass after adding my changes
- [ x ] I have updated necessary documentation
- [ x ] I have rebased my branch onto master
- [ x ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork

* I have write test for the validator, I need some help with the tests for the config generator. 