### PR TITLE
Update branches after CI run

### DIFF
--- a/.github/workflows/autoupdate-pr.yml
+++ b/.github/workflows/autoupdate-pr.yml
@@ -1,13 +1,17 @@
 name: Auto-update
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    branches: master
+    workflows:
+      - "Continuous Integration"
+    types:
+      - completed
 
 jobs:
   autoupdate:
     name: Auto-update PRs
     runs-on: ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:


### PR DESCRIPTION
Update branches after the CI workflow is done, instead of every commit to master. This should remove the check from the master branch.
Also, run only if the CI is successful so branches don't get a potentially "bad" commit.
