### PR TITLE
Remove sync workflow from master

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,9 +1,12 @@
 name: Sync
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    branches: master
+    workflows:
+      - "Continuous Integration"
+    types:
+      - completed
 
 jobs:
   # This job sync this repo to our internal repo


### PR DESCRIPTION
Trigger the workflow after CI finishes. This will also remove the checks from master, making them more readable. I don't think they should be there in the first place since this worflow it's not code related.