### PR TITLE
Allow empty string in server-tokens annotation for NGINX Plus

### DIFF
--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -111,7 +111,6 @@ var (
 			validateTimeAnnotation,
 		},
 		serverTokensAnnotation: {
-			validateRequiredAnnotation,
 			validateServerTokensAnnotation,
 		},
 		serverSnippetsAnnotation:   {},


### PR DESCRIPTION
- An empty value with NGINX OSS will now return `annotations.nginx.org/server-tokens: Invalid value: "": must be a boolean` instead of `default/cafe-ingress was rejected: with error: annotations.nginx.org/server-tokens: Required value`
- An empty value with NGINX Plus is valid.