### PR TITLE
fix: updated baseURL for prod and staging; fixes sitemap issues

### DIFF
--- a/docs/config/production/config.toml
+++ b/docs/config/production/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/nginx-ingress-controller/"
+baseURL = "https://docs.nginx.com/nginx-ingress-controller/"
 title = "NGINX Ingress Controller"
 publishDir = "public/nginx-ingress-controller"
 canonifyURLs = false

--- a/docs/config/staging/config.toml
+++ b/docs/config/staging/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/nginx-ingress-controller/"
+baseURL = "https://docs-staging.nginx.com/nginx-ingress-controller/"
 title = "STAGING -- NGINX Docs"
 publishDir = "public/nginx-ingress-controller"
 canonifyURLs = false


### PR DESCRIPTION
### Proposed changes

- Fixed the baseURL in the config.toml for the prod and staging doc sites. The baseURL should use the full domain and path; otherwise, the sitemaps won't be formatted correctly.
- Closes IND-27825

Current KIC sitemap:

https://docs.nginx.com/nginx-ingress-controller/sitemap.xml

<img width="582" alt="image" src="https://user-images.githubusercontent.com/33876974/130848136-4ad7750b-9796-436c-a4d8-8f7dd6c0d971.png">

Compare to Controller sitemap:

https://docs.nginx.com/nginx-controller/sitemap.xml

<img width="647" alt="image" src="https://user-images.githubusercontent.com/33876974/130848185-6d39c265-658d-4622-af08-cb525f81916a.png">



