### PR TITLE
chore: Remove requirement for getting git tag for version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
+VERSION ?= 2.0.0
 PREFIX = nginx/nginx-ingress
 GIT_COMMIT = $(shell git rev-parse HEAD || echo unknown)
-GIT_COMMIT_SHORT = $(shell echo ${GIT_COMMIT} | cut -c1-7)
-GIT_TAG = $(shell git describe --tags --abbrev=0 || echo untagged)
 DATE = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-VERSION = $(GIT_TAG)-SNAPSHOT-$(GIT_COMMIT_SHORT)
-TAG = $(VERSION:v%=%)
+TAG ?= $(VERSION)
 TARGET ?= local
 
 override DOCKER_BUILD_OPTIONS += --build-arg IC_VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg DATE=$(DATE)


### PR DESCRIPTION
### Proposed changes
See https://gitlab.com/f5/nginx/kic/kubernetes-ingress/-/pipelines/378633255 for successful pipeline in GitLab. 

This is just for the release for now, we can decide whether or not to keep it for edge.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
