### PR TITLE
Increase time before issues/PRs become stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,11 +10,14 @@ jobs:
       - uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 10 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-all-pr-assignees: true
+          exempt-all-assignees: true
+          exempt-issue-labels: 'proposal'
           operations-per-run: 100
+          days-before-stale: 90
+          days-before-close: 10


### PR DESCRIPTION
- 90 days to become stale
- 10 days to close after stale
- PRs/issues with assignee don't become stale
- issues with `proposal` label don't become stale