### PR TITLE
Fix increased IC pod startup time when hundreds VSRs are used

### DIFF
--- a/internal/k8s/status.go
+++ b/internal/k8s/status.go
@@ -513,6 +513,10 @@ func (su *statusUpdater) UpdateVirtualServerRouteStatusWithReferencedBy(vsr *con
 
 	vsrCopy := vsrLatest.(*conf_v1.VirtualServerRoute).DeepCopy()
 
+	if !hasVsrStatusChanged(vsrCopy, state, reason, message, referencedByString) {
+		return nil
+	}
+
 	vsrCopy.Status.State = state
 	vsrCopy.Status.Reason = reason
 	vsrCopy.Status.Message = message

--- a/tests/data/startup/virtual-server-routes/route.yaml
+++ b/tests/data/startup/virtual-server-routes/route.yaml
@@ -1,0 +1,11 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServerRoute
+metadata:
+  name: route
+spec:
+  host: example.com
+  subroutes:
+  - path: "/route"
+    action:
+      return:
+        body: "Hello World\n"

--- a/tests/data/startup/virtual-server-routes/virtual-server.yaml
+++ b/tests/data/startup/virtual-server-routes/virtual-server.yaml
@@ -1,0 +1,7 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: example.com
+  routes:

--- a/tests/suite/custom_resources_utils.py
+++ b/tests/suite/custom_resources_utils.py
@@ -260,15 +260,31 @@ def create_virtual_server_from_yaml(
     print("Create a VirtualServer:")
     with open(yaml_manifest) as f:
         dep = yaml.safe_load(f)
+
+    return create_virtual_server(custom_objects, dep, namespace)
+
+
+def create_virtual_server(
+    custom_objects: CustomObjectsApi, vs, namespace
+) -> str:
+    """
+    Create a VirtualServer.
+
+    :param custom_objects: CustomObjectsApi
+    :param vs: a VirtualServer
+    :param namespace:
+    :return: str
+    """
+    print("Create a VirtualServer:")
     try:
         custom_objects.create_namespaced_custom_object(
-            "k8s.nginx.org", "v1", namespace, "virtualservers", dep
+            "k8s.nginx.org", "v1", namespace, "virtualservers", vs
         )
-        print(f"VirtualServer created with name '{dep['metadata']['name']}'")
-        return dep["metadata"]["name"]
+        print(f"VirtualServer created with name '{vs['metadata']['name']}'")
+        return vs["metadata"]["name"]
     except ApiException as ex:
         logging.exception(
-            f"Exception: {ex} occurred while creating VirtualServer: {dep['metadata']['name']}"
+            f"Exception: {ex} occurred while creating VirtualServer: {vs['metadata']['name']}"
         )
         raise
 
@@ -697,11 +713,23 @@ def create_v_s_route_from_yaml(custom_objects: CustomObjectsApi, yaml_manifest, 
     with open(yaml_manifest) as f:
         dep = yaml.safe_load(f)
 
+    return create_v_s_route(custom_objects, dep, namespace)
+
+def create_v_s_route(custom_objects: CustomObjectsApi, vsr, namespace) -> str:
+    """
+    Create a VirtualServerRoute.
+
+    :param custom_objects: CustomObjectsApi
+    :param vsr: a VirtualServerRoute
+    :param namespace:
+    :return: str
+    """
+    print("Create a VirtualServerRoute:")
     custom_objects.create_namespaced_custom_object(
-        "k8s.nginx.org", "v1", namespace, "virtualserverroutes", dep
+        "k8s.nginx.org", "v1", namespace, "virtualserverroutes", vsr
     )
-    print(f"VirtualServerRoute created with a name '{dep['metadata']['name']}'")
-    return dep["metadata"]["name"]
+    print(f"VirtualServerRoute created with a name '{vsr['metadata']['name']}'")
+    return vsr["metadata"]["name"]
 
 
 def patch_v_s_route(custom_objects: CustomObjectsApi, name, namespace, body) -> str:

--- a/tests/suite/resources_utils.py
+++ b/tests/suite/resources_utils.py
@@ -1337,6 +1337,15 @@ def get_total_vs(req_url, ingress_class) -> str:
     return parse_metric_data(resp_content, metric_string)
 
 
+def get_total_vsr(req_url, ingress_class) -> str:
+    # return total number of virtualserverroutes in specified ingress class
+    ensure_connection(req_url, 200)
+    resp = requests.get(req_url)
+    resp_content = resp.content.decode("utf-8")
+    metric_string = 'virtualserverroute_resources_total{class="%s"}' % ingress_class
+    return parse_metric_data(resp_content, metric_string)
+
+
 def get_last_reload_status(req_url, ingress_class) -> str:
     # returnb last reload status 0/1
     ensure_connection(req_url, 200)


### PR DESCRIPTION
### Proposed changes

Previously, the IC would update the status of a VSR (via an API call to the k8s API) even if the status of the VSR wasn't changed. The unnecessary API calls lead to the increased IC pod startup time for cases when a VS had multiple (hundreds) VSRs.

The PR fixes the problem - the IC will skip the update if the status of a VSR isn't changed.

The PR includes a test that creates a VS with multiple VSRs and then checks the startup time of the pod.

The output is for 500 VSRs:

Before: gave up after 15 mins 

Now: 201 seconds 
```
All pods are ContainersReady
All pods came up in 201 seconds
Scale a deployment 'nginx-ingress': complete
```
