### PR TITLE
Increase default upstream zone size for NGINX Plus

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -476,7 +476,7 @@ func main() {
 		}
 	}
 
-	cfgParams := configs.NewDefaultConfigParams()
+	cfgParams := configs.NewDefaultConfigParams(*nginxPlus)
 
 	if *nginxConfigMaps != "" {
 		ns, name, err := k8s.ParseNamespaceName(*nginxConfigMaps)

--- a/docs/content/configuration/global-configuration/configmap-resource.md
+++ b/docs/content/configuration/global-configuration/configmap-resource.md
@@ -151,7 +151,7 @@ See the doc about [VirtualServer and VirtualServerRoute resources](/nginx-ingres
 | ---| ---| ---| --- | 
 |``lb-method`` | Sets the [load balancing method](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#choosing-a-load-balancing-method). To use the round-robin method, specify ``"round_robin"``. | ``"random two least_conn"`` |  | 
 |``max-fails`` | Sets the value of the [max_fails](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_fails) parameter of the ``server`` directive. | ``1`` |  | 
-|``upstream-zone-size`` | Sets the size of the shared memory [zone](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#zone) for upstreams. For NGINX, the special value 0 disables the shared memory zones. For NGINX Plus, shared memory zones are required and cannot be disabled. The special value 0 will be ignored. | ``256K`` |  | 
+|``upstream-zone-size`` | Sets the size of the shared memory [zone](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#zone) for upstreams. For NGINX, the special value 0 disables the shared memory zones. For NGINX Plus, shared memory zones are required and cannot be disabled. The special value 0 will be ignored. | ``256k`` for NGINX, ``512k`` for NGINX Plus  |  | 
 |``fail-timeout`` | Sets the value of the [fail_timeout](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#fail_timeout) parameter of the ``server`` directive. | ``10s`` |  | 
 |``keepalive`` | Sets the value of the [keepalive](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive) directive. Note that ``proxy_set_header Connection "";`` is added to the generated configuration when the value > 0. | ``0`` |  | 
 {{% /table %}} 

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -133,7 +133,12 @@ type Listener struct {
 }
 
 // NewDefaultConfigParams creates a ConfigParams with default values.
-func NewDefaultConfigParams() *ConfigParams {
+func NewDefaultConfigParams(isPlus bool) *ConfigParams {
+	upstreamZoneSize := "256k"
+	if isPlus {
+		upstreamZoneSize = "512k"
+	}
+
 	return &ConfigParams{
 		DefaultServerReturn:           "404",
 		ServerTokens:                  "on",
@@ -152,7 +157,7 @@ func NewDefaultConfigParams() *ConfigParams {
 		SSLPorts:                      []int{443},
 		MaxFails:                      1,
 		MaxConns:                      0,
-		UpstreamZoneSize:              "256k",
+		UpstreamZoneSize:              upstreamZoneSize,
 		FailTimeout:                   "10s",
 		LBMethod:                      "random two least_conn",
 		MainErrorLogLevel:             "notice",

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -11,7 +11,7 @@ import (
 
 // ParseConfigMap parses ConfigMap into ConfigParams.
 func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool, hasAppProtect bool) *ConfigParams {
-	cfgParams := NewDefaultConfigParams()
+	cfgParams := NewDefaultConfigParams(nginxPlus)
 
 	if serverTokens, exists, err := GetMapKeyAsBool(cfgm.Data, "server-tokens", cfgm); exists {
 		if err != nil {

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -41,7 +41,7 @@ func createTestConfigurator() (*Configurator, error) {
 
 	manager := nginx.NewFakeManager("/etc/nginx")
 
-	cnf, err := NewConfigurator(manager, createTestStaticConfigParams(), NewDefaultConfigParams(), templateExecutor, templateExecutorV2, false, false, nil, false, nil, false), nil
+	cnf, err := NewConfigurator(manager, createTestStaticConfigParams(), NewDefaultConfigParams(false), templateExecutor, templateExecutorV2, false, false, nil, false, nil, false), nil
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func createTestConfiguratorInvalidIngressTemplate() (*Configurator, error) {
 
 	manager := nginx.NewFakeManager("/etc/nginx")
 
-	cnf, err := NewConfigurator(manager, createTestStaticConfigParams(), NewDefaultConfigParams(), templateExecutor, &version2.TemplateExecutor{}, false, false, nil, false, nil, false), nil
+	cnf, err := NewConfigurator(manager, createTestStaticConfigParams(), NewDefaultConfigParams(false), templateExecutor, &version2.TemplateExecutor{}, false, false, nil, false, nil, false), nil
 	if err != nil {
 		return nil, err
 	}

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -17,13 +17,13 @@ import (
 
 func TestGenerateNginxCfg(t *testing.T) {
 	cafeIngressEx := createCafeIngressEx()
-	configParams := NewDefaultConfigParams()
-
 	isPlus := false
+	configParams := NewDefaultConfigParams(isPlus)
+
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 
 	apRes := AppProtectResources{}
-	result, warnings := generateNginxCfg(&cafeIngressEx, apRes, false, configParams, false, false, &StaticConfigParams{}, false)
+	result, warnings := generateNginxCfg(&cafeIngressEx, apRes, false, configParams, isPlus, false, &StaticConfigParams{}, false)
 
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("generateNginxCfg() returned unexpected result (-want +got):\n%s", diff)
@@ -46,9 +46,8 @@ func TestGenerateNginxCfgForJWT(t *testing.T) {
 		Path: "/etc/nginx/secrets/default-cafe-jwk",
 	}
 
-	configParams := NewDefaultConfigParams()
-
 	isPlus := true
+	configParams := NewDefaultConfigParams(isPlus)
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 	expected.Servers[0].JWTAuth = &version1.JWTAuth{
@@ -81,7 +80,7 @@ func TestGenerateNginxCfgForJWT(t *testing.T) {
 func TestGenerateNginxCfgWithMissingTLSSecret(t *testing.T) {
 	cafeIngressEx := createCafeIngressEx()
 	cafeIngressEx.SecretRefs["cafe-secret"].Error = errors.New("secret doesn't exist")
-	configParams := NewDefaultConfigParams()
+	configParams := NewDefaultConfigParams(false)
 
 	apRes := AppProtectResources{}
 	result, resultWarnings := generateNginxCfg(&cafeIngressEx, apRes, false, configParams, false, false, &StaticConfigParams{}, false)
@@ -105,7 +104,7 @@ func TestGenerateNginxCfgWithMissingTLSSecret(t *testing.T) {
 func TestGenerateNginxCfgWithWildcardTLSSecret(t *testing.T) {
 	cafeIngressEx := createCafeIngressEx()
 	cafeIngressEx.Ingress.Spec.TLS[0].SecretName = ""
-	configParams := NewDefaultConfigParams()
+	configParams := NewDefaultConfigParams(false)
 
 	apRes := AppProtectResources{}
 	result, warnings := generateNginxCfg(&cafeIngressEx, apRes, false, configParams, false, false, &StaticConfigParams{}, true)
@@ -176,10 +175,15 @@ func TestGenerateIngressPath(t *testing.T) {
 }
 
 func createExpectedConfigForCafeIngressEx(isPlus bool) version1.IngressNginxConfig {
+	upstreamZoneSize := "256k"
+	if isPlus {
+		upstreamZoneSize = "512k"
+	}
+
 	coffeeUpstream := version1.Upstream{
 		Name:             "default-cafe-ingress-cafe.example.com-coffee-svc-80",
 		LBMethod:         "random two least_conn",
-		UpstreamZoneSize: "256k",
+		UpstreamZoneSize: upstreamZoneSize,
 		UpstreamServers: []version1.UpstreamServer{
 			{
 				Address:     "10.0.0.1",
@@ -202,7 +206,7 @@ func createExpectedConfigForCafeIngressEx(isPlus bool) version1.IngressNginxConf
 	teaUpstream := version1.Upstream{
 		Name:             "default-cafe-ingress-cafe.example.com-tea-svc-80",
 		LBMethod:         "random two least_conn",
-		UpstreamZoneSize: "256k",
+		UpstreamZoneSize: upstreamZoneSize,
 		UpstreamServers: []version1.UpstreamServer{
 			{
 				Address:     "10.0.0.2",
@@ -356,7 +360,7 @@ func TestGenerateNginxCfgForMergeableIngresses(t *testing.T) {
 	isPlus := false
 	expected := createExpectedConfigForMergeableCafeIngress(isPlus)
 
-	configParams := NewDefaultConfigParams()
+	configParams := NewDefaultConfigParams(isPlus)
 
 	masterApRes := AppProtectResources{}
 	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, masterApRes, configParams, false, false, &StaticConfigParams{}, false)
@@ -381,7 +385,7 @@ func TestGenerateNginxConfigForCrossNamespaceMergeableIngresses(t *testing.T) {
 	}
 
 	expected := createExpectedConfigForCrossNamespaceMergeableCafeIngress()
-	configParams := NewDefaultConfigParams()
+	configParams := NewDefaultConfigParams(false)
 
 	emptyApResources := AppProtectResources{}
 	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, emptyApResources, configParams, false, false, &StaticConfigParams{}, false)
@@ -446,7 +450,7 @@ func TestGenerateNginxCfgForMergeableIngressesForJWT(t *testing.T) {
 
 	minionJwtKeyFileNames := make(map[string]string)
 	minionJwtKeyFileNames[objectMetaToFileName(&mergeableIngresses.Minions[0].Ingress.ObjectMeta)] = "/etc/nginx/secrets/default-coffee-jwk"
-	configParams := NewDefaultConfigParams()
+	configParams := NewDefaultConfigParams(isPlus)
 
 	masterApRes := AppProtectResources{}
 	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, masterApRes, configParams, isPlus, false, &StaticConfigParams{}, false)
@@ -619,10 +623,15 @@ func createMergeableCafeIngress() *MergeableIngresses {
 }
 
 func createExpectedConfigForMergeableCafeIngress(isPlus bool) version1.IngressNginxConfig {
+	upstreamZoneSize := "256k"
+	if isPlus {
+		upstreamZoneSize = "512k"
+	}
+
 	coffeeUpstream := version1.Upstream{
 		Name:             "default-cafe-ingress-coffee-minion-cafe.example.com-coffee-svc-80",
 		LBMethod:         "random two least_conn",
-		UpstreamZoneSize: "256k",
+		UpstreamZoneSize: upstreamZoneSize,
 		UpstreamServers: []version1.UpstreamServer{
 			{
 				Address:     "10.0.0.1",
@@ -645,7 +654,7 @@ func createExpectedConfigForMergeableCafeIngress(isPlus bool) version1.IngressNg
 	teaUpstream := version1.Upstream{
 		Name:             "default-cafe-ingress-tea-minion-cafe.example.com-tea-svc-80",
 		LBMethod:         "random two least_conn",
-		UpstreamZoneSize: "256k",
+		UpstreamZoneSize: upstreamZoneSize,
 		UpstreamServers: []version1.UpstreamServer{
 			{
 				Address:     "10.0.0.2",
@@ -842,9 +851,8 @@ func createExpectedConfigForCrossNamespaceMergeableCafeIngress() version1.Ingres
 
 func TestGenerateNginxCfgForSpiffe(t *testing.T) {
 	cafeIngressEx := createCafeIngressEx()
-	configParams := NewDefaultConfigParams()
-
 	isPlus := false
+	configParams := NewDefaultConfigParams(isPlus)
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 	expected.SpiffeClientCerts = true
@@ -868,9 +876,8 @@ func TestGenerateNginxCfgForInternalRoute(t *testing.T) {
 	internalRouteAnnotation := "nsm.nginx.com/internal-route"
 	cafeIngressEx := createCafeIngressEx()
 	cafeIngressEx.Ingress.Annotations[internalRouteAnnotation] = "true"
-	configParams := NewDefaultConfigParams()
-
 	isPlus := false
+	configParams := NewDefaultConfigParams(isPlus)
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 	expected.Servers[0].SpiffeCerts = true
@@ -1339,7 +1346,9 @@ func TestGenerateNginxCfgForAppProtect(t *testing.T) {
 		},
 	}
 
-	configParams := NewDefaultConfigParams()
+	isPlus := true
+
+	configParams := NewDefaultConfigParams(isPlus)
 	apRes := AppProtectResources{
 		AppProtectPolicy:   "/etc/nginx/waf/nac-policies/default_dataguard-alarm",
 		AppProtectLogconfs: []string{"/etc/nginx/waf/nac-logconfs/default_logconf syslog:server=127.0.0.1:514"},
@@ -1347,8 +1356,6 @@ func TestGenerateNginxCfgForAppProtect(t *testing.T) {
 	staticCfgParams := &StaticConfigParams{
 		MainAppProtectLoadModule: true,
 	}
-
-	isPlus := true
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 	expected.Servers[0].AppProtectEnable = "on"
@@ -1391,7 +1398,8 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtect(t *testing.T) {
 		},
 	}
 
-	configParams := NewDefaultConfigParams()
+	isPlus := true
+	configParams := NewDefaultConfigParams(isPlus)
 	apRes := AppProtectResources{
 		AppProtectPolicy:   "/etc/nginx/waf/nac-policies/default_dataguard-alarm",
 		AppProtectLogconfs: []string{"/etc/nginx/waf/nac-logconfs/default_logconf syslog:server=127.0.0.1:514"},
@@ -1399,8 +1407,6 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtect(t *testing.T) {
 	staticCfgParams := &StaticConfigParams{
 		MainAppProtectLoadModule: true,
 	}
-
-	isPlus := true
 
 	expected := createExpectedConfigForMergeableCafeIngress(isPlus)
 	expected.Servers[0].AppProtectEnable = "on"

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -1,7 +1,7 @@
 # configuration for {{.Ingress.Namespace}}/{{.Ingress.Name}}
 {{range $upstream := .Upstreams}}
 upstream {{$upstream.Name}} {
-	zone {{$upstream.Name}} {{if ne $upstream.UpstreamZoneSize "0"}}{{$upstream.UpstreamZoneSize}}{{else}}256k{{end}};
+	zone {{$upstream.Name}} {{if ne $upstream.UpstreamZoneSize "0"}}{{$upstream.UpstreamZoneSize}}{{else}}512k{{end}};
 	{{if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
 	{{range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}}:{{$server.Port}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}}

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -1,6 +1,6 @@
 {{ range $u := .Upstreams }}
 upstream {{ $u.Name }} {
-    zone {{ $u.Name }} {{ if ne $u.UpstreamZoneSize "0" }}{{ $u.UpstreamZoneSize }}{{ else }}256k{{ end }};
+    zone {{ $u.Name }} {{ if ne $u.UpstreamZoneSize "0" }}{{ $u.UpstreamZoneSize }}{{ else }}512k{{ end }};
 
     {{ if $u.LBMethod }}{{ $u.LBMethod }};{{ end }}
 

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -635,7 +635,7 @@ func (lbc *LoadBalancerController) syncConfigMap(task task) {
 }
 
 func (lbc *LoadBalancerController) updateAllConfigs() {
-	cfgParams := configs.NewDefaultConfigParams()
+	cfgParams := configs.NewDefaultConfigParams(lbc.isNginxPlus)
 
 	if lbc.configMap != nil {
 		cfgParams = configs.ParseConfigMap(lbc.configMap, lbc.isNginxPlus, lbc.appProtectEnabled)

--- a/tests/suite/test_externalname_service.py
+++ b/tests/suite/test_externalname_service.py
@@ -93,7 +93,7 @@ class TestExternalNameService:
                                                       ingress_controller_prerequisites.namespace)
         line = f"zone {external_name_setup.namespace}-" \
                f"{external_name_setup.ingress_name}-" \
-               f"{external_name_setup.ingress_host}-{external_name_setup.service}-80 256k;"
+               f"{external_name_setup.ingress_host}-{external_name_setup.service}-80 512k;"
         assert line in result_conf
 
     def test_ic_template_config_upstream_rule(self, kube_apis, ingress_controller_prerequisites,

--- a/tests/suite/test_v_s_route_externalname.py
+++ b/tests/suite/test_v_s_route_externalname.py
@@ -123,7 +123,7 @@ class TestVSRWithExternalNameService:
                                                     ingress_controller_prerequisites.namespace)
 
         line = f"zone vs_{vsr_externalname_setup.namespace}_{vsr_externalname_setup.vs_name}" \
-            f"_vsr_{vsr_externalname_setup.route.namespace}_{vsr_externalname_setup.route.name}_ext-backend 256k;"
+            f"_vsr_{vsr_externalname_setup.route.namespace}_{vsr_externalname_setup.route.name}_ext-backend 512k;"
         assert line in initial_config
         assert "random two least_conn;" in initial_config
         assert f"server {vsr_externalname_setup.external_host}:80 max_fails=1 fail_timeout=10s max_conns=0 resolve;"\

--- a/tests/suite/test_virtual_server_external_name.py
+++ b/tests/suite/test_virtual_server_external_name.py
@@ -78,7 +78,7 @@ class TestVSWithExternalNameService:
                                                  virtual_server_setup.vs_name,
                                                  vs_externalname_setup.ic_pod_name,
                                                  ingress_controller_prerequisites.namespace)
-        line = f"zone vs_{virtual_server_setup.namespace}_{virtual_server_setup.vs_name}_backend1 256k;"
+        line = f"zone vs_{virtual_server_setup.namespace}_{virtual_server_setup.vs_name}_backend1 512k;"
         assert line in result_conf
         assert "random two least_conn;" in result_conf
         assert f"server {vs_externalname_setup.external_host}:80 max_fails=1 fail_timeout=10s max_conns=0 resolve;"\


### PR DESCRIPTION
### Proposed changes
NGINX Plus R25 allocates more memory for storing upstream server (peer) data: +720 bytes per peer. This means upstream server zones will use more memory to accommodate that data.

If a zone is full, NGINX Plus will fail to reload and fail to add more upstream servers via the API.

To prevent reload failures after an upgrade to R25, this commit increases the default upstream zone size for NGINX Plus from 256K to 512K.
