### PR TITLE
fix: KIC-545 broken link in jwt-token page

### DIFF
--- a/docs/content/installation/using-the-jwt-token-docker-secret.md
+++ b/docs/content/installation/using-the-jwt-token-docker-secret.md
@@ -33,7 +33,7 @@ This document explains how to use the NGINX Plus Ingress Controller image from t
 
 3. This secret can now be added to a deployment spec, or to a service account to apply to all deployments for a given SA spec. See the official documentation [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) and [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account) for more details.
 
-4. Update the deployment spec with the chosen image path. Choose the image from the available images listed [here](/technical-specifications#images-with-nginx-plus).
+4. Update the deployment spec with the chosen image path. Choose the image from the available images listed [here](/nginx-ingress-controller/technical-specifications/#images-with-nginx-plus).
 
 5. You can use the certificate and key from the MyF5 portal and the Docker registry API to list the available image tags for the repositories, e.g.:
    ```

--- a/docs/content/installation/using-the-jwt-token-docker-secret.md
+++ b/docs/content/installation/using-the-jwt-token-docker-secret.md
@@ -33,7 +33,7 @@ This document explains how to use the NGINX Plus Ingress Controller image from t
 
 3. This secret can now be added to a deployment spec, or to a service account to apply to all deployments for a given SA spec. See the official documentation [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) and [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account) for more details.
 
-4. Update the deployment spec with the chosen image path. Choose the image from the available images listed [here](technical-specifications/#images-with-nginx-plus).
+4. Update the deployment spec with the chosen image path. Choose the image from the available images listed [here](/technical-specifications#images-with-nginx-plus).
 
 5. You can use the certificate and key from the MyF5 portal and the Docker registry API to list the available image tags for the repositories, e.g.:
    ```

--- a/docs/content/installation/using-the-jwt-token-docker-secret.md
+++ b/docs/content/installation/using-the-jwt-token-docker-secret.md
@@ -33,7 +33,7 @@ This document explains how to use the NGINX Plus Ingress Controller image from t
 
 3. This secret can now be added to a deployment spec, or to a service account to apply to all deployments for a given SA spec. See the official documentation [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) and [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account) for more details.
 
-4. Update the deployment spec with the chosen image path. Choose the image from the available images listed [here](nginx-ingress-controller/technical-specifications/#images-with-nginx-plus).
+4. Update the deployment spec with the chosen image path. Choose the image from the available images listed [here](/technical-specifications/#images-with-nginx-plus).
 
 5. You can use the certificate and key from the MyF5 portal and the Docker registry API to list the available image tags for the repositories, e.g.:
    ```

--- a/docs/content/installation/using-the-jwt-token-docker-secret.md
+++ b/docs/content/installation/using-the-jwt-token-docker-secret.md
@@ -33,7 +33,7 @@ This document explains how to use the NGINX Plus Ingress Controller image from t
 
 3. This secret can now be added to a deployment spec, or to a service account to apply to all deployments for a given SA spec. See the official documentation [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) and [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account) for more details.
 
-4. Update the deployment spec with the chosen image path. Choose the image from the available images listed [here](/technical-specifications/#images-with-nginx-plus).
+4. Update the deployment spec with the chosen image path. Choose the image from the available images listed [here](technical-specifications/#images-with-nginx-plus).
 
 5. You can use the certificate and key from the MyF5 portal and the Docker registry API to list the available image tags for the repositories, e.g.:
    ```


### PR DESCRIPTION
### Proposed changes
Correct a broken link in https://docs.nginx.com/nginx-ingress-controller/installation/using-the-jwt-token-docker-secret/  , step 4
