### PR TITLE
Downgrade the gitlab test image to python 3.9

### DIFF
--- a/tests/docker/gitlab.Dockerfile
+++ b/tests/docker/gitlab.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3
-FROM python:3.10
+FROM python:3.9
 
-ARG GCLOUD_VERSION=338.0.0
+ARG GCLOUD_VERSION=360.0.0
 
 RUN apt-get update && apt-get install -y curl git jq \
 	&& curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \


### PR DESCRIPTION
Temp downgrade the gitlab test image to python 3.9 because of compatibility issues. Also upgrade gcloud to the latest.

### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
