### PR TITLE
Add latest tag to latest stable version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,13 +62,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - tag: ${{ needs.binary.outputs.version }}
+          - tags: |
+              nginx/nginx-ingress:${{ needs.binary.outputs.version }}
+              nginx/nginx-ingress:latest
             type: debian
             platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
-          - tag: ${{ needs.binary.outputs.version }}-alpine
+          - tags: |
+              nginx/nginx-ingress:${{ needs.binary.outputs.version }}-alpine
+              nginx/nginx-ingress:alpine
             type: alpine
             platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
-          - tag: ${{ needs.binary.outputs.version }}-ubi
+          - tags: |
+              nginx/nginx-ingress:${{ needs.binary.outputs.version }}-ubi
+              nginx/nginx-ingress:ubi
             type: ubi
             platforms: linux/arm64,linux/amd64
     steps:
@@ -111,7 +117,7 @@ jobs:
           context: '.'
           cache-to: type=local,dest=/tmp/.buildx-${{ matrix.image }}-cache
           target: goreleaser
-          tags: nginx/nginx-ingress:${{ matrix.tag }}
+          tags: ${{ matrix.tags }}
           platforms: ${{ matrix.platforms }}
           push: true
           build-args: |

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -110,15 +110,21 @@ jobs:
     strategy:
       matrix:
         include:
-          - tag: ${{ needs.variables.outputs.kic-tag }}
+          - tags: |
+              nginx/nginx-ingress:${{ needs.variables.outputs.kic-tag }}
+              nginx/nginx-ingress:latest
             type: debian
             platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
             needs-updating: ${{ needs.check.outputs.needs-updating-debian }}
-          - tag: ${{ needs.variables.outputs.kic-tag }}-alpine
+          - tags: |
+              nginx/nginx-ingress:${{ needs.variables.outputs.kic-tag }}-alpine
+              nginx/nginx-ingress:alpine
             type: alpine
             platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
             needs-updating: ${{ needs.check.outputs.needs-updating-alpine }}
-          - tag: ${{ needs.variables.outputs.kic-tag }}-ubi
+          - tags: |
+              nginx/nginx-ingress:${{ needs.variables.outputs.kic-tag }}-ubi
+              nginx/nginx-ingress:ubi
             type: ubi
             platforms: linux/arm64,linux/amd64
             needs-updating: ${{ needs.check.outputs.needs-updating-ubi }}
@@ -232,7 +238,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-${{ matrix.image }}-cache
           cache-to: type=local,dest=/tmp/.buildx-${{ matrix.type }}-cache
           target: goreleaser
-          tags: nginx/nginx-ingress:${{ matrix.tag }}
+          tags: ${{ matrix.tags }}
           platforms: ${{ matrix.platforms }}
           push: true
           build-args: |


### PR DESCRIPTION
### Proposed changes
In the last release, tagging the latest stable version as 'latest' was inadvertently removed. This commit returns the stable tags, and adds them to the update docker workflow also. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
