### PR TITLE
fix issues with the 404 and robots.txts redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -34,14 +34,14 @@
 
 
 [[redirects]]
-  from = "https://nginx-kubernetes-ingress/robots.txt"
+  from = "/nginx-ingress-controller/robots.txt"
   to = "https://docs.nginx.com/robots.txt"
   status = 301
   force = true
 
 [[redirects]]
   from = "*"
-  to = "https://docs.nginx.com/404.html"
+  to = "/nginx-ingress-controller/404.html"
   status = 404
 
 


### PR DESCRIPTION
### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

This PR contains fixes for the docs redirects. Previously, we were seeing the Netlify 404 page for 404s found within docs.nginx.com/nginx-ingress-controller; with this fix, we should see the  docs-nginx-com 404 page. 

Previous:
![image](https://user-images.githubusercontent.com/12143793/136446031-ceb64982-6e28-4ed8-88ea-993ad62603d8.png)


Fixed:

![image](https://user-images.githubusercontent.com/12143793/136446205-d2b43c4e-b9b8-4bf2-ad84-030358f07e5c.png)


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
