### PR TITLE
fix: broken image

### DIFF
--- a/docs/content/intro/how-nginx-ingress-controller-works.md
+++ b/docs/content/intro/how-nginx-ingress-controller-works.md
@@ -108,7 +108,7 @@ This section covers the architecture of the IC process, including:
 
 The following diagram depicts how the IC processes a new Ingress resource. We represent the NGINX master and worker processes as a single rectangle *NGINX* for simplicity. Also, note that VirtualServer and VirtualServerRoute resources are processed similarly.
 
-{< img title="IC process" src="./img/ic-process.png" >}}
+{{< img title="IC process" src="./img/ic-process.png" >}}
 
 Processing a new Ingress resource involves the following steps, where each step corresponds to the arrow on the diagram with the same number:
 


### PR DESCRIPTION
Fixes the img shortcode in how-nginx-ingress-controller-works to restore the image

### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork


current state:
![2021-11-02_13-53-25](https://user-images.githubusercontent.com/12143793/139942811-8c2662d7-c367-4092-822b-f68859394362.png)


after fix:
![2021-11-02_13-54-11](https://user-images.githubusercontent.com/12143793/139942875-2774fb6f-5259-4f44-8c68-70f3ccb0148f.png)

