### PR TITLE
Docops 232 - Broken link in App-protect configuration doc

### DIFF
--- a/docs/content/app-protect/configuration.md
+++ b/docs/content/app-protect/configuration.md
@@ -107,7 +107,7 @@ To add the [App Protect log configurations](/nginx-app-protect/configuration/#se
 
    > **Note**: The fields from the JSON must be presented in the YAML *exactly* the same, in name and level. The Ingress Controller will transform the YAML into a valid JSON App Protect log config.
 
-For example, say you want to [log state changing requests](/nginx-app-protect/troubleshooting/#log-state-changing-requests) for your Ingress resources using App Protect. The App Protect log configuration looks like this:
+For example, say you want to [log state changing requests](/nginx-app-protect/configuration/#security-log-configuration-file) for your Ingress resources using App Protect. The App Protect log configuration looks like this:
 
 ```json
 {


### PR DESCRIPTION
### Proposed changes
In https://docs.nginx.com/nginx-ingress-controller/app-protect/configuration/  ​there is a broken link to https://docs.nginx.com/nginx-app-protect/troubleshooting/#log-state-changing-requests , the section does not seem to exist any more.

This PR changes the broken link to https://docs.nginx.com/nginx-app-protect/configuration/#security-log-configuration-file where the information lives now.


