### PR TITLE
fix: DOCOPS-408 broken image

### DIFF
--- a/docs/content/intro/how-nginx-ingress-controller-works.md
+++ b/docs/content/intro/how-nginx-ingress-controller-works.md
@@ -108,7 +108,7 @@ This section covers the architecture of the IC process, including:
 
 The following diagram depicts how the IC processes a new Ingress resource. We represent the NGINX master and worker processes as a single rectangle *NGINX* for simplicity. Also, note that VirtualServer and VirtualServerRoute resources are processed similarly.
 
-{< img title="IC process" src="./img/ic-process.png" >}}
+{{< img title="IC process" src="./img/ic-process.png" >}}
 
 Processing a new Ingress resource involves the following steps, where each step corresponds to the arrow on the diagram with the same number:
 


### PR DESCRIPTION
### Proposed changes
Correct broken image in https://docs.nginx.com/nginx-ingress-controller/intro/how-nginx-ingress-controller-works/#the-ingress-controller-process

![image](https://user-images.githubusercontent.com/78599298/137746699-d9c7f9cc-ffb9-4e6f-89c2-242a53d48f1b.png)

