### PR TITLE
Add accept-encoding header for oidc flow

### DIFF
--- a/internal/configs/oidc/oidc.conf
+++ b/internal/configs/oidc/oidc.conf
@@ -15,6 +15,7 @@
         proxy_method GET;                             # In case client request was non-GET
         proxy_set_header Content-Length "";           # ''
         proxy_pass $oidc_jwt_keyfile;                 # Expecting to find a URI here
+        proxy_set_header    Accept-Encoding "gzip";
         proxy_ignore_headers Cache-Control Expires Set-Cookie; # Does not influence caching
     }
 
@@ -39,6 +40,7 @@
         internal;
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
+        proxy_set_header      Accept-Encoding "gzip";
         proxy_set_body        "grant_type=authorization_code&client_id=$oidc_client&$args&redirect_uri=$redirect_base$redir_location";
         proxy_method          POST;
         proxy_pass            $oidc_token_endpoint;
@@ -52,6 +54,7 @@
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=refresh_token&refresh_token=$arg_token&client_id=$oidc_client&client_secret=$oidc_client_secret";
+        proxy_set_header      Accept-Encoding "gzip";
         proxy_method          POST;
         proxy_pass            $oidc_token_endpoint;
     }


### PR DESCRIPTION
add gzip as accept-encoding header to fix OIDC authorization code sent but token response is not JSON

### Proposed changes
Add accept encoding to resolve code exchange for a token. this is linked to #1893

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
