### PR TITLE
Remove libs compilation for OpenTracing, add more tracers

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -358,6 +358,9 @@ jobs:
           - tag: edge-ubi
             type: ubi
             platforms: linux/arm64,linux/amd64
+          - tag: edge-ot
+            type: opentracing
+            platforms: linux/amd64
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -155,85 +155,19 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 # RUN update-ca-trust extract
 
 
-############################################# Build image for Opentracing Builder #############################################
-FROM debian as opentracing-builder
-ARG NGINX_OPENTRACING=0.19.0
-ARG OPENTRACING_VERSION=1.6.0
+############################################# Base image containing libs for Opentracing #############################################
+FROM opentracing/nginx-opentracing:nginx-1.21.1 as opentracing-lib
 
-RUN apt-get update && apt-get install -y -q --fix-missing --no-install-recommends \
-	autoconf \
-	automake \
-	build-essential \
-	cmake \
-	git \
-	libcurl4-openssl-dev \
-	libgeoip-dev \
-	liblmdb-dev \
-	libpcre3-dev \
-	libprotobuf-dev \
-	libssl-dev \
-	libtool \
-	libxml2-dev \
-	libyajl-dev \
-	pkgconf \
-	protobuf-compiler \
-	zlib1g-dev
-
-# Get nginx to build against
-RUN curl -sS -O -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
-	&& tar zxvf nginx-${NGINX_VERSION}.tar.gz && rm -f nginx-${NGINX_VERSION}.tar.gz \
-	&& git clone --branch v${NGINX_OPENTRACING} https://github.com/opentracing-contrib/nginx-opentracing.git \
-	&& git clone --branch v${OPENTRACING_VERSION} https://github.com/opentracing/opentracing-cpp.git 
-
-WORKDIR /opentracing-cpp/.build
-RUN	cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DBUILD_STATIC_LIBS=OFF -DBUILD_MOCKTRACER=OFF -DENABLE_LINTING=OFF .. && \
-	make && make install
-
-WORKDIR /nginx-${NGINX_VERSION}
-RUN ./configure \
-	--with-compat --with-debug \
-	--add-dynamic-module=/nginx-opentracing/opentracing && \
-	make modules
-
-WORKDIR /
-
-############################################# Build image for Trace downloader #############################################
-FROM debian AS tracer-downloader
-
-ARG JAEGER_VERSION=v0.4.2
-
-RUN apt-get update \
-	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates apt-transport-https wget \
-	&& wget -nv https://github.com/jaegertracing/jaeger-client-cpp/releases/download/${JAEGER_VERSION}/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so
-
-############################################# Build image for Trace downloader #############################################
-FROM opentracing-builder AS tracer-builder
-
-ARG JAEGER_VERSION=0.7.0 
-# Jaeger version matched based on: https://github.com/opentracing-contrib/nginx-opentracing/blob/master/Dockerfile
-
-RUN git clone --branch v${JAEGER_VERSION} https://github.com/jaegertracing/cpp-client.git
-
-WORKDIR /cpp-client/.build
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DJAEGERTRACING_WITH_YAML_CPP=ON .. && \
-	make && make install \
-	&& export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
-  	&& cp $HUNTER_INSTALL_DIR/lib/libyaml*so /usr/local/lib/
 
 ############################################# Build image for Opentracing #############################################
 FROM debian as opentracing
 
-COPY --from=opentracing-builder /nginx-${NGINX_VERSION}/objs/ngx_http_opentracing_module.so /usr/lib/nginx/modules/ngx_http_opentracing_module.so
-COPY --from=opentracing-builder /usr/local/lib/libopentracing.so.* /usr/local/lib/libopentracing.so.1
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y libcurl3-gnutls \
+	&& rm -rf /var/lib/apt/lists/*
 
-# If tracer version is available through tracer downloader
-# COPY --from=tracer-downloader /usr/local/lib/libjaegertracing_plugin.so /usr/local/lib/libjaegertracing_plugin.so
-
-# If tracer version is avilable through tracer builder
-COPY --from=tracer-builder /usr/local/lib/libjaegertracing.so.* /usr/local/lib/libjaegertracing_plugin.so
-COPY --from=tracer-builder /usr/local/lib/libyaml*so /usr/local/lib/
-
-RUN ldconfig
+RUN --mount=type=bind,from=opentracing-lib,target=/tmp/ cp -av /tmp/usr/local/lib/libopentracing.so* /tmp/usr/local/lib/libjaegertracing*so* /tmp/usr/local/lib/libzipkin*so* /tmp/usr/local/lib/libdd*so* /tmp/usr/local/lib/libyaml*so* /usr/local/lib/ \
+	&& cp -av /tmp/usr/lib/nginx/modules/ngx_http_opentracing_module.so /usr/lib/nginx/modules/ \
+	&& ldconfig
 
 
 ############################################# Build image for Opentracing with NGINX Plus #############################################
@@ -243,10 +177,11 @@ ARG NGINX_PLUS_VERSION
 RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
 	apt-get update \
-	&& apt-get install --no-install-recommends --no-install-suggests -y nginx-plus-module-opentracing-${NGINX_PLUS_VERSION} \
+	&& apt-get install --no-install-recommends --no-install-suggests -y libcurl3-gnutls nginx-plus-module-opentracing-${NGINX_PLUS_VERSION} \
 	&& rm -rf /var/lib/apt/lists/*
 
-COPY --from=tracer-downloader /usr/local/lib/libjaegertracing_plugin.so /usr/local/lib/libjaegertracing_plugin.so
+RUN --mount=type=bind,from=opentracing-lib,target=/tmp/ cp -av /tmp/usr/local/lib/libjaegertracing*so* /tmp/usr/local/lib/libzipkin*so* /tmp/usr/local/lib/libdd*so* /tmp/usr/local/lib/libyaml*so* /usr/local/lib/ \
+	&& ldconfig
 
 
 ############################################# Create common files for NGINX Plus #############################################

--- a/docs/content/technical-specifications.md
+++ b/docs/content/technical-specifications.md
@@ -1,6 +1,6 @@
 ---
 title: Technical Specifications
-description: 
+description:
 weight: 2000
 doctypes: ["concept"]
 toc: true
@@ -21,17 +21,16 @@ We provide the following Docker images, which include NGINX/NGINX Plus bundled w
 
 ### Images with NGINX
 
-All images include NGINX 1.21.0.
-The supported architecture is x86-64.
+All images include NGINX 1.21.1.
 
-{{% table %}} 
-|Name | Base image | Third-party modules | DockerHub image | 
-| ---| ---| ---| --- | 
-|Debian-based image | ``nginx:1.21.0``, which is based on ``debian:buster-slim`` |  | ``nginx/nginx-ingress:1.12.0`` | 
-|Alpine-based image | ``nginx:1.21.0-alpine``, which is based on ``alpine:3.13`` |  | ``nginx/nginx-ingress:1.12.0-alpine`` | 
-|Debian-based image with Opentracing | ``nginx:1.21.0``, which is based on ``debian:buster-slim`` | OpenTracing API for C++ 1.6.0, NGINX plugin for OpenTracing 0.19.0, C++ OpenTracing binding for Jaeger 0.7.0 |  | 
-|Ubi-based image | ``registry.access.redhat.com/ubi8/ubi:8.3`` |  | ``nginx/nginx-ingress:1.12.0-ubi`` | 
-{{% /table %}} 
+{{% table %}}
+|Name | Base image | Third-party modules | DockerHub image | Architectures |
+| ---| ---| ---| --- | --- |
+|Alpine-based image | ``nginx:1.21.1-alpine``, which is based on ``alpine:3.14`` |  | ``nginx/nginx-ingress:1.12.0-alpine`` | arm/v7, arm64, amd64, ppc64le, s390x |
+|Debian-based image | ``nginx:1.21.1``, which is based on ``debian:buster-slim`` |  | ``nginx/nginx-ingress:1.12.0`` | arm/v7, arm64, amd64, ppc64le, s390x |
+|Debian-based image with Opentracing | ``nginx:1.21.1``, which is based on ``debian:buster-slim`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:1.12.0-ot`` | amd64 |
+|Ubi-based image | ``redhat/ubi8-minimal`` |  | ``nginx/nginx-ingress:1.12.0-ubi`` | arm64, amd64 |
+{{% /table %}}
 
 ### Images with NGINX Plus
 
@@ -40,16 +39,16 @@ The supported architecture is x86-64.
 
 NGINX Plus images are available through the F5 Container registry `private-registry.nginx.com` - see [Using the NGINX IC Plus JWT token in a Docker Config Secret](/nginx-ingress-controller/installation/using-the-jwt-token-docker-secret) and [Pulling the NGINX Ingress Controller image](/nginx-ingress-controller/installation/pulling-ingress-controller-image).
 
-{{% table %}} 
+{{% table %}}
 |Name | Base image | Third-party modules | F5 Container Registry Image |
-| ---| ---| --- | --- | 
+| ---| ---| --- | --- |
 |Alpine-based image | ``alpine:3.13`` |  | `nginx-ic/nginx-plus-ingress:1.12.0-alpine` |
 |Debian-based image | ``debian:buster-slim`` |  | `nginx-ic/nginx-plus-ingress:1.12.0` |
-|Debian-based image with Opentracing | ``debian:buster-slim`` | NGINX Plus OpenTracing module, C++ OpenTracing binding for Jaeger 0.4.2 | `nginx-ic/nginx-plus-ingress:1.12.0-ot` |
-|Ubi-based image | ``redhat/ubi8-minimal`` |  | `nginx-ic/nginx-plus-ingress:1.12.0-ubi` |
+|Debian-based image with Opentracing | ``debian:buster-slim`` | NGINX Plus OpenTracing module, OpenTracing tracers for Jaeger, Zipkin and Datadog | `nginx-ic/nginx-plus-ingress:1.12.0-ot` |
 |Debian-based image with App Protect | ``debian:buster-slim`` | NGINX Plus App Protect module | `nginx-ic-nap/nginx-plus-ingress:1.12.0` |
+|Ubi-based image | ``redhat/ubi8-minimal`` |  | `nginx-ic/nginx-plus-ingress:1.12.0-ubi` |
 |Ubi-based image with App Protect | ``registry.access.redhat.com/ubi7/ubi`` | NGINX Plus App Protect module | `nginx-ic-nap/nginx-plus-ingress:1.12.0-ubi` |
-{{% /table %}} 
+{{% /table %}}
 
 ### Custom Images
 

--- a/docs/content/third-party-modules/opentracing.md
+++ b/docs/content/third-party-modules/opentracing.md
@@ -1,6 +1,6 @@
 ---
 title: OpenTracing
-description: 
+description:
 weight: 2000
 doctypes: [""]
 aliases:
@@ -14,15 +14,8 @@ The Ingress Controller supports [OpenTracing](https://opentracing.io/) with the 
 This document explains how to use OpenTracing with the Ingress Controller.
 
 ## Prerequisites
-1. **Use the Ingress Controller image with OpenTracing.** The default Ingress Controller images don’t include the OpenTracing module. To use OpenTracing, you need to build the image with that module. Follow the build instructions to build the image using `debian-image-opentracing` for NGINX or `debian-image-opentracing-plus` for NGINX Plus.
-By default, the Dockerfiles build & install Jaeger as a tracer. However, it is possible to replace Jaeger with other supported [tracers](https://github.com/opentracing-contrib/nginx-opentracing#building-from-source). For that, please modify the Dockerfile accordingly:
-   1. Find out which version of supported tracer you will need based on the current OpenTracing C++ API
-   2. If direct download of that version is avilable:
-        1. Change the download line in the `tracer-downloader` stage of the Dockerfile to download the right tracer.
-        2. Edit the COPY line of the final image to copy the previously downloaded tracer to the image
-   2. If tracer needs to be built:
-        1. Change the content the `tracer-builder` stage of the Dockerfile to build the right tracer. Build steps can be found in [Nginx Opentracing Dockerfile](https://github.com/opentracing-contrib/nginx-opentracing/blob/master/Dockerfile)
-        2. Edit the COPY line of the final image to copy the previously built tracer to the image
+1. **Use the Ingress Controller image with OpenTracing.** You can find the images with NGINX or NGINX Plus with OpenTracing listed [here](/nginx-ingress-controller/technical-specifications/#supported-docker-images). Alternatively, you can follow the build instructions to build the image using `debian-image-opentracing` for NGINX or `debian-image-opentracing-plus` for NGINX Plus.
+[Jaeger](https://github.com/jaegertracing/jaeger-client-cpp), [Zipkin](https://github.com/rnburn/zipkin-cpp-opentracing) and [Datadog](https://github.com/DataDog/dd-opentracing-cpp/) tracers are installed by default.
 
 2. **Load the OpenTracing module.** You need to load the module with the configuration for the chosen tracer using the following ConfigMap keys:
    * `opentracing-tracer`: sets the path to the vendor tracer binary plugin. This is the path you used in the COPY line of step *ii* above.


### PR DESCRIPTION
- Remove steps for building OpenTracing and Jaeger
- Add support for Zipkin and Datadog
- Publish the image to DockerHub