### PR TITLE
Reload only once during the start

### DIFF
--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -41,7 +41,14 @@ func createTestConfigurator() (*Configurator, error) {
 
 	manager := nginx.NewFakeManager("/etc/nginx")
 
-	return NewConfigurator(manager, createTestStaticConfigParams(), NewDefaultConfigParams(), templateExecutor, templateExecutorV2, false, false, nil, false, nil, false), nil
+	cnf, err := NewConfigurator(manager, createTestStaticConfigParams(), NewDefaultConfigParams(), templateExecutor, templateExecutorV2, false, false, nil, false, nil, false), nil
+	if err != nil {
+		return nil, err
+	}
+
+	cnf.isReloadsEnabled = true
+
+	return cnf, nil
 }
 
 func createTestConfiguratorInvalidIngressTemplate() (*Configurator, error) {
@@ -57,7 +64,14 @@ func createTestConfiguratorInvalidIngressTemplate() (*Configurator, error) {
 
 	manager := nginx.NewFakeManager("/etc/nginx")
 
-	return NewConfigurator(manager, createTestStaticConfigParams(), NewDefaultConfigParams(), templateExecutor, &version2.TemplateExecutor{}, false, false, nil, false, nil, false), nil
+	cnf, err := NewConfigurator(manager, createTestStaticConfigParams(), NewDefaultConfigParams(), templateExecutor, &version2.TemplateExecutor{}, false, false, nil, false, nil, false), nil
+	if err != nil {
+		return nil, err
+	}
+
+	cnf.isReloadsEnabled = true
+
+	return cnf, nil
 }
 
 func TestAddOrUpdateIngress(t *testing.T) {


### PR DESCRIPTION
### Proposed changes

During the start, the IC processes resources in the cluster one by one
Each processing might lead to a new generated config or an updated config,
which requires an NGINX reload. After all resources are processed,
the IC pod is considered Ready (its readiness probe succeeds).

For clusters with big number of resources the combined time
of NGINX reloads during the start can be significant (minutes).

This PR ensures that the IC only reloads NGINX once during
the start, which reduces the start up time for clusters
with big number of resources.

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

Fixes https://github.com/nginxinc/kubernetes-ingress/issues/1655
