### PR TITLE
Create separate workflows for PRs and master in release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -64,6 +64,7 @@ autolabeler:
       - 'vendor*'
     branch:
       - '/deps\/.+/'
+filter-by-commitish: true
 commitish: master
 template: |
   *Help make the NGINX Ingress Controller better by participating in our [survey](https://forms.office.com/Pages/ResponsePage.aspx?id=L_093Ttq0UCb4L-DJ9gcUM6Dh1A0cORCorfgZAMdkwJUREhJUFAyM1ZHRzZLSzQyMUlCNFhXVkZENy4u)!*

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -64,7 +64,6 @@ autolabeler:
       - 'vendor*'
     branch:
       - '/deps\/.+/'
-filter-by-commitish: true
 commitish: master
 template: |
   *Help make the NGINX Ingress Controller better by participating in our [survey](https://forms.office.com/Pages/ResponsePage.aspx?id=L_093Ttq0UCb4L-DJ9gcUM6Dh1A0cORCorfgZAMdkwJUREhJUFAyM1ZHRzZLSzQyMUlCNFhXVkZENy4u)!*

--- a/.github/workflows/release-drafter-master.yml
+++ b/.github/workflows/release-drafter-master.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-20.04
     steps:
       - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter-pr.yml
+++ b/.github/workflows/release-drafter-pr.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-releaser: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Proposed changes
We are running into this issue: https://github.com/release-drafter/release-drafter/issues/680 when we have "filter-by-commitish" and the PR "autolabeler" set. As far as I can tell, running the release-drafter on every PR creates a different draft release when we have "filter-by-commitish" set. This attempts to rectify by creating separate release drafter workflows so we can run the auto-labeller only on PRs. I think we can support releasing from release branches going forward by setting the 'commitish' to the name of the release branch - this should support patch releases.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
