### PR TITLE
Use default python image, bump to 3.10

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3
-FROM python:3.9-slim
+FROM python:3.10
 
 RUN apt-get update \
 	&& apt-get install -y curl git \

--- a/tests/docker/gitlab.Dockerfile
+++ b/tests/docker/gitlab.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3
-FROM python:3.9-slim
+FROM python:3.10
 
 ARG GCLOUD_VERSION=338.0.0
 


### PR DESCRIPTION
We don't have space constraints, we can use the default `python` image. 
Fixes error in https://github.com/nginxinc/kubernetes-ingress/pull/2050 due to missing package.
