### PR TITLE
Use the right sha in metadata for Update Docker Images action

### DIFF
--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -21,7 +21,8 @@ jobs:
     outputs:
       kic-tag: ${{ steps.kic.outputs.tag }}
       versions: ${{ steps.versions.outputs.matrix }}
-      sha_short: ${{ steps.vars.outputs.sha }}
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+      sha_long: ${{ steps.vars.outputs.sha_long }}
       go_version: ${{ steps.vars.outputs.go_version }}
       k8s_version: ${{ steps.vars.outputs.k8s_version }}
     steps:
@@ -37,7 +38,7 @@ jobs:
       - name: Checkout Repository at ${{ steps.kic.outputs.tag }}
         uses: actions/checkout@v2
         with:
-          ref: v${{ steps.kic.outputs.tag }}
+          ref: refs/tags/v${{ steps.kic.outputs.tag }}
       - name: Set NGINX versions
         id: versions
         run: |
@@ -48,7 +49,8 @@ jobs:
       - name: Set other variables
         id: vars
         run: |
-          echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=sha_long::$(git rev-parse HEAD)"
           echo "::set-output name=go_version::$(grep "go 1." go.mod | cut -d " " -f 2)"
           echo "::set-output name=k8s_version::$(grep "K8S_VERSION:" .github/workflows/ci.yml | awk -F" " '{print $2}')"
 
@@ -89,7 +91,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: v${{ needs.variables.outputs.kic-tag }}
+          ref: refs/tags/v${{ needs.variables.outputs.kic-tag }}
       - name: Setup Golang Environment
         uses: actions/setup-go@v2
         with:
@@ -138,7 +140,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
-          ref: v${{ needs.variables.outputs.kic-tag }}
+          ref: refs/tags/v${{ needs.variables.outputs.kic-tag }}
         if: ${{ matrix.needs-updating == 'true' }}
       - name: Fetch Cached Artifacts
         uses: actions/cache@v2
@@ -202,6 +204,7 @@ jobs:
             org.opencontainers.image.description=NGINX Ingress Controller for Kubernetes
             org.opencontainers.image.documentation=https://docs.nginx.com/nginx-ingress-controller
             org.opencontainers.image.vendor=NGINX Inc <kubernetes@nginx.com>
+            org.opencontainers.image.revision=${{ needs.variables.outputs.sha_long }}
         if: ${{ matrix.needs-updating == 'true' }}
       - name: Push to Dockerhub
         id: push
@@ -278,7 +281,7 @@ jobs:
                 },
                 {
                   title: "Commit Hash",
-                  value: "${{ needs.variables.outputs.sha_short }}",
+                  value: `<https://github.com/${{ github.repository }}/commit/${{ needs.variables.outputs.sha_long }}|${{ needs.variables.outputs.sha_short }}>`,
                   short: true
                 }],
                 footer: "Update DockerHub Image",


### PR DESCRIPTION
The metadata action uses the sha from the context when the workflow is triggered. This is fine for the other workflows where we checkout the code for the same sha.
In this workflow we checkout a different tag and we need the sha from that.
