### PR TITLE
fix: add back anchor links for cmdline arguments

### DIFF
--- a/docs/content/configuration/global-configuration/command-line-arguments.md
+++ b/docs/content/configuration/global-configuration/command-line-arguments.md
@@ -8,242 +8,349 @@ toc: true
 
 
 The Ingress Controller supports several command-line arguments. Setting the arguments depends on how you install the Ingress Controller:
+
 * If you're using *Kubernetes manifests* (Deployment or DaemonSet) to install the Ingress Controller, to set the command-line arguments, modify those manifests accordingly. See the [Installation with Manifests](/nginx-ingress-controller/installation/installation-with-manifests) doc.
 * If you're using *Helm* to install the Ingress Controller, modify the parameters of the Helm chart that correspond to the command-line arguments. See the [Installation with Helm](/nginx-ingress-controller/installation/installation-with-helm) doc.
 
-Below we describe the available command-line arguments:
+Below we describe the available command-line arguments:  
+&nbsp;
+<a name="cmdoption-enable-snippets"></a>
 
-```
--enable-snippets
+### -enable-snippets
 
-		Enable custom NGINX configuration snippets in VirtualServer, VirtualServerRoute and TransportServer resources. (default false)
+Enable custom NGINX configuration snippets in VirtualServer, VirtualServerRoute and TransportServer resources.
 
--default-server-tls-secret <string>
+Default `false`.  
+&nbsp;
+<a name="cmdoption-default-server-tls-secret"></a>
 
-		Secret with a TLS certificate and key for TLS termination of the default server.
+### -default-server-tls-secret `<string>`
 
-		- If not set, certificate and key in the file "/etc/nginx/secrets/default" are used.
-		- If "/etc/nginx/secrets/default" doesn't exist, the Ingress Controller will configure NGINX to reject TLS connections to the default server.
-		- If a secret is set, but the Ingress controller is not able to fetch it from Kubernetes API, or it is not set and the Ingress Controller fails to read the file "/etc/nginx/secrets/default", the Ingress controller will fail to start.
+Secret with a TLS certificate and key for TLS termination of the default server.
 
-		Format: ``<namespace>/<name>``
+* If not set, certificate and key in the file `/etc/nginx/secrets/default` are used.
+* If `/etc/nginx/secrets/default` doesn't exist, the Ingress Controller will configure NGINX to reject TLS connections to the default server.
+* If a secret is set, but the Ingress controller is not able to fetch it from Kubernetes API, or it is not set and the Ingress Controller fails to read the file "/etc/nginx/secrets/default", the Ingress controller will fail to start.
 
--wildcard-tls-secret <string>
+Format: `<namespace>/<name>`  
+&nbsp;
+<a name="cmdoption-wildcard-tls-secret"></a>
 
-		A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified.
+### -wildcard-tls-secret `<string>`
 
-		- If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection.
+A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified.
 
-		- If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress controller will fail to start.
+* If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection.
 
-		Format: ``<namespace>/<name>``
+* If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress controller will fail to start.
 
--enable-custom-resources
+Format: `<namespace>/<name>`  
+&nbsp;
+<a name="cmdoption-enable-custom-resources"></a>
 
-		Enables custom resources. (default true)
+### -enable-custom-resources
 
--enable-preview-policies
+Enables custom resources.
 
-		Enables preview policies. (default false)
+Default `true`.  
+&nbsp;  
+<a name="cmdoption-enable-preview-policies"></a>
 
--enable-leader-election
+### -enable-preview-policies
 
-		Enables Leader election to avoid multiple replicas of the controller reporting the status of Ingress, VirtualServer and VirtualServerRoute resources -- only one replica will report status. (default true)
+Enables preview policies.
 
-		See -report-ingress-status flag.
+Default `false`.  
+&nbsp;  
+<a name="cmdoption-enable-leader-election"></a>
+### -enable-leader-election
 
--enable-tls-passthrough
 
-		Enable TLS Passthrough on port 443.
+Enables Leader election to avoid multiple replicas of the controller reporting the status of Ingress, VirtualServer and VirtualServerRoute resources -- only one replica will report status.
+Default `true`.
 
-		Requires -enable-custom-resources.
+See [-report-ingress-status](#cmdoption-report-ingress-status) flag.  
+&nbsp;  
+<a name="cmdoption-enable-tls-passthrough"></a>
 
--external-service <string>
+### -enable-tls-passthrough
 
-		Specifies the name of the service with the type LoadBalancer through which the Ingress controller pods are exposed externally. The external address of the service is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources.
+Enable TLS Passthrough on port 443.
 
-		For Ingress resources only: Requires -report-ingress-status.
+Requires [-enable-custom-resources](#cmdoption-enable-custom-resources).  
+&nbsp;  
+<a name="cmdoption-external-service"></a> 
 
--ingresslink <string>
+### -external-service `<string>`
 
-		Specifies the name of the IngressLink resource, which exposes the Ingress Controller pods via a BIG-IP system. The IP of the BIG-IP system is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources.
+Specifies the name of the service with the type LoadBalancer through which the Ingress controller pods are exposed externally. The external address of the service is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources.
 
-		For Ingress resources only: Requires -report-ingress-status.
+For Ingress resources only: Requires [-report-ingress-status](#cmdoption-report-ingress-status).  
+&nbsp;  
+<a name="cmdoption-ingresslink"></a> 
 
--global-configuration <string>
+### -ingresslink `<string>`
 
-		A GlobalConfiguration resource for global configuration of the Ingress Controller.
+Specifies the name of the IngressLink resource, which exposes the Ingress Controller pods via a BIG-IP system. The IP of the BIG-IP system is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources.
 
-		Format: ``<namespace>/<name>``
+For Ingress resources only: Requires [-report-ingress-status](#cmdoption-report-ingress-status).  
+&nbsp;  
+<a name="cmdoption-global-configuration"></a> 
 
-		Requires -enable-custom-resources.
+### -global-configuration `<string>`
 
--health-status
+A GlobalConfiguration resource for global configuration of the Ingress Controller.
 
-		Adds a location "/nginx-health" to the default server. The location responds with the 200 status code for any request.
-		Useful for external health-checking of the Ingress controller.
+Format: `<namespace>/<name>`
 
--health-status-uri <string>
+Requires [-enable-custom-resources](#cmdoption-enable-custom-resources).  
+&nbsp;  
+<a name="cmdoption-health-status"></a>
 
-		Sets the URI of health status location in the default server. Requires -health-status. (default "/nginx-health")
+### -health-status
 
--ingress-class <string>
+Adds a location "/nginx-health" to the default server. The location responds with the 200 status code for any request.
 
-		A class of the Ingress controller.
+Useful for external health-checking of the Ingress controller.  
+&nbsp;  
+<a name="cmdoption-health-status-uri"></a>
 
-		A corresponding IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start.
-		The Ingress controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class.
+### -health-status-uri `<string>`
 
-		The Ingress Controller processes all the resources that do not have the "ingressClassName" field.
+Sets the URI of health status location in the default server. Requires [-health-status](#cmdoption-health-status). (default `/nginx-health`)  
+&nbsp;  
+<a name="cmdoption-ingress-class"></a>
 
-		(default "nginx")
+### -ingress-class `<string>`
 
--ingress-template-path <string>
+A class of the Ingress controller.
 
-		Path to the ingress NGINX configuration template for an ingress resource. Default for NGINX is "nginx.ingress.tmpl"; default for NGINX Plus is "nginx-plus.ingress.tmpl".
+A corresponding IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start.
+The Ingress controller only processes resources that belong to its class - i.e. have the `ingressClassName` field resource equal to the class.
 
--leader-election-lock-name <string>
+The Ingress Controller processes all the resources that do not have the `ingressClassName` field.
 
-		Specifies the name of the ConfigMap, within the same namespace as the controller, used as the lock for leader election. Requires -enable-leader-election.
+Default `nginx`.  
+&nbsp;
+<a name="cmdoption-ingress-template-path"></a>  
 
--log_backtrace_at <value>
+### -ingress-template-path `<string>`
 
-		When logging hits line ``file:N``, emit a stack trace
+Path to the ingress NGINX configuration template for an ingress resource. Default for NGINX is `nginx.ingress.tmpl`; default for NGINX Plus is `nginx-plus.ingress.tmpl`.  
+&nbsp;  
+<a name="cmdoption-leader-election-lock-name"></a>
 
--main-template-path <string>
+### -leader-election-lock-name `<string>`
 
-		Path to the main NGINX configuration template.
+Specifies the name of the ConfigMap, within the same namespace as the controller, used as the lock for leader election.
 
-		- Default for NGINX is "nginx.ingress.tmpl"
-		- Default for NGINX Plus is "nginx-plus.ingress.tmpl".
+Requires [-enable-leader-election](#cmdoption-enable-leader-election).  
+&nbsp;  
+<a name="cmdoption-log_backtrace_at"></a>
 
--nginx-configmaps <string>
+### -log_backtrace_at `<value>`
 
-		A ConfigMap resource for customizing NGINX configuration. If a ConfigMap is set, but the Ingress controller is not able to fetch it from Kubernetes API, the Ingress controller will fail to start.
+When logging hits line `file:N`, emit a stack trace.  
+&nbsp;  
+<a name="cmdoption-main-template-path"></a>
 
-		Format: ``<namespace>/<name>``
+### -main-template-path `<string>`
 
--nginx-debug
+Path to the main NGINX configuration template.
 
-		Enable debugging for NGINX. Uses the nginx-debug binary. Requires 'error-log-level: debug' in the ConfigMap.
+* Default for NGINX is `nginx.ingress.tmpl`.
+* Default for NGINX Plus is `nginx-plus.ingress.tmpl`.  
+&nbsp;
+<a name="cmdoption-nginx-configmaps"></a>
 
--nginx-plus
+### -nginx-configmaps `<string>`
 
-		Enable support for NGINX Plus
+A ConfigMap resource for customizing NGINX configuration. If a ConfigMap is set, but the Ingress controller is not able to fetch it from Kubernetes API, the Ingress controller will fail to start.
 
--nginx-reload-timeout <value>
+Format: `<namespace>/<name>`  
+&nbsp;  
+<a name="cmdoption-nginx-debug"></a> 
 
-    Timeout in milliseconds which the Ingress Controller will wait for a successful NGINX reload after a change or at the initial start. (default is 4000. Default is 20000 instead if `enable-app-protect` is true)
+### -nginx-debug
 
--nginx-status
+Enable debugging for NGINX. Uses the nginx-debug binary. Requires 'error-log-level: debug' in the ConfigMap.  
+&nbsp;  
+<a name="cmdoption-nginx-plus"></a>
 
-		Enable the NGINX stub_status, or the NGINX Plus API. (default true)
+### -nginx-plus
 
--nginx-status-allow-cidrs <string>
+Enable support for NGINX Plus.  
+&nbsp;  
+<a name="cmdoption-nginx-reload-timeout"></a>
 
-		Add IPv4 IP/CIDR blocks to the allow list for NGINX stub_status or the NGINX Plus API.
-		Separate multiple IP/CIDR by commas. (default "127.0.0.1")
+### -nginx-reload-timeout `<value>`
 
--nginx-status-port [int]
+Timeout in milliseconds which the Ingress Controller will wait for a successful NGINX reload after a change or at the initial start.
 
-		Set the port where the NGINX stub_status or the NGINX Plus API is exposed.
+Default is 4000. Default is 20000 instead if `enable-app-protect` is true.  
+&nbsp;  
+<a name="cmdoption-nginx-status"></a>
 
-		Format: ``[1024 - 65535]`` (default 8080)
+### -nginx-status
 
--proxy <string>
+Enable the NGINX stub_status, or the NGINX Plus API.
 
-		Use a proxy server to connect to Kubernetes API started by "kubectl proxy" command. **For testing purposes only**.
-		The Ingress controller does not start NGINX and does not write any generated NGINX configuration files to disk.
+Default `true`.  
+&nbsp;  
+<a name="cmdoption-nginx-status-allow-cidrs"></a>
 
--report-ingress-status
+### -nginx-status-allow-cidrs `<string>`
 
-		Updates the address field in the status of Ingress resources.
-		Requires the -external-service or -ingresslink flag, or the ``external-status-address`` key in the ConfigMap.
+Add IPv4 IP/CIDR blocks to the allow list for NGINX stub_status or the NGINX Plus API.
 
--transportserver-template-path <string>
+Separate multiple IP/CIDR by commas. (default `127.0.0.1`)  
+&nbsp;  
+<a name="cmdoption-nginx-status-port"></a> 
 
-		Path to the TransportServer NGINX configuration template for a TransportServer resource.
+### -nginx-status-port `<int>`
 
-		- Default for NGINX is "nginx.transportserver.tmpl"
-		- Default for NGINX Plus is "nginx-plus.transportserver.tmpl".
+Set the port where the NGINX stub_status or the NGINX Plus API is exposed.
 
--v <value>
+Format: `[1024 - 65535]` (default `8080`)  
+&nbsp;  
+<a name="cmdoption-proxy"></a> 
 
-		Log level for V logs
+### -proxy `<string>`
 
--version
+Use a proxy server to connect to Kubernetes API started by "kubectl proxy" command. **For testing purposes only**.
 
-		Print the version, git-commit hash and build date and exit
+The Ingress controller does not start NGINX and does not write any generated NGINX configuration files to disk.  
+&nbsp;  
+<a name="cmdoption-report-ingress-status"></a>
 
--virtualserver-template-path <string>
+### -report-ingress-status
 
-		Path to the VirtualServer NGINX configuration template for a VirtualServer resource.
+Updates the address field in the status of Ingress resources.
 
-		- Default for NGINX is "nginx.ingress.tmpl"
-		- Default for NGINX Plus is "nginx-plus.ingress.tmpl".
+Requires the [-external-service](#cmdoption-external-service) or [-ingresslink](#cmdoption-ingresslink) flag, or the `external-status-address` key in the ConfigMap.  
+&nbsp;
+<a name="cmdoption-transportserver-template-path"></a> 
 
--vmodule <value>
+### -transportserver-template-path `<string>`
 
-		A comma-separated list of pattern=N settings for file-filtered logging.
+Path to the TransportServer NGINX configuration template for a TransportServer resource.
 
--watch-namespace <string>
+* Default for NGINX is `nginx.transportserver.tmpl`.
+* Default for NGINX Plus is `nginx-plus.transportserver.tmpl`.  
+  
+&nbsp;  
+<a name="cmdoption-v"></a> 
 
-		Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces.
+### -v `<value>`
 
--enable-prometheus-metrics
+Log level for V logs.  
+&nbsp;  
+<a name="cmdoption-version"></a> 
 
-		Enables exposing NGINX or NGINX Plus metrics in the Prometheus format.
+### -version
 
--prometheus-metrics-listen-port <int>
+Print the version, git-commit hash and build date and exit.  
+&nbsp;  
+<a name="cmdoption-virtualserver-template-path"></a> 
 
-		Sets the port where the Prometheus metrics are exposed.
+### -virtualserver-template-path `<string>`
 
-		Format: ``[1024 - 65535]`` (default 9113)
+Path to the VirtualServer NGINX configuration template for a VirtualServer resource.
 
--prometheus-tls-secret <string>
+* Default for NGINX is `nginx.ingress.tmpl`.
+* Default for NGINX Plus is `nginx-plus.ingress.tmpl`.  
+  
+&nbsp;  
+<a name="cmdoption-vmodule"></a> 
 
-		A Secret with a TLS certificate and key for TLS termination of the Prometheus metrics endpoint.
+### -vmodule `<value>`
 
-		- If the argument is not set, the prometheus endpoint will not use a TLS connection.
+A comma-separated list of pattern=N settings for file-filtered logging.  
+&nbsp;
+<a name="cmdoption-watch-namespace"></a> 
 
-		- If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress controller will fail to start.
+### -watch-namespace `<string>`
 
-		Format: ``<namespace>/<name>``
+Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces.  
+&nbsp;  
+<a name="cmdoption-enable-prometheus-metrics"></a> 
 
--spire-agent-address <string>
+### -enable-prometheus-metrics
 
-		Specifies the address of a running Spire agent. **For use with NGINX Service Mesh only**.
-    Requires -nginx-plus.
+Enables exposing NGINX or NGINX Plus metrics in the Prometheus format.  
+&nbsp;
+<a name="cmdoption-prometheus-metrics-listen-port"></a>
 
-		- If the argument is set, but the Ingress Controller is unable to connect to the Spire Agent, the Ingress Controller will fail to start.
+### -prometheus-metrics-listen-port `<int>`
 
--enable-internal-routes
+Sets the port where the Prometheus metrics are exposed.
 
-		Enable support for internal routes with NGINX Service Mesh. **For use with NGINX Service Mesh only**.
-    Requires -nginx-plus and -spire-agent-address.
+Format: `[1024 - 65535]` (default `9113`)  
+&nbsp;  
+<a name="cmdoption-prometheus-tls-secret"></a> 
 
-    - If the argument is set, but `nginx-plus` is set to false, or the `spire-agent-address` is not provided, the Ingress Controller will fail to start.
+### -prometheus-tls-secret `<string>`
 
--enable-latency-metrics
+A Secret with a TLS certificate and key for TLS termination of the Prometheus metrics endpoint.
 
-		Enable collection of latency metrics for upstreams.
-    Requires -enable-prometheus-metrics.
+* If the argument is not set, the prometheus endpoint will not use a TLS connection.
+* If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress controller will fail to start.
 
--enable-app-protect
+Format: `<namespace>/<name>`  
+&nbsp;  
+<a name="cmdoption-spire-agent-address"></a>
 
-	  Enables support for App Protect.
+### -spire-agent-address `<string>`
 
-   	Requires -nginx-plus
+Specifies the address of a running Spire agent. **For use with NGINX Service Mesh only**.
 
-	 	- If the argument is set, but `nginx-plus` is set to false, the Ingress Controller will fail to start.
+Requires [-nginx-plus](#cmdoption-nginx-plus).
 
--ready-status
+* If the argument is set, but the Ingress Controller is unable to connect to the Spire Agent, the Ingress Controller will fail to start.  
 
-		Enables the readiness endpoint "/nginx-ready". The endpoint returns a success code when NGINX has loaded all the config after the startup. (default true)
+&nbsp;  
+<a name="cmdoption-enable-internal-routes"></a> 
 
--ready-status-port
+### -enable-internal-routes
 
-		The HTTP port for the readiness endpoint.
+Enable support for internal routes with NGINX Service Mesh. **For use with NGINX Service Mesh only**.
 
-		Format: ``[1024 - 65535]`` (default 8081)
+Requires [-nginx-plus](#cmdoption-nginx-plus) and [-spire-agent-address](#cmdoption-spire-agent-address).
 
+* If the argument is set, but `nginx-plus` is set to false, or the `spire-agent-address` is not provided, the Ingress Controller will fail to start.  
+  
+&nbsp;  
+<a name="cmdoption-enable-latency-metrics"></a> 
+
+### -enable-latency-metrics
+
+Enable collection of latency metrics for upstreams.
+Requires [-enable-prometheus-metrics](#cmdoption-enable-prometheus-metrics).  
+&nbsp;
+<a name="cmdoption-enable-app-protect"></a> 
+
+### -enable-app-protect
+
+Enables support for App Protect.
+
+Requires [-nginx-plus](#cmdoption-nginx-plus).
+
+* If the argument is set, but `nginx-plus` is set to false, the Ingress Controller will fail to start.  
+
+&nbsp;  
+<a name="cmdoption-ready-status"></a> 
+
+### -ready-status
+
+Enables the readiness endpoint `/nginx-ready`. The endpoint returns a success code when NGINX has loaded all the config after the startup.
+
+Default `true`.  
+&nbsp;  
+<a name="cmdoption-ready-status-port"></a> 
+
+### -ready-status-port
+
+The HTTP port for the readiness endpoint.
+
+Format: `[1024 - 65535]` (default `8081`)  
+&nbsp; 


### PR DESCRIPTION
### Proposed changes
Adds back the missing anchor links to the Command line arguments documentation
![image](https://user-images.githubusercontent.com/78599298/134685552-ad0c162e-a277-4628-af73-c8490d5277cc.png)

DOCOPS-231