### PR TITLE
Docops 238b - reword link

### DIFF
--- a/docs/content/intro/nginx-ingress-controllers.md
+++ b/docs/content/intro/nginx-ingress-controllers.md
@@ -17,7 +17,7 @@ If you are unsure about which implementation you are using, check the container 
 
 ## The Key Differences
 
-The table below summarizes the key difference between nginxinc/kubernetes-ingress and kubernetes/ingress-nginx Ingress controllers. Note that the table has two columns for the nginxinc/kubernetes-ingress Ingress controller, as it can be used both with NGINX and NGINX Plus. For more information about nginxinc/kubernetes-ingress with NGINX Plus, read [here](/nginx-ingress-controller/intro/nginx-plus).
+The table below summarizes the key difference between nginxinc/kubernetes-ingress and kubernetes/ingress-nginx Ingress controllers. Note that the table has two columns for the nginxinc/kubernetes-ingress Ingress controller, as it can be used both with NGINX and NGINX Plus. For more information about nginxinc/kubernetes-ingress with NGINX Plus, read the [NGINX Ingress Controller with NGINX Plus](/nginx-ingress-controller/intro/nginx-plus) documentation.
 
 {{% table %}} 
 | Aspect or Feature | kubernetes/ingress-nginx | nginxinc/kubernetes-ingress with NGINX | nginxinc/kubernetes-ingress with NGINX Plus |


### PR DESCRIPTION
### Proposed changes
Rewording `here` link to provide more context and improve readability (users with screen readers, etc)

Before: For more information about nginxinc/kubernetes-ingress with NGINX Plus, read [here](/nginx-ingress-controller/intro/nginx-plus).

After: For more information about nginxinc/kubernetes-ingress with NGINX Plus, read the [NGINX Ingress Controller with NGINX Plus](/nginx-ingress-controller/intro/nginx-plus) documentation.