### PR TITLE
Remove patch number from oss alpine

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
 
 ############################################# Base image for Alpine #############################################
 # docker.io/library/nginx is a temporary workaround for Dependabot to see this as different from the one used in Debian
-FROM docker.io/library/nginx:1.21.1-alpine AS alpine
+FROM docker.io/library/nginx:1.21-alpine AS alpine
 
 RUN apk add --no-cache libcap
 


### PR DESCRIPTION
### Proposed changes
The `1.21.1-alpine` tag doesn’t have all the binary combinations for some reason. The 1.21-alpine tag does, so was probably an automation error. Removing the patch number for now.

![Screenshot 2021-07-14 at 10 45 11](https://user-images.githubusercontent.com/18287516/125601861-bbb6843d-d475-400a-b00b-95d0a88a9742.png)


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
