### PR TITLE
Opentracing update

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -155,8 +155,10 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 
 ############################################# Build image for Opentracing Builder #############################################
 FROM debian as opentracing-builder
-ARG NGINX_OPENTRACING=0.10.0
+ARG NGINX_OPENTRACING=0.19.0
 ARG OPENTRACING_VERSION=1.6.0
+ARG JAEGER_VERSION=0.7.0 
+# Jaeger version matched based on: https://github.com/opentracing-contrib/nginx-opentracing/blob/master/Dockerfile
 
 RUN apt-get update && apt-get install -y -q --fix-missing --no-install-recommends \
 	autoconf \
@@ -181,11 +183,18 @@ RUN apt-get update && apt-get install -y -q --fix-missing --no-install-recommend
 RUN curl -sS -O -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
 	&& tar zxvf nginx-${NGINX_VERSION}.tar.gz && rm -f nginx-${NGINX_VERSION}.tar.gz \
 	&& git clone --branch v${NGINX_OPENTRACING} https://github.com/opentracing-contrib/nginx-opentracing.git \
-	&& git clone --branch v${OPENTRACING_VERSION} https://github.com/opentracing/opentracing-cpp.git
+	&& git clone --branch v${OPENTRACING_VERSION} https://github.com/opentracing/opentracing-cpp.git \
+	&& git clone --branch v${JAEGER_VERSION} https://github.com/jaegertracing/cpp-client.git
 
 WORKDIR /opentracing-cpp/.build
 RUN	cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_STATIC_LIBS=OFF -DBUILD_MOCKTRACER=OFF -DENABLE_LINTING=OFF .. && \
 	make && make install
+
+WORKDIR /cpp-client/.build
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DJAEGERTRACING_WITH_YAML_CPP=ON .. && \
+	make && make install \
+	&& export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
+  	&& cp $HUNTER_INSTALL_DIR/lib/libyaml*so /usr/local/lib/
 
 WORKDIR /nginx-${NGINX_VERSION}
 RUN ./configure \
@@ -207,10 +216,12 @@ RUN apt-get update \
 ############################################# Build image for Opentracing #############################################
 FROM debian as opentracing
 ARG OPENTRACING_VERSION=1.6.0
+ARG JAEGER_VERSION=0.7.0
 
 COPY --from=opentracing-builder /nginx-${NGINX_VERSION}/objs/ngx_http_opentracing_module.so /usr/lib/nginx/modules/ngx_http_opentracing_module.so
 COPY --from=opentracing-builder /usr/local/lib/libopentracing.so.${OPENTRACING_VERSION} /usr/local/lib/libopentracing.so.1
-COPY --from=tracer-downloader /usr/local/lib/libjaegertracing_plugin.so /usr/local/lib/libjaegertracing_plugin.so
+COPY --from=opentracing-builder /usr/local/lib/libjaegertracing.so.${JAEGER_VERSION} /usr/local/lib/libjaegertracing_plugin.so
+COPY --from=opentracing-builder /usr/local/lib/libyaml*so /usr/local/lib/
 
 RUN ldconfig
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -157,8 +157,6 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 FROM debian as opentracing-builder
 ARG NGINX_OPENTRACING=0.19.0
 ARG OPENTRACING_VERSION=1.6.0
-ARG JAEGER_VERSION=0.7.0 
-# Jaeger version matched based on: https://github.com/opentracing-contrib/nginx-opentracing/blob/master/Dockerfile
 
 RUN apt-get update && apt-get install -y -q --fix-missing --no-install-recommends \
 	autoconf \
@@ -183,18 +181,11 @@ RUN apt-get update && apt-get install -y -q --fix-missing --no-install-recommend
 RUN curl -sS -O -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
 	&& tar zxvf nginx-${NGINX_VERSION}.tar.gz && rm -f nginx-${NGINX_VERSION}.tar.gz \
 	&& git clone --branch v${NGINX_OPENTRACING} https://github.com/opentracing-contrib/nginx-opentracing.git \
-	&& git clone --branch v${OPENTRACING_VERSION} https://github.com/opentracing/opentracing-cpp.git \
-	&& git clone --branch v${JAEGER_VERSION} https://github.com/jaegertracing/cpp-client.git
+	&& git clone --branch v${OPENTRACING_VERSION} https://github.com/opentracing/opentracing-cpp.git 
 
 WORKDIR /opentracing-cpp/.build
 RUN	cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_STATIC_LIBS=OFF -DBUILD_MOCKTRACER=OFF -DENABLE_LINTING=OFF .. && \
 	make && make install
-
-WORKDIR /cpp-client/.build
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DJAEGERTRACING_WITH_YAML_CPP=ON .. && \
-	make && make install \
-	&& export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
-  	&& cp $HUNTER_INSTALL_DIR/lib/libyaml*so /usr/local/lib/
 
 WORKDIR /nginx-${NGINX_VERSION}
 RUN ./configure \
@@ -202,6 +193,7 @@ RUN ./configure \
 	--add-dynamic-module=/nginx-opentracing/opentracing && \
 	make modules
 
+WORKDIR /
 
 ############################################# Build image for Trace downloader #############################################
 FROM debian AS tracer-downloader
@@ -212,16 +204,34 @@ RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates apt-transport-https wget \
 	&& wget -nv https://github.com/jaegertracing/jaeger-client-cpp/releases/download/${JAEGER_VERSION}/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so
 
+############################################# Build image for Trace downloader #############################################
+FROM opentracing-builder AS tracer-builder
+
+ARG JAEGER_VERSION=0.7.0 
+# Jaeger version matched based on: https://github.com/opentracing-contrib/nginx-opentracing/blob/master/Dockerfile
+
+RUN git clone --branch v${JAEGER_VERSION} https://github.com/jaegertracing/cpp-client.git
+
+WORKDIR /cpp-client/.build
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DJAEGERTRACING_WITH_YAML_CPP=ON .. && \
+	make && make install \
+	&& export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
+  	&& cp $HUNTER_INSTALL_DIR/lib/libyaml*so /usr/local/lib/
 
 ############################################# Build image for Opentracing #############################################
 FROM debian as opentracing
 ARG OPENTRACING_VERSION=1.6.0
-ARG JAEGER_VERSION=0.7.0
 
 COPY --from=opentracing-builder /nginx-${NGINX_VERSION}/objs/ngx_http_opentracing_module.so /usr/lib/nginx/modules/ngx_http_opentracing_module.so
 COPY --from=opentracing-builder /usr/local/lib/libopentracing.so.${OPENTRACING_VERSION} /usr/local/lib/libopentracing.so.1
-COPY --from=opentracing-builder /usr/local/lib/libjaegertracing.so.${JAEGER_VERSION} /usr/local/lib/libjaegertracing_plugin.so
-COPY --from=opentracing-builder /usr/local/lib/libyaml*so /usr/local/lib/
+
+# If tracer version is available through tracer downloader
+# COPY --from=tracer-downloader /usr/local/lib/libjaegertracing_plugin.so /usr/local/lib/libjaegertracing_plugin.so
+
+# If tracer version is avilable through tracer builder
+ARG JAEGER_VERSION=0.7.0
+COPY --from=tracer-builder /usr/local/lib/libjaegertracing.so.${JAEGER_VERSION} /usr/local/lib/libjaegertracing_plugin.so
+COPY --from=tracer-builder /usr/local/lib/libyaml*so /usr/local/lib/
 
 RUN ldconfig
 

--- a/docs/content/technical-specifications.md
+++ b/docs/content/technical-specifications.md
@@ -29,7 +29,7 @@ The supported architecture is x86-64.
 | ---| ---| ---| --- | 
 |Debian-based image | ``nginx:1.21.0``, which is based on ``debian:buster-slim`` |  | ``nginx/nginx-ingress:1.12.0`` | 
 |Alpine-based image | ``nginx:1.21.0-alpine``, which is based on ``alpine:3.13`` |  | ``nginx/nginx-ingress:1.12.0-alpine`` | 
-|Debian-based image with Opentracing | ``nginx:1.21.0``, which is based on ``debian:buster-slim`` | OpenTracing API for C++ 1.5.1, NGINX plugin for OpenTracing, C++ OpenTracing binding for Jaeger 0.4.2 |  | 
+|Debian-based image with Opentracing | ``nginx:1.21.0``, which is based on ``debian:buster-slim`` | OpenTracing API for C++ 1.6.0, NGINX plugin for OpenTracing 0.19.0, C++ OpenTracing binding for Jaeger 0.7.0 |  | 
 |Ubi-based image | ``registry.access.redhat.com/ubi8/ubi:8.3`` |  | ``nginx/nginx-ingress:1.12.0-ubi`` | 
 {{% /table %}} 
 


### PR DESCRIPTION
### Proposed changes
Docker opentracing build stage does not yield working image due to the Opentracing library version mismatch. This change updates Nginx Opentracing library from 0.10.0 to the latest available version of 0.19.0. 
It also requires higher version of Jaeger Tracing module which can't be just downloaded (last available download is v0.4.2) and therefore Jaeger Tracing module v0.7.0 is now built as part of the opentracing-builder stage. Latest Jaeger Tracing also has a dependency on libyaml libraries which are copied during the final build stage.

Changes just affect the Open Source version of Nginx Ingress

It seems the smoke tests in Github pipeline do not test the actual loading of the opentracing library in nginx config. It would be great to add this to the tests as well but I don't know how to do that right now, so I'm just sharing these changes which I tested.

Changes in the Dockerfile reflect the build steps in here: https://github.com/opentracing-contrib/nginx-opentracing/blob/master/Dockerfile

### Checklist
- [ x ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have checked that all unit tests pass after adding my changes
- [ x ] I have updated necessary documentation
- [ x ] I have rebased my branch onto master
- [ x ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
