### PR TITLE
Allow ingress to use a PSP

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -220,6 +220,8 @@ Parameter | Description | Default
 `controller.readyStatus.port` | The HTTP port for the readiness endpoint. | 8081
 `controller.enableLatencyMetrics` |  Enable collection of latency metrics for upstreams. Requires `prometheus.create`. | false
 `rbac.create` | Configures RBAC. | true
+`rbac.podSecurityPolicy.enabled` | Enables using a pod security policy in the cluster role. Requires `rbac.create` | false
+`rbac.podSecurityPolicy.existingPsp` | Chooses an existing pod security policy to use. Requires `rbac.create` and `rbac.podSecurityPolicy.enabled`  | ""
 `prometheus.create` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | false
 `prometheus.port` | Configures the port to scrape the metrics. | 9113
 `prometheus.scheme` | Configures the HTTP scheme to use for connections to the Prometheus endpoint. | http

--- a/deployments/helm-chart/templates/_helpers.tpl
+++ b/deployments/helm-chart/templates/_helpers.tpl
@@ -69,3 +69,14 @@ Expand app name.
 {{- define "nginx-ingress.appName" -}}
 {{- default (include "nginx-ingress.name" .) .Values.controller.name -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiGroup for PodSecurityPolicy.
+*/}}
+{{- define "podSecurityPolicy.apiGroup" -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "policy" -}}
+{{- else -}}
+{{- print "extensions" -}}
+{{- end -}}
+{{- end -}}

--- a/deployments/helm-chart/templates/rbac.yaml
+++ b/deployments/helm-chart/templates/rbac.yaml
@@ -7,14 +7,14 @@ metadata:
     {{- include "nginx-ingress.labels" . | nindent 4 }}
 rules:
 {{- if .Values.controller.appprotect.enable }}
-- apiGroups: 
+- apiGroups:
   - appprotect.f5.com
-  resources: 
+  resources:
   - appolicies
   - aplogconfs
   - apusersigs
-  verbs: 
-  - get 
+  verbs:
+  - get
   - watch
   - list
 {{- end }}
@@ -116,6 +116,18 @@ rules:
   - list
   - watch
   - get
+{{- end }}
+{{- if and .Values.rbac.podSecurityPolicy.enabled .Values.rbac.podSecurityPolicy.existingPsp }}
+- apiGroups:
+  - {{ template "podSecurityPolicy.apiGroup" . }}
+  resources:
+    - podsecuritypolicies
+  verbs:
+    - use
+  {{- with .Values.controller.existingPsp }}
+  resourceNames:
+    - {{ . }}
+  {{- end }}
 {{- end }}
 ---
 kind: ClusterRoleBinding

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -302,6 +302,10 @@ rbac:
   ## Configures RBAC.
   create: true
 
+  podSecurityPolicy:
+    enabled: false
+    existingPsp: ''
+
 prometheus:
   ## Expose NGINX or NGINX Plus metrics in the Prometheus format.
   create: true


### PR DESCRIPTION
### Proposed changes
Allows the cluster role to use a non-default pod security policy if they are enabled in the repository. Currently just allows using an existing pod security policy (`existingPsp`). But by having a separate `enabled` flag we setup the helm chart params in such a way that we can include a home baked pod security policy in the future if desired with minimal permissions required.

### Checklist
I have read all the items below - as far as I can tell there are no tests for the helm chart (and I'm not modifying anything else) but feel free to point me in the right direction if I've missed some!

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork

