### PR TITLE
Add metric about total number of TransportServers

### DIFF
--- a/docs/content/logging-and-monitoring/prometheus.md
+++ b/docs/content/logging-and-monitoring/prometheus.md
@@ -49,6 +49,7 @@ The Ingress Controller exports the following metrics:
   * `controller_ingress_resources_total`. Number of handled Ingress resources. This metric includes the label type, that groups the Ingress resources by their type (regular, [minion or master](/nginx-ingress-controller/configuration/ingress-resources/cross-namespace-configuration)). **Note**: The metric doesn't count minions without a master.
   * `controller_virtualserver_resources_total`. Number of handled VirtualServer resources.
   * `controller_virtualserverroute_resources_total`. Number of handled VirtualServerRoute resources. **Note**: The metric counts only VirtualServerRoutes that have a reference from a VirtualServer.
+  * `controller_transportserver_resources_total`. Number of handled TransportServer resources. This metric includes the label type, that groups the TransportServer resources by their type (passthrough, tcp or udp).
   * Workqueue metrics. **Note**: the workqueue is a queue used by the Ingress Controller to process changes to the relevant resources in the cluster like Ingress resources. The Ingress Controller uses only one queue. The metrics for that queue will have the label `name="taskQueue"`
     * `workqueue_depth`. Current depth of the workqueue.
     * `workqueue_queue_duration_second`. How long in seconds an item stays in the workqueue before being requested.

--- a/tests/data/prometheus/transport-server/global-configuration.yaml
+++ b/tests/data/prometheus/transport-server/global-configuration.yaml
@@ -1,0 +1,12 @@
+apiVersion: k8s.nginx.org/v1alpha1
+kind: GlobalConfiguration 
+metadata:
+  name: nginx-configuration
+spec:
+  listeners:
+  - name: tcp-server
+    port: 3333
+    protocol: TCP
+  - name: udp-server
+    port: 3333
+    protocol: UDP

--- a/tests/data/prometheus/transport-server/passthrough.yaml
+++ b/tests/data/prometheus/transport-server/passthrough.yaml
@@ -1,0 +1,15 @@
+apiVersion: k8s.nginx.org/v1alpha1
+kind: TransportServer
+metadata:
+  name: passthrough
+spec:
+  listener:
+    name: tls-passthrough
+    protocol: TLS_PASSTHROUGH
+  host: app.example.com
+  upstreams:
+    - name: secure-app
+      service: secure-app
+      port: 8443
+  action:
+    pass: secure-app

--- a/tests/data/prometheus/transport-server/tcp.yaml
+++ b/tests/data/prometheus/transport-server/tcp.yaml
@@ -1,0 +1,14 @@
+apiVersion: k8s.nginx.org/v1alpha1
+kind: TransportServer
+metadata:
+  name: tcp
+spec:
+  listener:
+    name: tcp-server
+    protocol: TCP
+  upstreams:
+    - name: tcp-app
+      service: tcp-service
+      port: 3333
+  action:
+    pass: tcp-app

--- a/tests/data/prometheus/transport-server/udp.yaml
+++ b/tests/data/prometheus/transport-server/udp.yaml
@@ -1,0 +1,14 @@
+apiVersion: k8s.nginx.org/v1alpha1
+kind: TransportServer
+metadata:
+  name: udp
+spec:
+  listener:
+    name: udp-server
+    protocol: UDP
+  upstreams:
+    - name: udp-app
+      service: udp-service
+      port: 3333
+  action:
+    pass: udp-app

--- a/tests/suite/custom_resources_utils.py
+++ b/tests/suite/custom_resources_utils.py
@@ -226,7 +226,7 @@ def delete_resource(custom_objects: CustomObjectsApi, resource, namespace, plura
     print(f"Resource '{kind}' was removed with name '{name}'")
 
 
-def patch_ts(
+def patch_ts_from_yaml(
         custom_objects: CustomObjectsApi, name, yaml_manifest, namespace
 ) -> None:
     """
@@ -246,6 +246,22 @@ def patch_custom_resource_v1alpha1(custom_objects: CustomObjectsApi, name, yaml_
     try:
         custom_objects.patch_namespaced_custom_object(
             "k8s.nginx.org", "v1alpha1", namespace, plural, name, dep
+        )
+    except ApiException:
+        logging.exception(f"Failed with exception while patching custom resource: {name}")
+        raise
+
+def patch_ts(custom_objects: CustomObjectsApi, namespace, body) -> None:
+    """
+    Patch a TransportServer
+    """
+    name = body['metadata']['name']
+
+    print(f"Update a Resource: {name}")
+
+    try:
+        custom_objects.patch_namespaced_custom_object(
+            "k8s.nginx.org", "v1alpha1", namespace, "transportservers", name, body
         )
     except ApiException:
         logging.exception(f"Failed with exception while patching custom resource: {name}")

--- a/tests/suite/test_transport_server.py
+++ b/tests/suite/test_transport_server.py
@@ -5,7 +5,7 @@ from suite.resources_utils import (
     get_ts_nginx_template_conf,
 )
 from suite.custom_resources_utils import (
-    patch_ts,
+    patch_ts_from_yaml,
 )
 from settings import TEST_DATA
 
@@ -36,7 +36,7 @@ class TestTransportServer:
         Test snippets are present in conf when enabled
         """
         patch_src = f"{TEST_DATA}/transport-server/transport-server-snippets.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -54,7 +54,7 @@ class TestTransportServer:
         print(conf)
 
         std_src = f"{TEST_DATA}/transport-server-status/standard/transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             std_src,
@@ -73,7 +73,7 @@ class TestTransportServer:
         Test session and upstream configurable timeouts are present in conf
         """
         patch_src = f"{TEST_DATA}/transport-server/transport-server-configurable-timeouts.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -91,7 +91,7 @@ class TestTransportServer:
         print(conf)
 
         std_src = f"{TEST_DATA}/transport-server-status/standard/transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             std_src,

--- a/tests/suite/test_transport_server_status.py
+++ b/tests/suite/test_transport_server_status.py
@@ -3,7 +3,7 @@ import pytest
 from suite.resources_utils import wait_before_test
 from suite.custom_resources_utils import (
     read_ts,
-    patch_ts,
+    patch_ts_from_yaml,
 )
 from settings import TEST_DATA
 
@@ -33,7 +33,7 @@ class TestTransportServerStatus:
         Function to revert a TransportServer resource to a valid state.
         """
         patch_src = f"{TEST_DATA}/transport-server-status/standard/transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -65,7 +65,7 @@ class TestTransportServerStatus:
         Test TransportServer status with a missing listener.
         """
         patch_src = f"{TEST_DATA}/transport-server-status/rejected-warning.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -91,7 +91,7 @@ class TestTransportServerStatus:
         Test TransportServer status with an invalid protocol.
         """
         patch_src = f"{TEST_DATA}/transport-server-status/rejected-invalid.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,

--- a/tests/suite/test_transport_server_tcp_load_balance.py
+++ b/tests/suite/test_transport_server_tcp_load_balance.py
@@ -13,7 +13,7 @@ from suite.resources_utils import (
     wait_for_event_increment,
 )
 from suite.custom_resources_utils import (
-    patch_ts,
+    patch_ts_from_yaml,
     read_ts,
     delete_ts,
     create_ts_from_yaml,
@@ -46,7 +46,7 @@ class TestTransportServerTcpLoadBalance:
         Function to revert a TransportServer resource to a valid state.
         """
         patch_src = f"{TEST_DATA}/transport-server-tcp-load-balance/standard/transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -236,7 +236,7 @@ class TestTransportServerTcpLoadBalance:
         """
 
         patch_src = f"{TEST_DATA}/transport-server-tcp-load-balance/wrong-port-transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -267,7 +267,7 @@ class TestTransportServerTcpLoadBalance:
         """
 
         patch_src = f"{TEST_DATA}/transport-server-tcp-load-balance/missing-service-transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -310,7 +310,7 @@ class TestTransportServerTcpLoadBalance:
 
         # step 1 - set max connections to 2 with 1 replica
         patch_src = f"{TEST_DATA}/transport-server-tcp-load-balance/max-connections-transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -358,7 +358,7 @@ class TestTransportServerTcpLoadBalance:
 
         # step 4 - revert to config with no max connections
         patch_src = f"{TEST_DATA}/transport-server-tcp-load-balance/standard/transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -386,7 +386,7 @@ class TestTransportServerTcpLoadBalance:
         # Step 1 - set the load balancing method.
 
         patch_src = f"{TEST_DATA}/transport-server-tcp-load-balance/method-transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -474,7 +474,7 @@ class TestTransportServerTcpLoadBalance:
         # Step 1 - configure a passing health check
 
         patch_src = f"{TEST_DATA}/transport-server-tcp-load-balance/passing-hc-transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -539,7 +539,7 @@ class TestTransportServerTcpLoadBalance:
         # Step 1 - configure a failing health check
 
         patch_src = f"{TEST_DATA}/transport-server-tcp-load-balance/failing-hc-transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,

--- a/tests/suite/test_transport_server_udp_load_balance.py
+++ b/tests/suite/test_transport_server_udp_load_balance.py
@@ -10,7 +10,7 @@ from suite.resources_utils import (
     wait_for_event_increment,
 )
 from suite.custom_resources_utils import (
-    patch_ts,
+    patch_ts_from_yaml,
     read_ts,
     delete_ts,
     create_ts_from_yaml,
@@ -43,7 +43,7 @@ class TestTransportServerUdpLoadBalance:
         Function to revert a TransportServer resource to a valid state.
         """
         patch_src = f"{TEST_DATA}/transport-server-udp-load-balance/standard/transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -223,7 +223,7 @@ class TestTransportServerUdpLoadBalance:
             self, kube_apis, crd_ingress_controller, transport_server_setup, file
     ):
         patch_src = f"{TEST_DATA}/transport-server-udp-load-balance/{file}"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -263,7 +263,7 @@ class TestTransportServerUdpLoadBalance:
         # Step 1 - configure a passing health check
 
         patch_src = f"{TEST_DATA}/transport-server-udp-load-balance/passing-hc-transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,
@@ -331,7 +331,7 @@ class TestTransportServerUdpLoadBalance:
         # Step 1 - configure a failing health check
 
         patch_src = f"{TEST_DATA}/transport-server-udp-load-balance/failing-hc-transport-server.yaml"
-        patch_ts(
+        patch_ts_from_yaml(
             kube_apis.custom_objects,
             transport_server_setup.name,
             patch_src,


### PR DESCRIPTION
### Proposed changes

Add a new Prometheus metric about TransportServers:
`controller_transportserver_resources_total`. Number of handled TransportServer resources. This metric includes the label type, that groups the TransportServer resources by their type (passthrough, tcp or udp).

