### PR TITLE
Add v1alpha1 version back to policy CRD

### DIFF
--- a/deployments/common/crds/k8s.nginx.org_policies.yaml
+++ b/deployments/common/crds/k8s.nginx.org_policies.yaml
@@ -170,6 +170,102 @@ spec:
       storage: true
       subresources:
         status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Policy defines a Policy for VirtualServer and VirtualServerRoute resources.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PolicySpec is the spec of the Policy resource. The spec includes multiple fields, where each field represents a different policy. Only one policy (field) is allowed.
+              type: object
+              properties:
+                accessControl:
+                  description: AccessControl defines an access policy based on the source IP of a request.
+                  type: object
+                  properties:
+                    allow:
+                      type: array
+                      items:
+                        type: string
+                    deny:
+                      type: array
+                      items:
+                        type: string
+                egressMTLS:
+                  description: EgressMTLS defines an Egress MTLS policy.
+                  type: object
+                  properties:
+                    ciphers:
+                      type: string
+                    protocols:
+                      type: string
+                    serverName:
+                      type: boolean
+                    sessionReuse:
+                      type: boolean
+                    sslName:
+                      type: string
+                    tlsSecret:
+                      type: string
+                    trustedCertSecret:
+                      type: string
+                    verifyDepth:
+                      type: integer
+                    verifyServer:
+                      type: boolean
+                ingressMTLS:
+                  description: IngressMTLS defines an Ingress MTLS policy.
+                  type: object
+                  properties:
+                    clientCertSecret:
+                      type: string
+                    verifyClient:
+                      type: string
+                    verifyDepth:
+                      type: integer
+                jwt:
+                  description: JWTAuth holds JWT authentication configuration.
+                  type: object
+                  properties:
+                    realm:
+                      type: string
+                    secret:
+                      type: string
+                    token:
+                      type: string
+                rateLimit:
+                  description: RateLimit defines a rate limit policy.
+                  type: object
+                  properties:
+                    burst:
+                      type: integer
+                    delay:
+                      type: integer
+                    dryRun:
+                      type: boolean
+                    key:
+                      type: string
+                    logLevel:
+                      type: string
+                    noDelay:
+                      type: boolean
+                    rate:
+                      type: string
+                    rejectCode:
+                      type: integer
+                    zoneSize:
+                      type: string
+      served: true
+      storage: false
 status:
   acceptedNames:
     kind: ""

--- a/deployments/helm-chart/crds/k8s.nginx.org_policies.yaml
+++ b/deployments/helm-chart/crds/k8s.nginx.org_policies.yaml
@@ -170,6 +170,102 @@ spec:
       storage: true
       subresources:
         status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Policy defines a Policy for VirtualServer and VirtualServerRoute resources.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PolicySpec is the spec of the Policy resource. The spec includes multiple fields, where each field represents a different policy. Only one policy (field) is allowed.
+              type: object
+              properties:
+                accessControl:
+                  description: AccessControl defines an access policy based on the source IP of a request.
+                  type: object
+                  properties:
+                    allow:
+                      type: array
+                      items:
+                        type: string
+                    deny:
+                      type: array
+                      items:
+                        type: string
+                egressMTLS:
+                  description: EgressMTLS defines an Egress MTLS policy.
+                  type: object
+                  properties:
+                    ciphers:
+                      type: string
+                    protocols:
+                      type: string
+                    serverName:
+                      type: boolean
+                    sessionReuse:
+                      type: boolean
+                    sslName:
+                      type: string
+                    tlsSecret:
+                      type: string
+                    trustedCertSecret:
+                      type: string
+                    verifyDepth:
+                      type: integer
+                    verifyServer:
+                      type: boolean
+                ingressMTLS:
+                  description: IngressMTLS defines an Ingress MTLS policy.
+                  type: object
+                  properties:
+                    clientCertSecret:
+                      type: string
+                    verifyClient:
+                      type: string
+                    verifyDepth:
+                      type: integer
+                jwt:
+                  description: JWTAuth holds JWT authentication configuration.
+                  type: object
+                  properties:
+                    realm:
+                      type: string
+                    secret:
+                      type: string
+                    token:
+                      type: string
+                rateLimit:
+                  description: RateLimit defines a rate limit policy.
+                  type: object
+                  properties:
+                    burst:
+                      type: integer
+                    delay:
+                      type: integer
+                    dryRun:
+                      type: boolean
+                    key:
+                      type: string
+                    logLevel:
+                      type: string
+                    noDelay:
+                      type: boolean
+                    rate:
+                      type: string
+                    rejectCode:
+                      type: integer
+                    zoneSize:
+                      type: string
+      served: true
+      storage: false
 status:
   acceptedNames:
     kind: ""

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -321,6 +321,7 @@ type VirtualServerRouteStatus struct {
 // +kubebuilder:validation:Optional
 // +kubebuilder:resource:shortName=pol
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`,description="Current state of the Policy. If the resource has a valid status, it means it has been validated and accepted by the Ingress Controller."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/pkg/apis/configuration/v1alpha1/types.go
+++ b/pkg/apis/configuration/v1alpha1/types.go
@@ -150,3 +150,82 @@ type TransportServerList struct {
 
 	Items []TransportServer `json:"items"`
 }
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:validation:Optional
+
+// Policy defines a Policy for VirtualServer and VirtualServerRoute resources.
+type Policy struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec PolicySpec `json:"spec"`
+}
+
+// PolicySpec is the spec of the Policy resource.
+// The spec includes multiple fields, where each field represents a different policy.
+// Only one policy (field) is allowed.
+type PolicySpec struct {
+	AccessControl *AccessControl `json:"accessControl"`
+	RateLimit     *RateLimit     `json:"rateLimit"`
+	JWTAuth       *JWTAuth       `json:"jwt"`
+	IngressMTLS   *IngressMTLS   `json:"ingressMTLS"`
+	EgressMTLS    *EgressMTLS    `json:"egressMTLS"`
+}
+
+// AccessControl defines an access policy based on the source IP of a request.
+type AccessControl struct {
+	Allow []string `json:"allow"`
+	Deny  []string `json:"deny"`
+}
+
+// RateLimit defines a rate limit policy.
+type RateLimit struct {
+	Rate       string `json:"rate"`
+	Key        string `json:"key"`
+	Delay      *int   `json:"delay"`
+	NoDelay    *bool  `json:"noDelay"`
+	Burst      *int   `json:"burst"`
+	ZoneSize   string `json:"zoneSize"`
+	DryRun     *bool  `json:"dryRun"`
+	LogLevel   string `json:"logLevel"`
+	RejectCode *int   `json:"rejectCode"`
+}
+
+// JWTAuth holds JWT authentication configuration.
+type JWTAuth struct {
+	Realm  string `json:"realm"`
+	Secret string `json:"secret"`
+	Token  string `json:"token"`
+}
+
+// IngressMTLS defines an Ingress MTLS policy.
+type IngressMTLS struct {
+	ClientCertSecret string `json:"clientCertSecret"`
+	VerifyClient     string `json:"verifyClient"`
+	VerifyDepth      *int   `json:"verifyDepth"`
+}
+
+// EgressMTLS defines an Egress MTLS policy.
+type EgressMTLS struct {
+	TLSSecret         string `json:"tlsSecret"`
+	VerifyServer      bool   `json:"verifyServer"`
+	VerifyDepth       *int   `json:"verifyDepth"`
+	Protocols         string `json:"protocols"`
+	SessionReuse      *bool  `json:"sessionReuse"`
+	Ciphers           string `json:"ciphers"`
+	TrustedCertSecret string `json:"trustedCertSecret"`
+	ServerName        bool   `json:"serverName"`
+	SSLName           string `json:"sslName"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// PolicyList is a list of the Policy resources.
+type PolicyList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+
+	Items []Policy `json:"items"`
+}


### PR DESCRIPTION
### Proposed changes
This commit provides a non-destructive upgrade path for policy v1alpha1 -> v1.
This is NOT re-adding support for v1alpha1, v1alpha1 is deprecated and v1 policy should be used.
v1alpha1 will be re-removed in 1.14

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
