### PR TITLE
Update JWT library to golang-jwt/jwt

### DIFF
--- a/cmd/nginx-ingress/aws.go
+++ b/cmd/nginx-ingress/aws.go
@@ -1,4 +1,4 @@
-// +build aws
+//go:build aws
 
 package main
 
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/marketplacemetering"
 	"github.com/aws/aws-sdk-go-v2/service/marketplacemetering/types"
 
-	"github.com/dgrijalva/jwt-go/v4"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 var (
@@ -61,49 +61,52 @@ func checkAWSEntitlement() error {
 		return err
 	}
 
-	pk, err := base64.StdEncoding.DecodeString(pubKeyString)
-	if err != nil {
-		return fmt.Errorf("error decoding Public Key string: %w", err)
-	}
-	pubKey, err := jwt.ParseRSAPublicKeyFromPEM(pk)
-	if err != nil {
-		return fmt.Errorf("error parsing Public Key: %w", err)
-	}
+	token, err := jwt.ParseWithClaims(*out.Signature, &claims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodRSAPSS); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
 
-	token, err := jwt.ParseWithClaims(*out.Signature, &claims{}, jwt.KnownKeyfunc(jwt.SigningMethodPS256, pubKey))
-	if err != nil {
-		return fmt.Errorf("error parsing the JWT token: %w", err)
-	}
+		pk, err := base64.StdEncoding.DecodeString(pubKeyString)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding Public Key string: %w", err)
+		}
+		pubKey, err := jwt.ParseRSAPublicKeyFromPEM(pk)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing Public Key: %w", err)
+		}
+
+		return pubKey, nil
+	})
 
 	if claims, ok := token.Claims.(*claims); ok && token.Valid {
 		if claims.ProductCode != productCode || claims.PublicKeyVersion != pubKeyVersion || claims.Nonce != nonce {
 			return fmt.Errorf("the claims in the JWT token don't match the request")
 		}
 	} else {
-		return fmt.Errorf("something is wrong with the JWT token")
+		return fmt.Errorf("something is wrong with the JWT token: %w", err)
 	}
-
 	return nil
 }
 
 type claims struct {
-	ProductCode      string    `json:"productCode,omitempty"`
-	PublicKeyVersion int32     `json:"publicKeyVersion,omitempty"`
-	IssuedAt         *jwt.Time `json:"iat,omitempty"`
-	Nonce            string    `json:"nonce,omitempty"`
+	ProductCode      string `json:"productCode,omitempty"`
+	PublicKeyVersion int32  `json:"publicKeyVersion,omitempty"`
+	Nonce            string `json:"nonce,omitempty"`
+	jwt.RegisteredClaims
 }
 
-func (c claims) Valid(h *jwt.ValidationHelper) error {
+func (c claims) Valid() error {
 	if c.Nonce == "" {
-		return &jwt.InvalidClaimsError{Message: "the JWT token doesn't include the Nonce"}
+		return jwt.NewValidationError("token doesn't include the Nonce", jwt.ValidationErrorClaimsInvalid)
 	}
 	if c.ProductCode == "" {
-		return &jwt.InvalidClaimsError{Message: "the JWT token doesn't include the ProductCode"}
+		return jwt.NewValidationError("token doesn't include the ProductCode", jwt.ValidationErrorClaimsInvalid)
 	}
 	if c.PublicKeyVersion == 0 {
-		return &jwt.InvalidClaimsError{Message: "the JWT token doesn't include the PublicKeyVersion"}
+		return jwt.NewValidationError("token doesn't include the PublicKeyVersion", jwt.ValidationErrorClaimsInvalid)
 	}
-	if err := h.ValidateNotBefore(c.IssuedAt); err != nil {
+
+	if err := c.RegisteredClaims.Valid(); err != nil {
 		return err
 	}
 

--- a/cmd/nginx-ingress/aws_test.go
+++ b/cmd/nginx-ingress/aws_test.go
@@ -1,0 +1,89 @@
+//go:build aws
+
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+func TestValidClaims(t *testing.T) {
+	iat := *jwt.NewNumericDate(time.Now().Add(time.Hour * -1))
+
+	c := claims{
+		"test",
+		1,
+		"nonce",
+		jwt.RegisteredClaims{
+			IssuedAt: &iat,
+		},
+	}
+	if err := c.Valid(); err != nil {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", nil, err)
+	}
+}
+
+func TestInvalidClaims(t *testing.T) {
+	badClaims := []struct {
+		c             claims
+		expectedError error
+	}{
+		{
+			claims{
+				"",
+				1,
+				"nonce",
+				jwt.RegisteredClaims{
+					IssuedAt: jwt.NewNumericDate(time.Now().Add(time.Hour * -1)),
+				},
+			},
+			errors.New("token doesn't include the ProductCode"),
+		},
+		{
+			claims{
+				"productCode",
+				1,
+				"",
+				jwt.RegisteredClaims{
+					IssuedAt: jwt.NewNumericDate(time.Now().Add(time.Hour * -1)),
+				},
+			},
+			errors.New("token doesn't include the Nonce"),
+		},
+		{
+			claims{
+				"productCode",
+				0,
+				"nonce",
+				jwt.RegisteredClaims{
+					IssuedAt: jwt.NewNumericDate(time.Now().Add(time.Hour * -1)),
+				},
+			},
+			errors.New("token doesn't include the PublicKeyVersion"),
+		},
+		{
+			claims{
+				"test",
+				1,
+				"nonce",
+				jwt.RegisteredClaims{
+					IssuedAt: jwt.NewNumericDate(time.Now().Add(time.Hour * +2)),
+				},
+			},
+			errors.New("token used before issued"),
+		},
+	}
+
+	for _, badC := range badClaims {
+
+		err := badC.c.Valid()
+		if err == nil {
+			t.Errorf("Valid() returned no error when it should have returned error %q", badC.expectedError)
+		} else if err.Error() != badC.expectedError.Error() {
+			t.Errorf("Valid() returned error %q when it should have returned error %q", err, badC.expectedError)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.8.2
 	github.com/aws/aws-sdk-go-v2/service/marketplacemetering v1.5.1
-	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
+	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/golang/glog v1.0.0
 	github.com/google/go-cmp v0.5.6
 	github.com/nginxinc/nginx-plus-go-client v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -145,10 +145,7 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=
-github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -220,6 +217,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.1.0 h1:XUgk2Ex5veyVFVeLm0xhusUTQybEbexJXrvPNOKkSY0=
+github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=


### PR DESCRIPTION
https://github.com/dgrijalva/jwt-go is no longer maintained, the development has moved to https://github.com/golang-jwt/jwt. 

This PR replaces the old library with the new one. Also added some simple unit tests for claims validation.
