### PR TITLE
Add gocyclo linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,8 @@ linters-settings:
       - name: unused-parameter
       - name: var-declaration
       - name: var-naming
+  gocyclo:
+    min-complexity: 15
 
 linters:
     enable:
@@ -35,6 +37,7 @@ linters:
     - deadcode
     - errcheck
     - errorlint
+    - gocyclo
     - gofmt
     - gofumpt
     - goimports


### PR DESCRIPTION
Adding https://github.com/fzipp/gocyclo since we now have the linters enabled only for new code.

> Gocyclo calculates cyclomatic complexities of functions in Go source code.
Cyclomatic complexity is a code quality metric which can be used to identify code that needs refactoring. It measures the number of linearly independent paths through a function's source code.