### PR TITLE
fix issues with raw html code tags in docs

### DIFF
--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/_default/_markup/render-link.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/_default/_markup/render-link.html
@@ -1,1 +1,1 @@
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text }}</a>
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text | markdownify }}</a>

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/header.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/header.html
@@ -5,7 +5,7 @@
       <img class="navbar-img" src="{{.Site.BaseURL}}images/icons/NGINX-Docs-horiz-white-type.svg" alt="NGINX Docs">
     </a>
     <div class="navbar navbar-nav">
-      {{ if ne .Site.Params.buildtype "package"}}
+      {{ if ( not ( in .Site.Params.buildtype "package" ) ) }}
       <!-- Standalone search box. -->
       <div id="searchbox">
         <!--div class="CoveoAnalytics" data-search-hub="HUB_ES_Nginx_Docs_And_Org"></div-->

--- a/docs/_vendor/modules.txt
+++ b/docs/_vendor/modules.txt
@@ -1,2 +1,2 @@
-# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.5
+# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.7
 # github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/nginxinc/kubernetes-ingress/docs
 
 go 1.15
 
-require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.5 // indirect
+require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.7 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -12,3 +12,8 @@ gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.0 h1:T/PHaQAccJ6fs2NolIHenLzdZ8
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.0/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.5 h1:mKgLpM0sALsTeLnTezHwJ9ouJp1B8it4K4qIkUX+Qok=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.5/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.5 h1:mKgLpM0sALsTeLnTezHwJ9ouJp1B8it4K4qIkUX+Qok=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.5/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.7 h1:Nh2O61QVMwUR8iOsYM00QEC0D9bSS7HZcl7WiSdS3p4=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.11.7/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
+


### PR DESCRIPTION
### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

This PR contains an update to the docs theme that fixes an issue where raw `<code>` tags are displayed when monospace formatting is applied within a link.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
