### PR TITLE
Fix AppProtect resource names collisions

### DIFF
--- a/internal/configs/configurator.go
+++ b/internal/configs/configurator.go
@@ -265,6 +265,7 @@ func (cnf *Configurator) AddOrUpdateIngress(ingEx *IngressEx) (Warnings, error) 
 
 func (cnf *Configurator) addOrUpdateIngress(ingEx *IngressEx) (Warnings, error) {
 	apResources := cnf.updateApResources(ingEx)
+	dosResources := cnf.updateApDosResources(ingEx)
 
 	if jwtKey, exists := ingEx.Ingress.Annotations[JWTKeyAnnotation]; exists {
 		// LocalSecretStore will not set Path if the secret is not on the filesystem.
@@ -274,7 +275,7 @@ func (cnf *Configurator) addOrUpdateIngress(ingEx *IngressEx) (Warnings, error) 
 	}
 
 	isMinion := false
-	nginxCfg, warnings := generateNginxCfg(ingEx, apResources, isMinion, cnf.cfgParams, cnf.isPlus, cnf.IsResolverConfigured(),
+	nginxCfg, warnings := generateNginxCfg(ingEx, apResources, dosResources, isMinion, cnf.cfgParams, cnf.isPlus, cnf.IsResolverConfigured(),
 		cnf.staticCfgParams, cnf.isWildcardEnabled)
 	name := objectMetaToFileName(&ingEx.Ingress.ObjectMeta)
 	content, err := cnf.templateExecutor.ExecuteIngressConfigTemplate(&nginxCfg)
@@ -305,7 +306,8 @@ func (cnf *Configurator) AddOrUpdateMergeableIngress(mergeableIngs *MergeableIng
 }
 
 func (cnf *Configurator) addOrUpdateMergeableIngress(mergeableIngs *MergeableIngresses) (Warnings, error) {
-	masterApResources := cnf.updateApResources(mergeableIngs.Master)
+	apResources := cnf.updateApResources(mergeableIngs.Master)
+	dosResources := cnf.updateApDosResources(mergeableIngs.Master)
 
 	// LocalSecretStore will not set Path if the secret is not on the filesystem.
 	// However, NGINX configuration for an Ingress resource, to handle the case of a missing secret,
@@ -319,7 +321,7 @@ func (cnf *Configurator) addOrUpdateMergeableIngress(mergeableIngs *MergeableIng
 		}
 	}
 
-	nginxCfg, warnings := generateNginxCfgForMergeableIngresses(mergeableIngs, masterApResources, cnf.cfgParams, cnf.isPlus,
+	nginxCfg, warnings := generateNginxCfgForMergeableIngresses(mergeableIngs, apResources, dosResources, cnf.cfgParams, cnf.isPlus,
 		cnf.IsResolverConfigured(), cnf.staticCfgParams, cnf.isWildcardEnabled)
 
 	name := objectMetaToFileName(&mergeableIngs.Master.Ingress.ObjectMeta)
@@ -1265,36 +1267,44 @@ func createSpiffeCert(certs []*x509.Certificate) []byte {
 	return pemData
 }
 
-func (cnf *Configurator) updateApResources(ingEx *IngressEx) (apRes AppProtectResources) {
+func (cnf *Configurator) updateApResources(ingEx *IngressEx) *appProtectResources {
+	var apResources appProtectResources
+
 	if ingEx.AppProtectPolicy != nil {
 		policyFileName := appProtectPolicyFileNameFromUnstruct(ingEx.AppProtectPolicy)
 		policyContent := generateApResourceFileContent(ingEx.AppProtectPolicy)
 		cnf.nginxManager.CreateAppProtectResourceFile(policyFileName, policyContent)
-		apRes.AppProtectPolicy = policyFileName
+		apResources.AppProtectPolicy = policyFileName
 	}
 
 	for _, logConf := range ingEx.AppProtectLogs {
 		logConfFileName := appProtectLogConfFileNameFromUnstruct(logConf.LogConf)
 		logConfContent := generateApResourceFileContent(logConf.LogConf)
 		cnf.nginxManager.CreateAppProtectResourceFile(logConfFileName, logConfContent)
-		apRes.AppProtectLogconfs = append(apRes.AppProtectLogconfs, logConfFileName+" "+logConf.Dest)
+		apResources.AppProtectLogconfs = append(apResources.AppProtectLogconfs, logConfFileName+" "+logConf.Dest)
 	}
+
+	return &apResources
+}
+
+func (cnf *Configurator) updateApDosResources(ingEx *IngressEx) *appProtectDosResources {
+	var dosResources appProtectDosResources
 
 	if ingEx.AppProtectDosPolicy != nil {
 		policyFileName := appProtectDosPolicyFileNameFromUnstruct(ingEx.AppProtectDosPolicy)
 		policyContent := generateApResourceFileContent(ingEx.AppProtectDosPolicy)
 		cnf.nginxManager.CreateAppProtectResourceFile(policyFileName, policyContent)
-		apRes.AppProtectDosPolicy = policyFileName
+		dosResources.AppProtectDosPolicy = policyFileName
 	}
 
 	if ingEx.AppProtectDosLogConf != nil {
 		logConfFileName := appProtectDosLogConfFileNameFromUnstruct(ingEx.AppProtectDosLogConf)
 		logConfContent := generateApResourceFileContent(ingEx.AppProtectDosLogConf)
 		cnf.nginxManager.CreateAppProtectResourceFile(logConfFileName, logConfContent)
-		apRes.AppProtectDosLogconfs = logConfFileName + " " + ingEx.AppProtectDosLogDst
+		dosResources.AppProtectDosLogconfs = logConfFileName + " " + ingEx.AppProtectDosLogDst
 	}
 
-	return apRes
+	return &dosResources
 }
 
 func (cnf *Configurator) updateApResourcesForVs(vsEx *VirtualServerEx) *appProtectResourcesForVS {

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -1106,7 +1106,7 @@ func TestUpdateApResources(t *testing.T) {
 
 	tests := []struct {
 		ingEx    *IngressEx
-		expected AppProtectResources
+		expected *appProtectResources
 		msg      string
 	}{
 		{
@@ -1115,7 +1115,7 @@ func TestUpdateApResources(t *testing.T) {
 					ObjectMeta: meta_v1.ObjectMeta{},
 				},
 			},
-			expected: AppProtectResources{},
+			expected: &appProtectResources{},
 			msg:      "no app protect resources",
 		},
 		{
@@ -1125,7 +1125,7 @@ func TestUpdateApResources(t *testing.T) {
 				},
 				AppProtectPolicy: appProtectPolicy,
 			},
-			expected: AppProtectResources{
+			expected: &appProtectResources{
 				AppProtectPolicy: "/etc/nginx/waf/nac-policies/test-ns_test-name",
 			},
 			msg: "app protect policy",
@@ -1142,7 +1142,7 @@ func TestUpdateApResources(t *testing.T) {
 					},
 				},
 			},
-			expected: AppProtectResources{
+			expected: &appProtectResources{
 				AppProtectLogconfs: []string{"/etc/nginx/waf/nac-logconfs/test-ns_test-name test-dst"},
 			},
 			msg: "app protect log conf",
@@ -1160,7 +1160,7 @@ func TestUpdateApResources(t *testing.T) {
 					},
 				},
 			},
-			expected: AppProtectResources{
+			expected: &appProtectResources{
 				AppProtectPolicy:   "/etc/nginx/waf/nac-policies/test-ns_test-name",
 				AppProtectLogconfs: []string{"/etc/nginx/waf/nac-logconfs/test-ns_test-name test-dst"},
 			},
@@ -1325,7 +1325,7 @@ func TestUpdateApDosResources(t *testing.T) {
 
 	tests := []struct {
 		ingEx    *IngressEx
-		expected AppProtectResources
+		expected *appProtectDosResources
 		msg      string
 	}{
 		{
@@ -1334,7 +1334,7 @@ func TestUpdateApDosResources(t *testing.T) {
 					ObjectMeta: meta_v1.ObjectMeta{},
 				},
 			},
-			expected: AppProtectResources{},
+			expected: &appProtectDosResources{},
 			msg:      "no app protect dos resources",
 		},
 		{
@@ -1344,7 +1344,7 @@ func TestUpdateApDosResources(t *testing.T) {
 				},
 				AppProtectDosPolicy: appProtectDosPolicy,
 			},
-			expected: AppProtectResources{
+			expected: &appProtectDosResources{
 				AppProtectDosPolicy: "/etc/nginx/dos/policies/test-ns_test-name.json",
 			},
 			msg: "app protect dos policy",
@@ -1357,7 +1357,7 @@ func TestUpdateApDosResources(t *testing.T) {
 				AppProtectDosLogConf: appProtectDosLogConf,
 				AppProtectDosLogDst:  appProtectDosLogDst,
 			},
-			expected: AppProtectResources{
+			expected: &appProtectDosResources{
 				AppProtectDosLogconfs: "/etc/nginx/dos/logconfs/test-ns_test-name.json test-dst",
 			},
 			msg: "app protect dos log conf",
@@ -1371,7 +1371,7 @@ func TestUpdateApDosResources(t *testing.T) {
 				AppProtectDosLogConf: appProtectDosLogConf,
 				AppProtectDosLogDst:  appProtectDosLogDst,
 			},
-			expected: AppProtectResources{
+			expected: &appProtectDosResources{
 				AppProtectDosPolicy:   "/etc/nginx/dos/policies/test-ns_test-name.json",
 				AppProtectDosLogconfs: "/etc/nginx/dos/logconfs/test-ns_test-name.json test-dst",
 			},
@@ -1385,7 +1385,7 @@ func TestUpdateApDosResources(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := conf.updateApResources(test.ingEx)
+		result := conf.updateApDosResources(test.ingEx)
 		if !reflect.DeepEqual(result, test.expected) {
 			t.Errorf("updateApResources() returned \n%v but expected\n%v for the case of %s", result, test.expected, test.msg)
 		}

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	networking "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1220,7 +1221,7 @@ func TestUpdateApResourcesForVs(t *testing.T) {
 
 	tests := []struct {
 		vsEx     *VirtualServerEx
-		expected map[string]string
+		expected *appProtectResourcesForVS
 		msg      string
 	}{
 		{
@@ -1229,8 +1230,11 @@ func TestUpdateApResourcesForVs(t *testing.T) {
 					ObjectMeta: meta_v1.ObjectMeta{},
 				},
 			},
-			expected: map[string]string{},
-			msg:      "no app protect resources",
+			expected: &appProtectResourcesForVS{
+				Policies: map[string]string{},
+				LogConfs: map[string]string{},
+			},
+			msg: "no app protect resources",
 		},
 		{
 			vsEx: &VirtualServerEx{
@@ -1239,9 +1243,12 @@ func TestUpdateApResourcesForVs(t *testing.T) {
 				},
 				ApPolRefs: apPolRefs,
 			},
-			expected: map[string]string{
-				"test-ns-1/test-name-1": "/etc/nginx/waf/nac-policies/test-ns-1_test-name-1",
-				"test-ns-2/test-name-2": "/etc/nginx/waf/nac-policies/test-ns-2_test-name-2",
+			expected: &appProtectResourcesForVS{
+				Policies: map[string]string{
+					"test-ns-1/test-name-1": "/etc/nginx/waf/nac-policies/test-ns-1_test-name-1",
+					"test-ns-2/test-name-2": "/etc/nginx/waf/nac-policies/test-ns-2_test-name-2",
+				},
+				LogConfs: map[string]string{},
 			},
 			msg: "app protect policies",
 		},
@@ -1252,9 +1259,12 @@ func TestUpdateApResourcesForVs(t *testing.T) {
 				},
 				LogConfRefs: logConfRefs,
 			},
-			expected: map[string]string{
-				"test-ns-1/test-name-1": "/etc/nginx/waf/nac-logconfs/test-ns-1_test-name-1",
-				"test-ns-2/test-name-2": "/etc/nginx/waf/nac-logconfs/test-ns-2_test-name-2",
+			expected: &appProtectResourcesForVS{
+				Policies: map[string]string{},
+				LogConfs: map[string]string{
+					"test-ns-1/test-name-1": "/etc/nginx/waf/nac-logconfs/test-ns-1_test-name-1",
+					"test-ns-2/test-name-2": "/etc/nginx/waf/nac-logconfs/test-ns-2_test-name-2",
+				},
 			},
 			msg: "app protect log confs",
 		},
@@ -1266,10 +1276,15 @@ func TestUpdateApResourcesForVs(t *testing.T) {
 				ApPolRefs:   apPolRefs,
 				LogConfRefs: logConfRefs,
 			},
-			expected: map[string]string{
-				// this is a bug - the result needs to include both policies and log confs
-				"test-ns-1/test-name-1": "/etc/nginx/waf/nac-logconfs/test-ns-1_test-name-1",
-				"test-ns-2/test-name-2": "/etc/nginx/waf/nac-logconfs/test-ns-2_test-name-2",
+			expected: &appProtectResourcesForVS{
+				Policies: map[string]string{
+					"test-ns-1/test-name-1": "/etc/nginx/waf/nac-policies/test-ns-1_test-name-1",
+					"test-ns-2/test-name-2": "/etc/nginx/waf/nac-policies/test-ns-2_test-name-2",
+				},
+				LogConfs: map[string]string{
+					"test-ns-1/test-name-1": "/etc/nginx/waf/nac-logconfs/test-ns-1_test-name-1",
+					"test-ns-2/test-name-2": "/etc/nginx/waf/nac-logconfs/test-ns-2_test-name-2",
+				},
 			},
 			msg: "app protect policies and log confs",
 		},
@@ -1282,8 +1297,8 @@ func TestUpdateApResourcesForVs(t *testing.T) {
 
 	for _, test := range tests {
 		result := conf.updateApResourcesForVs(test.vsEx)
-		if !reflect.DeepEqual(result, test.expected) {
-			t.Errorf("updateApResourcesForVs() returned \n%v but expected\n%v for the case of %s", result, test.expected, test.msg)
+		if diff := cmp.Diff(test.expected, result); diff != "" {
+			t.Errorf("updateApResourcesForVs() '%s' mismatch (-want +got):\n%s", test.msg, diff)
 		}
 	}
 }
@@ -1340,7 +1355,7 @@ func TestUpdateApDosResources(t *testing.T) {
 					ObjectMeta: meta_v1.ObjectMeta{},
 				},
 				AppProtectDosLogConf: appProtectDosLogConf,
-				AppProtectDosLogDst: appProtectDosLogDst,
+				AppProtectDosLogDst:  appProtectDosLogDst,
 			},
 			expected: AppProtectResources{
 				AppProtectDosLogconfs: "/etc/nginx/dos/logconfs/test-ns_test-name.json test-dst",
@@ -1352,9 +1367,9 @@ func TestUpdateApDosResources(t *testing.T) {
 				Ingress: &networking.Ingress{
 					ObjectMeta: meta_v1.ObjectMeta{},
 				},
-				AppProtectDosPolicy: appProtectDosPolicy,
+				AppProtectDosPolicy:  appProtectDosPolicy,
 				AppProtectDosLogConf: appProtectDosLogConf,
-				AppProtectDosLogDst: appProtectDosLogDst,
+				AppProtectDosLogDst:  appProtectDosLogDst,
 			},
 			expected: AppProtectResources{
 				AppProtectDosPolicy:   "/etc/nginx/dos/policies/test-ns_test-name.json",
@@ -1417,7 +1432,7 @@ func TestUpdateApDosResourcesForVs(t *testing.T) {
 
 	tests := []struct {
 		vsEx     *VirtualServerEx
-		expected map[string]string
+		expected *appProtectDosResourcesForVS
 		msg      string
 	}{
 		{
@@ -1426,8 +1441,11 @@ func TestUpdateApDosResourcesForVs(t *testing.T) {
 					ObjectMeta: meta_v1.ObjectMeta{},
 				},
 			},
-			expected: map[string]string{},
-			msg:      "no app protect dos resources",
+			expected: &appProtectDosResourcesForVS{
+				Policies: map[string]string{},
+				LogConfs: map[string]string{},
+			},
+			msg: "no app protect dos resources",
 		},
 		{
 			vsEx: &VirtualServerEx{
@@ -1436,9 +1454,12 @@ func TestUpdateApDosResourcesForVs(t *testing.T) {
 				},
 				ApDosPolRefs: apDosPolRefs,
 			},
-			expected: map[string]string{
-				"test-ns-1/test-name-1": "/etc/nginx/dos/policies/test-ns-1_test-name-1.json",
-				"test-ns-2/test-name-2": "/etc/nginx/dos/policies/test-ns-2_test-name-2.json",
+			expected: &appProtectDosResourcesForVS{
+				Policies: map[string]string{
+					"test-ns-1/test-name-1": "/etc/nginx/dos/policies/test-ns-1_test-name-1.json",
+					"test-ns-2/test-name-2": "/etc/nginx/dos/policies/test-ns-2_test-name-2.json",
+				},
+				LogConfs: map[string]string{},
 			},
 			msg: "app protect dos policies",
 		},
@@ -1449,9 +1470,12 @@ func TestUpdateApDosResourcesForVs(t *testing.T) {
 				},
 				DosLogConfRefs: dosLogConfRefs,
 			},
-			expected: map[string]string{
-				"test-ns-1/test-name-1": "/etc/nginx/dos/logconfs/test-ns-1_test-name-1.json",
-				"test-ns-2/test-name-2": "/etc/nginx/dos/logconfs/test-ns-2_test-name-2.json",
+			expected: &appProtectDosResourcesForVS{
+				Policies: map[string]string{},
+				LogConfs: map[string]string{
+					"test-ns-1/test-name-1": "/etc/nginx/dos/logconfs/test-ns-1_test-name-1.json",
+					"test-ns-2/test-name-2": "/etc/nginx/dos/logconfs/test-ns-2_test-name-2.json",
+				},
 			},
 			msg: "app protect dos log confs",
 		},
@@ -1463,10 +1487,15 @@ func TestUpdateApDosResourcesForVs(t *testing.T) {
 				ApDosPolRefs:   apDosPolRefs,
 				DosLogConfRefs: dosLogConfRefs,
 			},
-			expected: map[string]string{
-				// this is a bug - the result needs to include both policies and log confs
-				"test-ns-1/test-name-1": "/etc/nginx/dos/logconfs/test-ns-1_test-name-1.json",
-				"test-ns-2/test-name-2": "/etc/nginx/dos/logconfs/test-ns-2_test-name-2.json",
+			expected: &appProtectDosResourcesForVS{
+				Policies: map[string]string{
+					"test-ns-1/test-name-1": "/etc/nginx/dos/policies/test-ns-1_test-name-1.json",
+					"test-ns-2/test-name-2": "/etc/nginx/dos/policies/test-ns-2_test-name-2.json",
+				},
+				LogConfs: map[string]string{
+					"test-ns-1/test-name-1": "/etc/nginx/dos/logconfs/test-ns-1_test-name-1.json",
+					"test-ns-2/test-name-2": "/etc/nginx/dos/logconfs/test-ns-2_test-name-2.json",
+				},
 			},
 			msg: "app protect Dos policies and log confs",
 		},
@@ -1478,9 +1507,9 @@ func TestUpdateApDosResourcesForVs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := conf.updateApResourcesForVs(test.vsEx)
-		if !reflect.DeepEqual(result, test.expected) {
-			t.Errorf("updateApResourcesForVs() returned \n%v but expected\n%v for the case of %s", result, test.expected, test.msg)
+		result := conf.updateApDosResourcesForVS(test.vsEx)
+		if diff := cmp.Diff(test.expected, result); diff != "" {
+			t.Errorf("updateApDosResourcesForVS() '%s' mismatch (-want +got):\n%s", test.msg, diff)
 		}
 	}
 }

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -22,8 +22,7 @@ func TestGenerateNginxCfg(t *testing.T) {
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 
-	apRes := AppProtectResources{}
-	result, warnings := generateNginxCfg(&cafeIngressEx, apRes, false, configParams, isPlus, false, &StaticConfigParams{}, false)
+	result, warnings := generateNginxCfg(&cafeIngressEx, nil, nil, false, configParams, isPlus, false, &StaticConfigParams{}, false)
 
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("generateNginxCfg() returned unexpected result (-want +got):\n%s", diff)
@@ -63,8 +62,7 @@ func TestGenerateNginxCfgForJWT(t *testing.T) {
 		},
 	}
 
-	apRes := AppProtectResources{}
-	result, warnings := generateNginxCfg(&cafeIngressEx, apRes, false, configParams, true, false, &StaticConfigParams{}, false)
+	result, warnings := generateNginxCfg(&cafeIngressEx, nil, nil, false, configParams, true, false, &StaticConfigParams{}, false)
 
 	if !reflect.DeepEqual(result.Servers[0].JWTAuth, expected.Servers[0].JWTAuth) {
 		t.Errorf("generateNginxCfg returned \n%v,  but expected \n%v", result.Servers[0].JWTAuth, expected.Servers[0].JWTAuth)
@@ -82,8 +80,7 @@ func TestGenerateNginxCfgWithMissingTLSSecret(t *testing.T) {
 	cafeIngressEx.SecretRefs["cafe-secret"].Error = errors.New("secret doesn't exist")
 	configParams := NewDefaultConfigParams(false)
 
-	apRes := AppProtectResources{}
-	result, resultWarnings := generateNginxCfg(&cafeIngressEx, apRes, false, configParams, false, false, &StaticConfigParams{}, false)
+	result, resultWarnings := generateNginxCfg(&cafeIngressEx, nil, nil, false, configParams, false, false, &StaticConfigParams{}, false)
 
 	expectedSSLRejectHandshake := true
 	expectedWarnings := Warnings{
@@ -106,8 +103,7 @@ func TestGenerateNginxCfgWithWildcardTLSSecret(t *testing.T) {
 	cafeIngressEx.Ingress.Spec.TLS[0].SecretName = ""
 	configParams := NewDefaultConfigParams(false)
 
-	apRes := AppProtectResources{}
-	result, warnings := generateNginxCfg(&cafeIngressEx, apRes, false, configParams, false, false, &StaticConfigParams{}, true)
+	result, warnings := generateNginxCfg(&cafeIngressEx, nil, nil, false, configParams, false, false, &StaticConfigParams{}, true)
 
 	resultServer := result.Servers[0]
 	if !reflect.DeepEqual(resultServer.SSLCertificate, pemFileNameForWildcardTLSSecret) {
@@ -362,8 +358,7 @@ func TestGenerateNginxCfgForMergeableIngresses(t *testing.T) {
 
 	configParams := NewDefaultConfigParams(isPlus)
 
-	masterApRes := AppProtectResources{}
-	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, masterApRes, configParams, false, false, &StaticConfigParams{}, false)
+	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, nil, nil, configParams, false, false, &StaticConfigParams{}, false)
 
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("generateNginxCfgForMergeableIngresses() returned unexpected result (-want +got):\n%s", diff)
@@ -387,8 +382,7 @@ func TestGenerateNginxConfigForCrossNamespaceMergeableIngresses(t *testing.T) {
 	expected := createExpectedConfigForCrossNamespaceMergeableCafeIngress()
 	configParams := NewDefaultConfigParams(false)
 
-	emptyApResources := AppProtectResources{}
-	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, emptyApResources, configParams, false, false, &StaticConfigParams{}, false)
+	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, nil, nil, configParams, false, false, &StaticConfigParams{}, false)
 
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("generateNginxCfgForMergeableIngresses() returned unexpected result (-want +got):\n%s", diff)
@@ -452,8 +446,7 @@ func TestGenerateNginxCfgForMergeableIngressesForJWT(t *testing.T) {
 	minionJwtKeyFileNames[objectMetaToFileName(&mergeableIngresses.Minions[0].Ingress.ObjectMeta)] = "/etc/nginx/secrets/default-coffee-jwk"
 	configParams := NewDefaultConfigParams(isPlus)
 
-	masterApRes := AppProtectResources{}
-	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, masterApRes, configParams, isPlus, false, &StaticConfigParams{}, false)
+	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, nil, nil, configParams, isPlus, false, &StaticConfigParams{}, false)
 
 	if !reflect.DeepEqual(result.Servers[0].JWTAuth, expected.Servers[0].JWTAuth) {
 		t.Errorf("generateNginxCfgForMergeableIngresses returned \n%v,  but expected \n%v", result.Servers[0].JWTAuth, expected.Servers[0].JWTAuth)
@@ -860,8 +853,7 @@ func TestGenerateNginxCfgForSpiffe(t *testing.T) {
 		expected.Servers[0].Locations[i].SSL = true
 	}
 
-	apResources := AppProtectResources{}
-	result, warnings := generateNginxCfg(&cafeIngressEx, apResources, false, configParams, false, false,
+	result, warnings := generateNginxCfg(&cafeIngressEx, nil, nil, false, configParams, false, false,
 		&StaticConfigParams{NginxServiceMesh: true}, false)
 
 	if diff := cmp.Diff(expected, result); diff != "" {
@@ -883,8 +875,7 @@ func TestGenerateNginxCfgForInternalRoute(t *testing.T) {
 	expected.Servers[0].SpiffeCerts = true
 	expected.Ingress.Annotations[internalRouteAnnotation] = "true"
 
-	apResources := AppProtectResources{}
-	result, warnings := generateNginxCfg(&cafeIngressEx, apResources, false, configParams, false, false,
+	result, warnings := generateNginxCfg(&cafeIngressEx, nil, nil, false, configParams, false, false,
 		&StaticConfigParams{NginxServiceMesh: true, EnableInternalRoutes: true}, false)
 
 	if diff := cmp.Diff(expected, result); diff != "" {
@@ -1349,7 +1340,7 @@ func TestGenerateNginxCfgForAppProtect(t *testing.T) {
 	isPlus := true
 
 	configParams := NewDefaultConfigParams(isPlus)
-	apRes := AppProtectResources{
+	apResources := &appProtectResources{
 		AppProtectPolicy:   "/etc/nginx/waf/nac-policies/default_dataguard-alarm",
 		AppProtectLogconfs: []string{"/etc/nginx/waf/nac-logconfs/default_logconf syslog:server=127.0.0.1:514"},
 	}
@@ -1364,7 +1355,7 @@ func TestGenerateNginxCfgForAppProtect(t *testing.T) {
 	expected.Servers[0].AppProtectLogEnable = "on"
 	expected.Ingress.Annotations = cafeIngressEx.Ingress.Annotations
 
-	result, warnings := generateNginxCfg(&cafeIngressEx, apRes, false, configParams, isPlus, false, staticCfgParams, false)
+	result, warnings := generateNginxCfg(&cafeIngressEx, apResources, nil, false, configParams, isPlus, false, staticCfgParams, false)
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("generateNginxCfg() returned unexpected result (-want +got):\n%s", diff)
 	}
@@ -1400,7 +1391,7 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtect(t *testing.T) {
 
 	isPlus := true
 	configParams := NewDefaultConfigParams(isPlus)
-	apRes := AppProtectResources{
+	apResources := &appProtectResources{
 		AppProtectPolicy:   "/etc/nginx/waf/nac-policies/default_dataguard-alarm",
 		AppProtectLogconfs: []string{"/etc/nginx/waf/nac-logconfs/default_logconf syslog:server=127.0.0.1:514"},
 	}
@@ -1415,7 +1406,7 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtect(t *testing.T) {
 	expected.Servers[0].AppProtectLogEnable = "on"
 	expected.Ingress.Annotations = mergeableIngresses.Master.Ingress.Annotations
 
-	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, apRes, configParams, isPlus, false, staticCfgParams, false)
+	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, apResources, nil, configParams, isPlus, false, staticCfgParams, false)
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("generateNginxCfgForMergeableIngresses() returned unexpected result (-want +got):\n%s", diff)
 	}
@@ -1447,7 +1438,7 @@ func TestGenerateNginxCfgForAppProtectDos(t *testing.T) {
 
 	isPlus := true
 	configParams := NewDefaultConfigParams(isPlus)
-	apRes := AppProtectResources{
+	dosResources := &appProtectDosResources{
 		AppProtectDosPolicy:   "/etc/nginx/dos/policies/default_policy",
 		AppProtectDosLogconfs: "/etc/nginx/dos/logconfs/default_logconf syslog:server=127.0.0.1:514",
 	}
@@ -1462,7 +1453,7 @@ func TestGenerateNginxCfgForAppProtectDos(t *testing.T) {
 	expected.Servers[0].AppProtectDosLogEnable = "on"
 	expected.Ingress.Annotations = cafeIngressEx.Ingress.Annotations
 
-	result, warnings := generateNginxCfg(&cafeIngressEx, apRes, false, configParams, isPlus, false, staticCfgParams, false)
+	result, warnings := generateNginxCfg(&cafeIngressEx, nil, dosResources, false, configParams, isPlus, false, staticCfgParams, false)
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("generateNginxCfg() returned unexpected result (-want +got):\n%s", diff)
 	}
@@ -1494,7 +1485,7 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtectDos(t *testing.T) {
 
 	isPlus := true
 	configParams := NewDefaultConfigParams(isPlus)
-	apRes := AppProtectResources{
+	apRes := &appProtectDosResources{
 		AppProtectDosPolicy:   "/etc/nginx/dos/policies/default_policy",
 		AppProtectDosLogconfs: "/etc/nginx/dos/logconfs/default_policy syslog:server=127.0.0.1:514",
 	}
@@ -1509,7 +1500,7 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtectDos(t *testing.T) {
 	expected.Servers[0].AppProtectDosLogEnable = "on"
 	expected.Ingress.Annotations = mergeableIngresses.Master.Ingress.Annotations
 
-	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, apRes, configParams, isPlus, false, staticCfgParams, false)
+	result, warnings := generateNginxCfgForMergeableIngresses(mergeableIngresses, nil, apRes, configParams, isPlus, false, staticCfgParams, false)
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("generateNginxCfgForMergeableIngresses() returned unexpected result (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
### Proposed changes

(1) Fix AppProtect resource names collisions. Previously if a VS/VSR referenced a waf or a dos policy, and that policy referenced both policy and log configuration resources with the same namespace and name, the IC would incorrectly assume that the policy didn't exist. (see https://github.com/nginxinc/kubernetes-ingress/pull/2004#discussion_r717105210 )
(2) Refactor NAP and DOS resource handling in Configurator. This is to make it consistent with the changes in (1)