### PR TITLE
Use release branch for k8s python client

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -15,6 +15,5 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 	&& install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 COPY tests /workspace/tests
-WORKDIR /workspace/tests/suite
 
 ENTRYPOINT ["python3", "-m", "pytest"]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML==5.4.1
 requests==2.26.0
 forcediphttpsadapter==1.0.1
--e git://github.com/kubernetes-client/python.git@c0ea27acc7347c9ae605f0c03e902b14c5ab9e5a#egg=kubernetes
+git+git://github.com/kubernetes-client/python.git@release-19.0#egg=kubernetes
 pytest==6.2.4
 ipaddress==1.0.23 # >= 1.0.17
 cffi==1.14.6


### PR DESCRIPTION
Seems like that with the branch the source folder is not created.
