### PR TITLE
Add Docker images for arm, arm64, ppc64le and s390x for OpenTracing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
             platforms: linux/arm64,linux/amd64
           - type: opentracing
             suffix: '-ot'
-            platforms: linux/amd64
+            platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -32,7 +32,7 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/apk/cert.pem,mode=0644 \
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/apk/cert.key,mode=0644 \
 	wget -nv -O /etc/apk/keys/nginx_signing.rsa.pub https://cs.nginx.com/static/keys/nginx_signing.rsa.pub \
 	&& printf "%s\n" "https://pkgs.nginx.com/plus/alpine/v$(grep -E -o '^[0-9]+\.[0-9]+' /etc/alpine-release)/main" >> /etc/apk/repositories \
-	&& apk add --no-cache libcap nginx-plus~${NGINX_PLUS_VERSION#r} nginx-plus-module-njs~${NGINX_PLUS_VERSION#r} 
+	&& apk add --no-cache libcap nginx-plus~${NGINX_PLUS_VERSION#r} nginx-plus-module-njs~${NGINX_PLUS_VERSION#r}
 
 
 ############################################# Base image for Debian with NGINX Plus #############################################
@@ -164,9 +164,6 @@ FROM opentracing/nginx-opentracing:nginx-1.21.3 as opentracing-lib
 ############################################# Build image for Opentracing #############################################
 FROM debian as opentracing
 
-RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y libcurl3-gnutls \
-	&& rm -rf /var/lib/apt/lists/*
-
 RUN --mount=type=bind,from=opentracing-lib,target=/tmp/ cp -av /tmp/usr/local/lib/libopentracing.so* /tmp/usr/local/lib/libjaegertracing*so* /tmp/usr/local/lib/libzipkin*so* /tmp/usr/local/lib/libdd*so* /tmp/usr/local/lib/libyaml*so* /usr/local/lib/ \
 	&& cp -av /tmp/usr/lib/nginx/modules/ngx_http_opentracing_module.so /usr/lib/nginx/modules/ \
 	&& ldconfig
@@ -179,7 +176,7 @@ ARG NGINX_PLUS_VERSION
 RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
 	apt-get update \
-	&& apt-get install --no-install-recommends --no-install-suggests -y libcurl3-gnutls nginx-plus-module-opentracing-${NGINX_PLUS_VERSION} \
+	&& apt-get install --no-install-recommends --no-install-suggests -y nginx-plus-module-opentracing-${NGINX_PLUS_VERSION} \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=bind,from=opentracing-lib,target=/tmp/ cp -av /tmp/usr/local/lib/libjaegertracing*so* /tmp/usr/local/lib/libzipkin*so* /tmp/usr/local/lib/libdd*so* /tmp/usr/local/lib/libyaml*so* /usr/local/lib/ \

--- a/docs/content/technical-specifications.md
+++ b/docs/content/technical-specifications.md
@@ -28,7 +28,7 @@ All images include NGINX 1.21.1.
 | ---| ---| ---| --- | --- |
 |Alpine-based image | ``nginx:1.21.1-alpine``, which is based on ``alpine:3.14`` |  | ``nginx/nginx-ingress:1.12.1-alpine`` | arm/v7, arm64, amd64, ppc64le, s390x |
 |Debian-based image | ``nginx:1.21.1``, which is based on ``debian:buster-slim`` |  | ``nginx/nginx-ingress:1.12.1`` | arm/v7, arm64, amd64, ppc64le, s390x |
-|Debian-based image with Opentracing | ``nginx:1.21.1``, which is based on ``debian:buster-slim`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:1.12.1-ot`` | amd64 |
+|Debian-based image with Opentracing | ``nginx:1.21.1``, which is based on ``debian:buster-slim`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:1.12.1-ot`` | arm/v7, arm64, amd64, ppc64le, s390x |
 |Ubi-based image | ``redhat/ubi8-minimal`` |  | ``nginx/nginx-ingress:1.12.1-ubi`` | arm64, amd64 |
 {{% /table %}}
 


### PR DESCRIPTION
Since https://github.com/opentracing-contrib/nginx-opentracing/pull/186 we can add builds for arm, arm64, ppc64le and s390x