### PR TITLE
Add revive linter with recommended config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,3 +34,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           args: --timeout ${{ env.GOLANGCI_TIMEOUT }}
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,33 @@
 linters-settings:
   misspell:
     locale: US
+  revive:
+    ignore-generated-header: true
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
 
 linters:
     enable:
@@ -18,8 +45,10 @@ linters:
     - makezero
     - misspell
     - nilerr
+    - noctx
     - predeclared
     - promlinter
+    - revive
     - staticcheck
     - structcheck
     - typecheck
@@ -32,5 +61,6 @@ linters:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  new: true
 run:
   timeout: 5m


### PR DESCRIPTION
Adding revive linter and enabling golangci-lint to check only for new changes (`new-from-rev: HEAD~`) so at least we don't introduce new problems.

(There are 41 issues at the moment, but they're mostly in tests and fake managers)