### PR TITLE
Pin trivy scanner to v0.0.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
             BUILD_OS=${{ matrix.image }}
             IC_VERSION=${{ steps.var.outputs.ic_version }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.0.21
         continue-on-error: true
         with:
           image-ref: nginx/nginx-ingress:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}


### PR DESCRIPTION
### Proposed changes
All the known vulnerabilities are being reported in the security tab, even if they have no fixes, and it looks to be because of a change made in the trivy action to always report all vulnerabilities in the sarif file (see https://github.com/aquasecurity/trivy-action/pull/73/files).

Pinning the trivy scanner to the previous version resolves the issue.


