### PR TITLE
fix for missing image, docs Makefile, and netlify build commands

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -27,10 +27,10 @@ build-staging:
 	hugo --gc -e staging
 
 hugo-server-drafts:
-	hugo server -e production -b 127.0.0.1/nginx/ -D --disableFastRender
+	hugo server -e production -b 127.0.0.1/nginx-ingress-controller/ -D --disableFastRender
 
 hugo-server:
-	hugo server -e production -b 127.0.0.1/nginx/ --disableFastRender
+	hugo server -e production -b 127.0.0.1/nginx-ingress-controller/ --disableFastRender
 
 netlify:
 	netlify build --context=branch-deploy

--- a/docs/content/intro/how-nginx-ingress-controller-works.md
+++ b/docs/content/intro/how-nginx-ingress-controller-works.md
@@ -209,7 +209,7 @@ The Controller [sync](https://github.com/nginxinc/kubernetes-ingress/blob/v1.11.
 
 Rather than show how all the various sync methods work, we focus on the most important one -- the *syncIngress* method -- and look at how it processes a new Ingress resource, illustrated in the diagram below.
 
-{{< img src="./controller-sync.png" title="Controller sync" >}}
+{{< img src="/img/controller-sync.png" title="Controller sync" >}}
 
 1. The *Workqueue* calls the *sync* method and passes a workqueue element to it that includes the changed resource *kind* and *key* (the key is the resource namespace/name like “default/cafe-ingress”).
 2. Using the *kind*, the *sync* method calls the appropriate sync method and passes the resource key. For Ingresses, that method is *syncIngress*.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base = "docs/"
   publish = "public"
-  command = "hugo --gc -b '$DEPLOY_PRIME_URL/nginx-ingress-controller'"
+  command = "hugo --gc -b $DEPLOY_PRIME_URL/nginx-ingress-controller"
 
 [build.environment]
   HUGO_VERSION = "0.80.0"
@@ -16,10 +16,10 @@
   command = "hugo --gc -e production"
 
 [context.deploy-preview]
-  command = "hugo --gc -b '$DEPLOY_PRIME_URL/nginx-ingress-controller'"
+  command = "hugo --gc -b $DEPLOY_PRIME_URL/nginx-ingress-controller"
 
 [context.branch-deploy]
-  command = "hugo --gc -b '$DEPLOY_PRIME_URL/nginx-ingress-controller'"
+  command = "hugo --gc -b $DEPLOY_PRIME_URL/nginx-ingress-controller"
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

- This PR restores a missing image to the How NIC Works doc:
   ![image](https://user-images.githubusercontent.com/12143793/125989261-f22009cd-a8ec-4194-9e05-fc22c359431d.png)
- fixes the path used in the docs Makefile when running the hugo server locally
- fixes the netlify build command for deploy previews and branch deploys


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
