### PR TITLE
fix: bumped f5-theme to v12.6

### DIFF
--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/f5-hugo.css
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/f5-hugo.css
@@ -621,6 +621,15 @@ h3.bd-links, #TableOfContents ul li a {
     border: none;
 }
 
+.bd-links ul > li:last-child {
+    padding-bottom: 0px !important;
+    margin-bottom: 0px !important;
+}
+
+.bd-links ul > li > ul:last-child{
+    padding-bottom: 0px !important;
+}
+
 .page {
     background-color: #F7F8FA;
 }
@@ -751,6 +760,7 @@ button, input[type=button], input[type=reset], input[type=submit] {
     display: list-item;
     padding-left: 0;
     margin-left: 0rem;
+    margin-bottom: 0 !important;
 }
 
 .sidebar-ul-border {

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/breadcrumb.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/breadcrumb.html
@@ -1,8 +1,7 @@
-
 <nav aria-label="breadcrumb" class="breadcrumb navbar">
     <div class="nav flex-md-row">
         <ol class="breadcrumb">
-            <li><a href="{{ .Site.BaseURL }}" alt="NGINX Docs Home">Home</a></li>
+            <li><a href="/" alt="NGINX Docs Home">Home</a></li>
 
             {{ define "breadcrumb" }}
             

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/footer.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/footer.html
@@ -13,7 +13,7 @@
               <span>Found a bug? Looking for something new?</span>
             </div>   
             <div class="col-lg d-none d-md-block pl-0">
-              <button class="button footer-button"><a href="{{ .Site.BaseURL }}/feedback/" alt="Select to open the submit feedback form">Let Us Know</a></button>
+              <button class="button footer-button"><a href="https://docs.nginx.com/feedback/" alt="Select to open the submit feedback form">Let Us Know</a></button>
             </div>    
           </div>
           {{ end }}

--- a/docs/_vendor/modules.txt
+++ b/docs/_vendor/modules.txt
@@ -1,2 +1,2 @@
-# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.12.4-0.20210920200041-c38578cf7945
+# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.12.6
 # github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/nginxinc/kubernetes-ingress/docs
 
 go 1.15
 
-require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.12.4-0.20210920200041-c38578cf7945 // indirect
+require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.12.6 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -4,3 +4,5 @@ gitlab.com/f5/nginx/controller/poc/f5-hugo v0.12.1-0.20210915172724-df3b014edc7e
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.12.1-0.20210915172724-df3b014edc7e/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.12.4-0.20210920200041-c38578cf7945 h1:7O1KjKaRVEthmXNhoZ7D48qcV/N0EbL7n13JoRL5KzE=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.12.4-0.20210920200041-c38578cf7945/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.12.6 h1:yDtJ1xqECha6lZ04fSG2wiSWCJMosjIVb/D0RoKLC6M=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.12.6/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=


### PR DESCRIPTION
### Proposed changes

- Increments the f5-theme to v12.6.
- Fixes the following issues:
  - Broken NGINX Docs link in site header
  - Broken "Home" link in breadcrumb
  - Broken "Submit Feedback" button on sub-pages
  - Unbalanced spacing in left/right navs