### PR TITLE
allow init containers, e.g. to deploy a crl file to nginx

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -170,6 +170,7 @@ Parameter | Description | Default
 `controller.affinity` | The affinity of the Ingress controller pods. | {}
 `controller.volumes` | The volumes of the Ingress controller pods. | []
 `controller.volumeMounts` | The volumeMounts of the Ingress controller pods. | []
+`controller.initContainers` | InitContainers for the Ingress controller pods. | []
 `controller.resources` | The resources of the Ingress controller pods. | {}
 `controller.replicaCount` | The number of replicas of the Ingress controller deployment. | 1
 `controller.ingressClass` | A class of the Ingress controller. An IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start. The Ingress controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class. The Ingress Controller processes all the VirtualServer/VirtualServerRoute/TransportServer resources that do not have the "ingressClassName" field for all versions of kubernetes. | nginx

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -170,7 +170,7 @@ Parameter | Description | Default
 `controller.affinity` | The affinity of the Ingress controller pods. | {}
 `controller.volumes` | The volumes of the Ingress controller pods. | []
 `controller.volumeMounts` | The volumeMounts of the Ingress controller pods. | []
-`controller.initContainers` | InitContainers for the Ingress controller pods. Useful for fetching crl files from a URL and copy the data to a mounted volume to crl.pem for using with nginx | []
+`controller.initContainers` | InitContainers for the Ingress controller pods. | []
 `controller.resources` | The resources of the Ingress controller pods. | {}
 `controller.replicaCount` | The number of replicas of the Ingress controller deployment. | 1
 `controller.ingressClass` | A class of the Ingress controller. An IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start. The Ingress controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class. The Ingress Controller processes all the VirtualServer/VirtualServerRoute/TransportServer resources that do not have the "ingressClassName" field for all versions of kubernetes. | nginx

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -170,7 +170,7 @@ Parameter | Description | Default
 `controller.affinity` | The affinity of the Ingress controller pods. | {}
 `controller.volumes` | The volumes of the Ingress controller pods. | []
 `controller.volumeMounts` | The volumeMounts of the Ingress controller pods. | []
-`controller.initContainers` | InitContainers for the Ingress controller pods. | []
+`controller.initContainers` | InitContainers for the Ingress controller pods. Useful for fetching crl files from a URL and copy the data to a mounted volume to crl.pem for using with nginx | []
 `controller.resources` | The resources of the Ingress controller pods. | {}
 `controller.replicaCount` | The number of replicas of the Ingress controller deployment. | 1
 `controller.ingressClass` | A class of the Ingress controller. An IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start. The Ingress controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class. The Ingress Controller processes all the VirtualServer/VirtualServerRoute/TransportServer resources that do not have the "ingressClassName" field for all versions of kubernetes. | nginx

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -156,4 +156,7 @@ spec:
           - -ready-status={{ .Values.controller.readyStatus.enable }}
           - -ready-status-port={{ .Values.controller.readyStatus.port }}
           - -enable-latency-metrics={{ .Values.controller.enableLatencyMetrics }}
+{{- if .Values.controller.initContainers }}
+      initContainers: {{ toYaml .Values.controller.initContainers | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -154,7 +154,7 @@ spec:
           - -ready-status={{ .Values.controller.readyStatus.enable }}
           - -ready-status-port={{ .Values.controller.readyStatus.port }}
           - -enable-latency-metrics={{ .Values.controller.enableLatencyMetrics }}
-{{- end }}
 {{- if .Values.controller.initContainers }}
       initContainers: {{ toYaml .Values.controller.initContainers | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -155,3 +155,6 @@ spec:
           - -ready-status-port={{ .Values.controller.readyStatus.port }}
           - -enable-latency-metrics={{ .Values.controller.enableLatencyMetrics }}
 {{- end }}
+{{- if .Values.controller.initContainers }}
+      initContainers: {{ toYaml .Values.controller.initContainers | nindent 8 }}
+{{- end }}

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -114,7 +114,17 @@ controller:
   #   mountPath: /etc/nginx/conf.d/extra.conf
   #   subPath: extra.conf
 
+  ## InitContainers for the Ingress controller pods.
+  ## Useful for fetching crl files from a URL and copy the data to a mounted volume to crl.pem for using with nginx
   initContainers: []
+  # - name: init-container
+  #   image: busybox:1.34
+  #   command: ['sh', '-c', 'wget http://example.com/crl.pem -O /data/pem/crl.pem']
+  #   volumeMounts:
+  #     - name: extra-volume
+  #       mountPath: /data/pem
+  # additionally then create a volume mount the crl.pem to /etc/nginx/crl.pem and add ssl_crl crl.pem; in the nginx config
+  # To update the crl file create a cron job with kubectl rollout restart deployment/{ nginx deployment name }
 
   ## The number of replicas of the Ingress controller deployment.
   replicaCount: 1

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -114,6 +114,8 @@ controller:
   #   mountPath: /etc/nginx/conf.d/extra.conf
   #   subPath: extra.conf
 
+  initContainers: []
+
   ## The number of replicas of the Ingress controller deployment.
   replicaCount: 1
 

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -115,16 +115,10 @@ controller:
   #   subPath: extra.conf
 
   ## InitContainers for the Ingress controller pods.
-  ## Useful for fetching crl files from a URL and copy the data to a mounted volume to crl.pem for using with nginx
   initContainers: []
   # - name: init-container
   #   image: busybox:1.34
-  #   command: ['sh', '-c', 'wget http://example.com/crl.pem -O /data/pem/crl.pem']
-  #   volumeMounts:
-  #     - name: extra-volume
-  #       mountPath: /data/pem
-  # additionally then create a volume mount the crl.pem to /etc/nginx/crl.pem and add ssl_crl crl.pem; in the nginx config
-  # To update the crl file create a cron job with kubectl rollout restart deployment/{ nginx deployment name }
+  #   command: ['sh', '-c', 'echo this is initial setup!']
 
   ## The number of replicas of the Ingress controller deployment.
   replicaCount: 1

--- a/docs/content/installation/installation-with-helm.md
+++ b/docs/content/installation/installation-with-helm.md
@@ -171,6 +171,7 @@ The following tables lists the configurable parameters of the NGINX Ingress cont
 |``controller.affinity`` | The affinity of the Ingress controller pods. | {} | 
 |``controller.volumes`` | The volumes of the Ingress controller pods. | [] | 
 |``controller.volumeMounts`` | The volumeMounts of the Ingress controller pods. | [] | 
+|``controller.initContainers`` | InitContainers for the Ingress controller pods. Useful for fetching crl files from a URL and copy the data to a mounted volume to crl.pem for using with nginx | []
 |``controller.resources`` | The resources of the Ingress controller pods. | {} | 
 |``controller.replicaCount`` | The number of replicas of the Ingress controller deployment. | 1 | 
 |``controller.ingressClass`` | A class of the Ingress controller. An IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start. The Ingress controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class. The Ingress Controller processes all the VirtualServer/VirtualServerRoute/TransportServer resources that do not have the "ingressClassName" field for all versions of kubernetes. | nginx |

--- a/docs/content/installation/installation-with-helm.md
+++ b/docs/content/installation/installation-with-helm.md
@@ -171,7 +171,7 @@ The following tables lists the configurable parameters of the NGINX Ingress cont
 |``controller.affinity`` | The affinity of the Ingress controller pods. | {} | 
 |``controller.volumes`` | The volumes of the Ingress controller pods. | [] | 
 |``controller.volumeMounts`` | The volumeMounts of the Ingress controller pods. | [] | 
-|``controller.initContainers`` | InitContainers for the Ingress controller pods. Useful for fetching crl files from a URL and copy the data to a mounted volume to crl.pem for using with nginx | []
+|``controller.initContainers`` | InitContainers for the Ingress controller pods. | []
 |``controller.resources`` | The resources of the Ingress controller pods. | {} | 
 |``controller.replicaCount`` | The number of replicas of the Ingress controller deployment. | 1 | 
 |``controller.ingressClass`` | A class of the Ingress controller. An IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start. The Ingress controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class. The Ingress Controller processes all the VirtualServer/VirtualServerRoute/TransportServer resources that do not have the "ingressClassName" field for all versions of kubernetes. | nginx |


### PR DESCRIPTION
### Proposed changes
For deploying crl files with size of several MBs to nginx we need an InitContainer. 
Our crl file is about 8 MB which can not be stored in a config map because of the size. Therfore we use an init container to provide the crl.
E. g.  here a values file snippet with an init container that copys a crl file to data/pem/crl.pem
```
  initContainers:
  - name: init-nginx
    image: xyz.dkr.ecr.eu-central-1.amazonaws.com/init-nginx:1.1.12 
    volumeMounts:
    - name: extra-volume
      mountPath: /data/pem
  volumeMounts:
  - name: extra-volume
    mountPath: /etc/nginx/crl.pem
    subPath: crl.pem
  volumes:
  - name: extra-volume
    emptyDir: {}
```

The corresponding ingress yaml snippet is 
```
metadata:
  annotations:
    nginx.org/server-snippets: |
      ssl_verify_client optional;
      ssl_verify_depth 2;
      ssl_crl crl.pem;
      ...
 ```
     
Additionally we use a cronjob which does a kubectl rollout restart of the deployment so that new crl files are used by nginx. Would be nice, if this is supported by the helm chart.