### PR TITLE
Support Ingress and Ingress class v1

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,7 +121,7 @@ jobs:
     needs: [build, binary, unit-tests]
     strategy:
       matrix:
-        k8s: [1.21.1, 1.20.7, 1.19.11, 1.18.19, 1.17.17, 1.16.15]
+        k8s: [1.21.1, 1.20.7, 1.19.11]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -307,7 +307,7 @@ func main() {
 		*useIngressClassOnly = true
 		glog.Warningln("The '-use-ingress-class-only' flag will be deprecated and has no effect on versions of kubernetes >= 1.18.0. Processing ONLY resources that have the 'ingressClassName' field in Ingress equal to the class.")
 
-		ingressClassRes, err := kubeClient.NetworkingV1beta1().IngressClasses().Get(context.TODO(), *ingressClass, meta_v1.GetOptions{})
+		ingressClassRes, err := kubeClient.NetworkingV1().IngressClasses().Get(context.TODO(), *ingressClass, meta_v1.GetOptions{})
 		if err != nil {
 			glog.Fatalf("Error when getting IngressClass %v: %v", *ingressClass, err)
 		}

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 

--- a/internal/configs/parsing_helpers_test.go
+++ b/internal/configs/parsing_helpers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,7 +20,7 @@ var configMap = v1.ConfigMap{
 	},
 }
 
-var ingress = v1beta1.Ingress{
+var ingress = networking.Ingress{
 	ObjectMeta: meta_v1.ObjectMeta{
 		Name:      "test",
 		Namespace: "kube-system",

--- a/internal/k8s/configuration.go
+++ b/internal/k8s/configuration.go
@@ -11,7 +11,7 @@ import (
 	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
 	conf_v1alpha1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1alpha1"
 	"github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/validation"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/k8s/configuration_test.go
+++ b/internal/k8s/configuration_test.go
@@ -9,7 +9,7 @@ import (
 	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
 	conf_v1alpha1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1alpha1"
 	"github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/validation"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -44,7 +44,7 @@ import (
 	"github.com/nginxinc/kubernetes-ingress/internal/metrics/collectors"
 
 	api_v1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
@@ -381,7 +381,7 @@ func (lbc *LoadBalancerController) addServiceHandler(handlers cache.ResourceEven
 
 // addIngressHandler adds the handler for ingresses to the controller
 func (lbc *LoadBalancerController) addIngressHandler(handlers cache.ResourceEventHandlerFuncs) {
-	informer := lbc.sharedInformerFactory.Networking().V1beta1().Ingresses().Informer()
+	informer := lbc.sharedInformerFactory.Networking().V1().Ingresses().Informer()
 	informer.AddEventHandler(handlers)
 	lbc.ingressLister.Store = informer.GetStore()
 
@@ -2109,32 +2109,32 @@ func (lbc *LoadBalancerController) createIngressEx(ing *networking.Ingress, vali
 	ingEx.ExternalNameSvcs = make(map[string]bool)
 	ingEx.PodsByIP = make(map[string]configs.PodInfo)
 
-	if ing.Spec.Backend != nil {
+	if ing.Spec.DefaultBackend != nil {
 		podEndps := []podEndpoint{}
 		var external bool
-		svc, err := lbc.getServiceForIngressBackend(ing.Spec.Backend, ing.Namespace)
+		svc, err := lbc.getServiceForIngressBackend(ing.Spec.DefaultBackend, ing.Namespace)
 		if err != nil {
-			glog.V(3).Infof("Error getting service %v: %v", ing.Spec.Backend.ServiceName, err)
+			glog.V(3).Infof("Error getting service %v: %v", ing.Spec.DefaultBackend.Service.Name, err)
 		} else {
-			podEndps, external, err = lbc.getEndpointsForIngressBackend(ing.Spec.Backend, svc)
+			podEndps, external, err = lbc.getEndpointsForIngressBackend(ing.Spec.DefaultBackend, svc)
 			if err == nil && external && lbc.isNginxPlus {
 				ingEx.ExternalNameSvcs[svc.Name] = true
 			}
 		}
 
 		if err != nil {
-			glog.Warningf("Error retrieving endpoints for the service %v: %v", ing.Spec.Backend.ServiceName, err)
+			glog.Warningf("Error retrieving endpoints for the service %v: %v", ing.Spec.DefaultBackend.Service.Name, err)
 		}
 
 		endps := getIPAddressesFromEndpoints(podEndps)
 
 		// endps is empty if there was any error before this point
-		ingEx.Endpoints[ing.Spec.Backend.ServiceName+ing.Spec.Backend.ServicePort.String()] = endps
+		ingEx.Endpoints[ing.Spec.DefaultBackend.Service.Name+configs.GetBackendPortAsString(ing.Spec.DefaultBackend.Service.Port)] = endps
 
 		if lbc.isNginxPlus && lbc.isHealthCheckEnabled(ing) {
-			healthCheck := lbc.getHealthChecksForIngressBackend(ing.Spec.Backend, ing.Namespace)
+			healthCheck := lbc.getHealthChecksForIngressBackend(ing.Spec.DefaultBackend, ing.Namespace)
 			if healthCheck != nil {
-				ingEx.HealthChecks[ing.Spec.Backend.ServiceName+ing.Spec.Backend.ServicePort.String()] = healthCheck
+				ingEx.HealthChecks[ing.Spec.DefaultBackend.Service.Name+configs.GetBackendPortAsString(ing.Spec.DefaultBackend.Service.Port)] = healthCheck
 			}
 		}
 
@@ -2169,7 +2169,7 @@ func (lbc *LoadBalancerController) createIngressEx(ing *networking.Ingress, vali
 			var external bool
 			svc, err := lbc.getServiceForIngressBackend(&path.Backend, ing.Namespace)
 			if err != nil {
-				glog.V(3).Infof("Error getting service %v: %v", &path.Backend.ServiceName, err)
+				glog.V(3).Infof("Error getting service %v: %v", &path.Backend.Service.Name, err)
 			} else {
 				podEndps, external, err = lbc.getEndpointsForIngressBackend(&path.Backend, svc)
 				if err == nil && external && lbc.isNginxPlus {
@@ -2178,19 +2178,19 @@ func (lbc *LoadBalancerController) createIngressEx(ing *networking.Ingress, vali
 			}
 
 			if err != nil {
-				glog.Warningf("Error retrieving endpoints for the service %v: %v", path.Backend.ServiceName, err)
+				glog.Warningf("Error retrieving endpoints for the service %v: %v", path.Backend.Service.Name, err)
 			}
 
 			endps := getIPAddressesFromEndpoints(podEndps)
 
 			// endps is empty if there was any error before this point
-			ingEx.Endpoints[path.Backend.ServiceName+path.Backend.ServicePort.String()] = endps
+			ingEx.Endpoints[path.Backend.Service.Name+configs.GetBackendPortAsString(path.Backend.Service.Port)] = endps
 
 			// Pull active health checks from k8 api
 			if lbc.isNginxPlus && lbc.isHealthCheckEnabled(ing) {
 				healthCheck := lbc.getHealthChecksForIngressBackend(&path.Backend, ing.Namespace)
 				if healthCheck != nil {
-					ingEx.HealthChecks[path.Backend.ServiceName+path.Backend.ServicePort.String()] = healthCheck
+					ingEx.HealthChecks[path.Backend.Service.Name+configs.GetBackendPortAsString(path.Backend.Service.Port)] = healthCheck
 				}
 			}
 
@@ -2750,8 +2750,12 @@ func (lbc *LoadBalancerController) getEndpointsForUpstream(namespace string, ups
 	}
 
 	backend := &networking.IngressBackend{
-		ServiceName: upstreamService,
-		ServicePort: intstr.FromInt(int(upstreamPort)),
+		Service: &networking.IngressServiceBackend{
+			Name: upstreamService,
+			Port: networking.ServiceBackendPort{
+				Number: int32(upstreamPort),
+			},
+		},
 	}
 
 	endps, isExternal, err = lbc.getEndpointsForIngressBackend(backend, svc)
@@ -2846,10 +2850,10 @@ func getPodName(pod *api_v1.ObjectReference) string {
 func (lbc *LoadBalancerController) getHealthChecksForIngressBackend(backend *networking.IngressBackend, namespace string) *api_v1.Probe {
 	svc, err := lbc.getServiceForIngressBackend(backend, namespace)
 	if err != nil {
-		glog.V(3).Infof("Error getting service %v: %v", backend.ServiceName, err)
+		glog.V(3).Infof("Error getting service %v: %v", backend.Service.Name, err)
 		return nil
 	}
-	svcPort := lbc.getServicePortForIngressPort(backend.ServicePort, svc)
+	svcPort := lbc.getServicePortForIngressPort(backend.Service.Port, svc)
 	if svcPort == nil {
 		return nil
 	}
@@ -2893,7 +2897,7 @@ func compareContainerPortAndServicePort(containerPort api_v1.ContainerPort, svcP
 }
 
 func (lbc *LoadBalancerController) getExternalEndpointsForIngressBackend(backend *networking.IngressBackend, svc *api_v1.Service) []podEndpoint {
-	address := fmt.Sprintf("%s:%d", svc.Spec.ExternalName, int32(backend.ServicePort.IntValue()))
+	address := fmt.Sprintf("%s:%d", svc.Spec.ExternalName, backend.Service.Port.Number)
 	endpoints := []podEndpoint{
 		{
 			Address: address,
@@ -2917,30 +2921,30 @@ func (lbc *LoadBalancerController) getEndpointsForIngressBackend(backend *networ
 		return nil, false, err
 	}
 
-	result, err = lbc.getEndpointsForPort(endps, backend.ServicePort, svc)
+	result, err = lbc.getEndpointsForPort(endps, backend.Service.Port, svc)
 	if err != nil {
-		glog.V(3).Infof("Error getting endpoints for service %s port %v: %v", svc.Name, backend.ServicePort, err)
+		glog.V(3).Infof("Error getting endpoints for service %s port %v: %v", svc.Name, configs.GetBackendPortAsString(backend.Service.Port), err)
 		return nil, false, err
 	}
 	return result, false, nil
 }
 
-func (lbc *LoadBalancerController) getEndpointsForPort(endps api_v1.Endpoints, ingSvcPort intstr.IntOrString, svc *api_v1.Service) ([]podEndpoint, error) {
+func (lbc *LoadBalancerController) getEndpointsForPort(endps api_v1.Endpoints, backendPort networking.ServiceBackendPort, svc *api_v1.Service) ([]podEndpoint, error) {
 	var targetPort int32
 	var err error
 
 	for _, port := range svc.Spec.Ports {
-		if (ingSvcPort.Type == intstr.Int && port.Port == int32(ingSvcPort.IntValue())) || (ingSvcPort.Type == intstr.String && port.Name == ingSvcPort.String()) {
+		if (backendPort.Name == "" && port.Port == backendPort.Number) || port.Name == backendPort.Name {
 			targetPort, err = lbc.getTargetPort(port, svc)
 			if err != nil {
-				return nil, fmt.Errorf("Error determining target port for port %v in Ingress: %w", ingSvcPort, err)
+				return nil, fmt.Errorf("Error determining target port for port %v in Ingress: %w", backendPort, err)
 			}
 			break
 		}
 	}
 
 	if targetPort == 0 {
-		return nil, fmt.Errorf("No port %v in service %s", ingSvcPort, svc.Name)
+		return nil, fmt.Errorf("No port %v in service %s", backendPort, svc.Name)
 	}
 
 	for _, subset := range endps.Subsets {
@@ -2997,9 +3001,9 @@ func getPodOwnerTypeAndName(pod *api_v1.Pod) (parentType, parentName string) {
 	return parentType, parentName
 }
 
-func (lbc *LoadBalancerController) getServicePortForIngressPort(ingSvcPort intstr.IntOrString, svc *api_v1.Service) *api_v1.ServicePort {
+func (lbc *LoadBalancerController) getServicePortForIngressPort(backendPort networking.ServiceBackendPort, svc *api_v1.Service) *api_v1.ServicePort {
 	for _, port := range svc.Spec.Ports {
-		if (ingSvcPort.Type == intstr.Int && port.Port == int32(ingSvcPort.IntValue())) || (ingSvcPort.Type == intstr.String && port.Name == ingSvcPort.String()) {
+		if (backendPort.Name == "" && port.Port == backendPort.Number) || port.Name == backendPort.Name {
 			return &port
 		}
 	}
@@ -3036,14 +3040,18 @@ func (lbc *LoadBalancerController) getTargetPort(svcPort api_v1.ServicePort, svc
 
 func (lbc *LoadBalancerController) getServiceForUpstream(namespace string, upstreamService string, upstreamPort uint16) (*api_v1.Service, error) {
 	backend := &networking.IngressBackend{
-		ServiceName: upstreamService,
-		ServicePort: intstr.FromInt(int(upstreamPort)),
+		Service: &networking.IngressServiceBackend{
+			Name: upstreamService,
+			Port: networking.ServiceBackendPort{
+				Number: int32(upstreamPort),
+			},
+		},
 	}
 	return lbc.getServiceForIngressBackend(backend, namespace)
 }
 
 func (lbc *LoadBalancerController) getServiceForIngressBackend(backend *networking.IngressBackend, namespace string) (*api_v1.Service, error) {
-	svcKey := namespace + "/" + backend.ServiceName
+	svcKey := namespace + "/" + backend.Service.Name
 	svcObj, svcExists, err := lbc.svcLister.GetByKey(svcKey)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -20,7 +20,7 @@ import (
 	conf_v1alpha1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1alpha1"
 	api_v1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -531,25 +531,33 @@ func TestGetServicePortForIngressPort(t *testing.T) {
 		},
 		Status: v1.ServiceStatus{},
 	}
-	ingSvcPort := intstr.FromString("foo")
-	svcPort := lbc.getServicePortForIngressPort(ingSvcPort, &svc)
+	backendPort := networking.ServiceBackendPort{
+		Name: "foo",
+	}
+	svcPort := lbc.getServicePortForIngressPort(backendPort, &svc)
 	if svcPort == nil || svcPort.Port != 80 {
 		t.Errorf("TargetPort string match failed: %+v", svcPort)
 	}
 
-	ingSvcPort = intstr.FromInt(80)
-	svcPort = lbc.getServicePortForIngressPort(ingSvcPort, &svc)
+	backendPort = networking.ServiceBackendPort{
+		Number: 80,
+	}
+	svcPort = lbc.getServicePortForIngressPort(backendPort, &svc)
 	if svcPort == nil || svcPort.Port != 80 {
 		t.Errorf("TargetPort int match failed: %+v", svcPort)
 	}
 
-	ingSvcPort = intstr.FromInt(22)
-	svcPort = lbc.getServicePortForIngressPort(ingSvcPort, &svc)
+	backendPort = networking.ServiceBackendPort{
+		Number: 22,
+	}
+	svcPort = lbc.getServicePortForIngressPort(backendPort, &svc)
 	if svcPort != nil {
 		t.Errorf("Mismatched ints should not return port: %+v", svcPort)
 	}
-	ingSvcPort = intstr.FromString("bar")
-	svcPort = lbc.getServicePortForIngressPort(ingSvcPort, &svc)
+	backendPort = networking.ServiceBackendPort{
+		Name: "bar",
+	}
+	svcPort = lbc.getServicePortForIngressPort(backendPort, &svc)
 	if svcPort != nil {
 		t.Errorf("Mismatched strings should not return port: %+v", svcPort)
 	}

--- a/internal/k8s/handlers.go
+++ b/internal/k8s/handlers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/nginxinc/kubernetes-ingress/internal/k8s/secrets"
 	v1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	"k8s.io/client-go/tools/cache"
 
 	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"

--- a/internal/k8s/reference_checkers.go
+++ b/internal/k8s/reference_checkers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nginxinc/kubernetes-ingress/internal/configs"
 	v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
 	conf_v1alpha1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1alpha1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 )
 
 type resourceReferenceChecker interface {
@@ -96,8 +96,8 @@ func (rc *serviceReferenceChecker) IsReferencedByIngress(svcNamespace string, sv
 		return false
 	}
 
-	if ing.Spec.Backend != nil {
-		if ing.Spec.Backend.ServiceName == svcName {
+	if ing.Spec.DefaultBackend != nil {
+		if ing.Spec.DefaultBackend.Service.Name == svcName {
 			return true
 		}
 	}
@@ -106,7 +106,7 @@ func (rc *serviceReferenceChecker) IsReferencedByIngress(svcNamespace string, sv
 			continue
 		}
 		for _, p := range rules.IngressRuleValue.HTTP.Paths {
-			if p.Backend.ServiceName == svcName {
+			if p.Backend.Service.Name == svcName {
 				return true
 			}
 		}

--- a/internal/k8s/reference_checkers_test.go
+++ b/internal/k8s/reference_checkers_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nginxinc/kubernetes-ingress/internal/configs"
 	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
 	conf_v1alpha1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1alpha1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -333,8 +333,10 @@ func TestServiceIsReferencedByIngressAndMinion(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: networking.IngressSpec{
-					Backend: &networking.IngressBackend{
-						ServiceName: "test-service",
+					DefaultBackend: &networking.IngressBackend{
+						Service: &networking.IngressServiceBackend{
+							Name: "test-service",
+						},
 					},
 				},
 			},
@@ -356,7 +358,9 @@ func TestServiceIsReferencedByIngressAndMinion(t *testing.T) {
 									Paths: []networking.HTTPIngressPath{
 										{
 											Backend: networking.IngressBackend{
-												ServiceName: "test-service",
+												Service: &networking.IngressServiceBackend{
+													Name: "test-service",
+												},
 											},
 										},
 									},
@@ -384,7 +388,9 @@ func TestServiceIsReferencedByIngressAndMinion(t *testing.T) {
 									Paths: []networking.HTTPIngressPath{
 										{
 											Backend: networking.IngressBackend{
-												ServiceName: "test-service",
+												Service: &networking.IngressServiceBackend{
+													Name: "test-service",
+												},
 											},
 										},
 									},
@@ -412,7 +418,9 @@ func TestServiceIsReferencedByIngressAndMinion(t *testing.T) {
 									Paths: []networking.HTTPIngressPath{
 										{
 											Backend: networking.IngressBackend{
-												ServiceName: "test-service",
+												Service: &networking.IngressServiceBackend{
+													Name: "test-service",
+												},
 											},
 										},
 									},

--- a/internal/k8s/status.go
+++ b/internal/k8s/status.go
@@ -14,9 +14,9 @@ import (
 	conf_v1alpha1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1alpha1"
 	k8s_nginx "github.com/nginxinc/kubernetes-ingress/pkg/client/clientset/versioned"
 	api_v1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	typednetworking "k8s.io/client-go/kubernetes/typed/networking/v1beta1"
+	typednetworking "k8s.io/client-go/kubernetes/typed/networking/v1"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -132,7 +132,7 @@ func (su *statusUpdater) updateIngressWithStatus(ing networking.Ingress, status 
 	}
 
 	ingCopy.Status.LoadBalancer.Ingress = status
-	clientIngress := su.client.NetworkingV1beta1().Ingresses(ingCopy.Namespace)
+	clientIngress := su.client.NetworkingV1().Ingresses(ingCopy.Namespace)
 	_, err = clientIngress.UpdateStatus(context.TODO(), ingCopy, metav1.UpdateOptions{})
 	if err != nil {
 		glog.V(3).Infof("error setting ingress status: %v", err)

--- a/internal/k8s/status_test.go
+++ b/internal/k8s/status_test.go
@@ -10,7 +10,7 @@ import (
 	conf_v1alpha1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1alpha1"
 	fake_v1alpha1 "github.com/nginxinc/kubernetes-ingress/pkg/client/clientset/versioned/fake"
 	v1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -202,7 +202,7 @@ func TestStatusUpdateWithExternalStatusAndExternalService(t *testing.T) {
 	)
 	ingLister := storeToIngressLister{}
 	ingLister.Store, _ = cache.NewInformer(
-		cache.NewListWatchFromClient(fakeClient.NetworkingV1beta1().RESTClient(), "ingresses", "nginx-ingress", fields.Everything()),
+		cache.NewListWatchFromClient(fakeClient.NetworkingV1().RESTClient(), "ingresses", "nginx-ingress", fields.Everything()),
 		&networking.Ingress{}, 2, nil)
 
 	err := ingLister.Store.Add(&ing)
@@ -222,7 +222,7 @@ func TestStatusUpdateWithExternalStatusAndExternalService(t *testing.T) {
 	if err != nil {
 		t.Errorf("error clearing ing status: %v", err)
 	}
-	ings, _ := fakeClient.NetworkingV1beta1().Ingresses("namespace").List(context.TODO(), meta_v1.ListOptions{})
+	ings, _ := fakeClient.NetworkingV1().Ingresses("namespace").List(context.TODO(), meta_v1.ListOptions{})
 	ingf := ings.Items[0]
 	if !checkStatus("", ingf) {
 		t.Errorf("expected: %v actual: %v", "", ingf.Status.LoadBalancer.Ingress[0])
@@ -233,7 +233,7 @@ func TestStatusUpdateWithExternalStatusAndExternalService(t *testing.T) {
 	if err != nil {
 		t.Errorf("error updating ing status: %v", err)
 	}
-	ring, _ := fakeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
+	ring, _ := fakeClient.NetworkingV1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
 	if !checkStatus("1.1.1.1", *ring) {
 		t.Errorf("expected: %v actual: %v", "", ring.Status.LoadBalancer.Ingress)
 	}
@@ -256,7 +256,7 @@ func TestStatusUpdateWithExternalStatusAndExternalService(t *testing.T) {
 	if err != nil {
 		t.Errorf("error updating ing status: %v", err)
 	}
-	ring, _ = fakeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
+	ring, _ = fakeClient.NetworkingV1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
 	if !checkStatus("1.1.1.1", *ring) {
 		t.Errorf("expected: %v actual: %v", "1.1.1.1", ring.Status.LoadBalancer.Ingress)
 	}
@@ -266,7 +266,7 @@ func TestStatusUpdateWithExternalStatusAndExternalService(t *testing.T) {
 	if err != nil {
 		t.Errorf("error updating ing status: %v", err)
 	}
-	ring, _ = fakeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
+	ring, _ = fakeClient.NetworkingV1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
 	if !checkStatus("2.2.2.2", *ring) {
 		t.Errorf("expected: %v actual: %v", "2.2.2.2", ring.Status.LoadBalancer.Ingress)
 	}
@@ -276,7 +276,7 @@ func TestStatusUpdateWithExternalStatusAndExternalService(t *testing.T) {
 	if err != nil {
 		t.Errorf("error updating ing status: %v", err)
 	}
-	ring, _ = fakeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
+	ring, _ = fakeClient.NetworkingV1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
 	if !checkStatus("", *ring) {
 		t.Errorf("expected: %v actual: %v", "", ring.Status.LoadBalancer.Ingress)
 	}
@@ -305,7 +305,7 @@ func TestStatusUpdateWithExternalStatusAndIngressLink(t *testing.T) {
 	)
 	ingLister := storeToIngressLister{}
 	ingLister.Store, _ = cache.NewInformer(
-		cache.NewListWatchFromClient(fakeClient.NetworkingV1beta1().RESTClient(), "ingresses", "nginx-ingress", fields.Everything()),
+		cache.NewListWatchFromClient(fakeClient.NetworkingV1().RESTClient(), "ingresses", "nginx-ingress", fields.Everything()),
 		&networking.Ingress{}, 2, nil)
 
 	err := ingLister.Store.Add(&ing)
@@ -326,7 +326,7 @@ func TestStatusUpdateWithExternalStatusAndIngressLink(t *testing.T) {
 	if err != nil {
 		t.Errorf("error updating ing status: %v", err)
 	}
-	ring, _ := fakeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
+	ring, _ := fakeClient.NetworkingV1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
 	if !checkStatus("3.3.3.3", *ring) {
 		t.Errorf("expected: %v actual: %v", "3.3.3.3", ring.Status.LoadBalancer.Ingress)
 	}
@@ -336,7 +336,7 @@ func TestStatusUpdateWithExternalStatusAndIngressLink(t *testing.T) {
 	if err != nil {
 		t.Errorf("error updating ing status: %v", err)
 	}
-	ring, _ = fakeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
+	ring, _ = fakeClient.NetworkingV1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
 	if !checkStatus("1.1.1.1", *ring) {
 		t.Errorf("expected: %v actual: %v", "1.1.1.1", ring.Status.LoadBalancer.Ingress)
 	}
@@ -346,7 +346,7 @@ func TestStatusUpdateWithExternalStatusAndIngressLink(t *testing.T) {
 	if err != nil {
 		t.Errorf("error updating ing status: %v", err)
 	}
-	ring, _ = fakeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
+	ring, _ = fakeClient.NetworkingV1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
 	if !checkStatus("1.1.1.1", *ring) {
 		t.Errorf("expected: %v actual: %v", "1.1.1.1", ring.Status.LoadBalancer.Ingress)
 	}
@@ -356,7 +356,7 @@ func TestStatusUpdateWithExternalStatusAndIngressLink(t *testing.T) {
 	if err != nil {
 		t.Errorf("error updating ing status: %v", err)
 	}
-	ring, _ = fakeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
+	ring, _ = fakeClient.NetworkingV1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
 	if !checkStatus("1.1.1.1", *ring) {
 		t.Errorf("expected: %v actual: %v", "1.1.1.1", ring.Status.LoadBalancer.Ingress)
 	}
@@ -366,7 +366,7 @@ func TestStatusUpdateWithExternalStatusAndIngressLink(t *testing.T) {
 	if err != nil {
 		t.Errorf("error updating ing status: %v", err)
 	}
-	ring, _ = fakeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
+	ring, _ = fakeClient.NetworkingV1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
 	if !checkStatus("4.4.4.4", *ring) {
 		t.Errorf("expected: %v actual: %v", "4.4.4.4", ring.Status.LoadBalancer.Ingress)
 	}
@@ -376,7 +376,7 @@ func TestStatusUpdateWithExternalStatusAndIngressLink(t *testing.T) {
 	if err != nil {
 		t.Errorf("error updating ing status: %v", err)
 	}
-	ring, _ = fakeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
+	ring, _ = fakeClient.NetworkingV1().Ingresses(ing.Namespace).Get(context.TODO(), ing.Name, meta_v1.GetOptions{})
 	if !checkStatus("", *ring) {
 		t.Errorf("expected: %v actual: %v", "", ring.Status.LoadBalancer.Ingress)
 	}

--- a/internal/k8s/task_queue.go
+++ b/internal/k8s/task_queue.go
@@ -9,7 +9,7 @@ import (
 	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
 	conf_v1alpha1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1alpha1"
 	v1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"

--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -55,36 +55,6 @@ func (s *storeToIngressLister) List() (ing networking.IngressList, err error) {
 		ing.Items = append(ing.Items, *(m.(*networking.Ingress)).DeepCopy())
 	}
 	return ing, nil
-}
-
-// GetServiceIngress gets all the Ingress' that have rules pointing to a service.
-// Note that this ignores services without the right nodePorts.
-func (s *storeToIngressLister) GetServiceIngress(svc *v1.Service) (ings []networking.Ingress, err error) {
-	for _, m := range s.Store.List() {
-		ing := *m.(*networking.Ingress).DeepCopy()
-		if ing.Namespace != svc.Namespace {
-			continue
-		}
-		if ing.Spec.Backend != nil {
-			if ing.Spec.Backend.ServiceName == svc.Name {
-				ings = append(ings, ing)
-			}
-		}
-		for _, rules := range ing.Spec.Rules {
-			if rules.IngressRuleValue.HTTP == nil {
-				continue
-			}
-			for _, p := range rules.IngressRuleValue.HTTP.Paths {
-				if p.Backend.ServiceName == svc.Name {
-					ings = append(ings, ing)
-				}
-			}
-		}
-	}
-	if len(ings) == 0 {
-		err = fmt.Errorf("No ingress for service %v", svc.Name)
-	}
-	return
 }
 
 // storeToConfigMapLister makes a Store that lists ConfigMaps

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -543,6 +543,10 @@ func validateIsTrue(v string) error {
 func validateIngressSpec(spec *networking.IngressSpec, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	if spec.DefaultBackend != nil {
+		allErrs = append(allErrs, validateBackend(spec.DefaultBackend, fieldPath.Child("defaultBackend"))...)
+	}
+
 	allHosts := sets.String{}
 
 	if len(spec.Rules) == 0 {
@@ -550,15 +554,35 @@ func validateIngressSpec(spec *networking.IngressSpec, fieldPath *field.Path) fi
 	}
 
 	for i, r := range spec.Rules {
-		idxPath := fieldPath.Child("rules").Index(i)
+		idxRule := fieldPath.Child("rules").Index(i)
 
 		if r.Host == "" {
-			allErrs = append(allErrs, field.Required(idxPath.Child("host"), ""))
+			allErrs = append(allErrs, field.Required(idxRule.Child("host"), ""))
 		} else if allHosts.Has(r.Host) {
-			allErrs = append(allErrs, field.Duplicate(idxPath.Child("host"), r.Host))
+			allErrs = append(allErrs, field.Duplicate(idxRule.Child("host"), r.Host))
 		} else {
 			allHosts.Insert(r.Host)
 		}
+
+		if r.HTTP == nil {
+			continue
+		}
+
+		for _, path := range r.HTTP.Paths {
+			idxPath := idxRule.Child("http").Child("path").Index(i)
+
+			allErrs = append(allErrs, validateBackend(&path.Backend, idxPath.Child("backend"))...)
+		}
+	}
+
+	return allErrs
+}
+
+func validateBackend(backend *networking.IngressBackend, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if backend.Resource != nil {
+		return append(allErrs, field.Forbidden(fieldPath.Child("resource"), "resource backends are not supported"))
 	}
 
 	return allErrs

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/nginxinc/kubernetes-ingress/internal/configs"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -602,13 +602,15 @@ func validateMinionSpec(spec *networking.IngressSpec, fieldPath *field.Path) fie
 
 func getSpecServices(ingressSpec networking.IngressSpec) map[string]bool {
 	services := make(map[string]bool)
-	if ingressSpec.Backend != nil {
-		services[ingressSpec.Backend.ServiceName] = true
+	if ingressSpec.DefaultBackend != nil && ingressSpec.DefaultBackend.Service != nil {
+		services[ingressSpec.DefaultBackend.Service.Name] = true
 	}
 	for _, rule := range ingressSpec.Rules {
 		if rule.HTTP != nil {
 			for _, path := range rule.HTTP.Paths {
-				services[path.Backend.ServiceName] = true
+				if path.Backend.Service != nil {
+					services[path.Backend.Service.Name] = true
+				}
 			}
 		}
 	}

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -1925,4 +1925,73 @@ func errorListToStrings(list field.ErrorList) []string {
 	}
 
 	return result
+}
+
+func TestGetSpecServices(t *testing.T) {
+	tests := []struct {
+		spec     networking.IngressSpec
+		expected map[string]bool
+		msg      string
+	}{
+		{
+			spec: networking.IngressSpec{
+				DefaultBackend: &networking.IngressBackend{
+					Service: &networking.IngressServiceBackend{
+						Name: "svc1",
+					},
+				},
+				Rules: []networking.IngressRule{
+					{
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: networking.IngressBackend{
+											Service: &networking.IngressServiceBackend{
+												Name: "svc2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"svc1": true,
+				"svc2": true,
+			},
+			msg: "services are referenced",
+		},
+		{
+			spec: networking.IngressSpec{
+				DefaultBackend: &networking.IngressBackend{},
+				Rules: []networking.IngressRule{
+					{
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
+									{
+										Path:    "/",
+										Backend: networking.IngressBackend{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{},
+			msg:      "services are not referenced",
+		},
+	}
+
+	for _, test := range tests {
+		result := getSpecServices(test.spec)
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Errorf("getSpecServices() returned %v but expected %v for the case of %s", result, test.expected, test.msg)
+		}
+	}
 }


### PR DESCRIPTION
### Proposed changes
- Use Ingress v1 in the code
- Reject Ingresses with resource backends, because the IC doesn't support such backends:
```yaml
          - path: /icons
            pathType: ImplementationSpecific
            backend:
              resource:
                apiGroup: k8s.example.com
                kind: StorageBucket
                name: icon-assets
```
- Use IngressClass v1 in the code
- Remove k8s < 1.19 from nightly

Note: the existing tests work for k8s 1.19-1.21
in a separate PR we will update the tests so that they work for k8s 1.19-1.22

The PR doesn't change the minimum supported k8s version  for the IC - that will be done separately.
The PR doesn't update any docs - that will be done separately.