### PR TITLE
Fix IngressClass test

### DIFF
--- a/tests/suite/test_ingress_class.py
+++ b/tests/suite/test_ingress_class.py
@@ -99,10 +99,17 @@ class TestIngressClassArgs:
         backend_setup,
         expected_responses,
         ingress_controller_prerequisites,
+        ingress_controller_endpoint,
     ):
         """
         Checks for ingressClass behaviour
         """
+        ensure_connection_to_public_endpoint(
+            ingress_controller_endpoint.public_ip,
+            ingress_controller_endpoint.port,
+            ingress_controller_endpoint.port_ssl,
+        )
+
         for item in ingresses_under_test:
             ensure_response_from_backend(
                 backend_setup.req_url, backend_setup.ingress_hosts[item]


### PR DESCRIPTION
Previously, the test would try to send a request to NGINX without ensuring the connection to NGINX first. This could lead to a request timeout, which in turn would lead to a test run hang.

The commit ensures the connection to NGINX.