### PR TITLE
Add tests label and category in changelog

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -40,9 +40,15 @@
 - color: cc317c
   description: An issue asking a question
   name: question
+- color: FEF2C0
+  description: Pull requests that don't need to be added to the changelog
+  name: skip-changelog
 - color: 8E7888
   description: Pull requests/issues with no activity
   name: stale
+- color: A4EF7D
+  description: Pull requests that update tests
+  name: tests
 - color: C2E0C6
   description: Waiting for author's response
   name: waiting for response

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,9 @@ categories:
   - title: '📝 Documentation'
     labels:
       - "documentation"
+  - title: '🧪 Tests'
+    labels:
+      - "tests"
   - title: '🔨 Maintenance'
     labels:
       - "chore"
@@ -32,6 +35,7 @@ version-resolver:
       - 'chore'
       - 'dependencies'
       - 'documentation'
+      - 'tests'
   default: patch
 exclude-labels:
   - 'skip-changelog'
@@ -41,6 +45,9 @@ autolabeler:
       - '*.md'
     branch:
       - '/docs{0,1}\/.+/'
+  - label: 'tests'
+    branch:
+      - '/tests\/.+/'
   - label: 'chore'
     branch:
       - '/chore\/.+/'


### PR DESCRIPTION
- Added label and category for PRs containing only tests
- Added skip-changelog label to the list so it can be used
