### PR TITLE
fix: fix broken link DOCOPS-238

### DIFF
--- a/docs/content/intro/nginx-ingress-controllers.md
+++ b/docs/content/intro/nginx-ingress-controllers.md
@@ -17,7 +17,7 @@ If you are unsure about which implementation you are using, check the container 
 
 ## The Key Differences
 
-The table below summarizes the key difference between nginxinc/kubernetes-ingress and kubernetes/ingress-nginx Ingress controllers. Note that the table has two columns for the nginxinc/kubernetes-ingress Ingress controller, as it can be used both with NGINX and NGINX Plus. For more information about nginxinc/kubernetes-ingress with NGINX Plus, read [here](nginx-plus.md).
+The table below summarizes the key difference between nginxinc/kubernetes-ingress and kubernetes/ingress-nginx Ingress controllers. Note that the table has two columns for the nginxinc/kubernetes-ingress Ingress controller, as it can be used both with NGINX and NGINX Plus. For more information about nginxinc/kubernetes-ingress with NGINX Plus, read [here](/nginx-ingress-controller/intro/nginx-plus).
 
 {{% table %}} 
 | Aspect or Feature | kubernetes/ingress-nginx | nginxinc/kubernetes-ingress with NGINX | nginxinc/kubernetes-ingress with NGINX Plus |


### PR DESCRIPTION
### Proposed changes
Fix broken link to the correct URL

![image](https://user-images.githubusercontent.com/78599298/132853097-4782f8a7-048f-4053-99f3-4dea33e4eee2.png)

(Broken links to examples are being investigated separately in DOCOPS-228)

Closes DOCOPS-238