### PR TITLE
Use k8s version in the filename for nightly tests

### DIFF
--- a/.github/actions/smoke-tests/action.yaml
+++ b/.github/actions/smoke-tests/action.yaml
@@ -66,7 +66,7 @@ runs:
         kind create cluster --name ${{ github.run_id }} --image=kindest/node:v${{ inputs.k8s-version }} --config ${{ github.workspace }}/tests/ci-files/ci-kind-config.yaml --kubeconfig kube-${{ github.run_id }} --wait ${{ inputs.k8s-timeout }}
         kind load docker-image docker.io/nginx/nginx-ingress:${{ inputs.image }}-${{ github.sha }} --name ${{ github.run_id }}
         echo ::set-output name=cluster_ip::$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${{ github.run_id }}-control-plane)
-        echo ::set-output name=cluster::$(echo 'nginx-${{ inputs.image }}-${{ inputs.marker }}')
+        echo ::set-output name=cluster::$(echo 'nginx-${{ inputs.image }}-${{ inputs.marker != '""' && inputs.marker || inputs.k8s-version }}')
       shell: bash
 
     - name: Setup Kubeconfig


### PR DESCRIPTION
The nightly doesn't have a marker and the action to upload results was having issues with that, so we can use k8s instead.
