### PR TITLE
fix: DOCOPS-404 add a note about ingress only parameter

### DIFF
--- a/docs/content/configuration/global-configuration/command-line-arguments.md
+++ b/docs/content/configuration/global-configuration/command-line-arguments.md
@@ -38,6 +38,8 @@ Format: `<namespace>/<name>`
 
 ### -wildcard-tls-secret `<string>`
 
+This parameter works with **Ingress resources only**.
+
 A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified.
 
 * If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection.


### PR DESCRIPTION
### Proposed changes
Add a callout to the `cmdoption-wildcard-tls-secret` parameter indicating it only works with `Ingress` resources.
![image](https://user-images.githubusercontent.com/78599298/139118877-e3f64b3d-ede6-48dd-86ca-5313f663e9ec.png)


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
