### PR TITLE
Reject VS with empty TLS secret reference

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -605,7 +605,7 @@ func main() {
 	controllerNamespace := os.Getenv("POD_NAMESPACE")
 
 	transportServerValidator := cr_validation.NewTransportServerValidator(*enableTLSPassthrough, *enableSnippets, *nginxPlus)
-	virtualServerValidator := cr_validation.NewVirtualServerValidator(*nginxPlus)
+	virtualServerValidator := cr_validation.NewVirtualServerValidator(*nginxPlus, isWildcardEnabled)
 
 	lbcInput := k8s.NewLoadBalancerControllerInput{
 		KubeClient:                   kubeClient,

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -2036,6 +2036,7 @@ func (vsc *virtualServerConfigurator) generateSSLConfig(owner runtime.Object, tl
 			}
 			return &ssl
 		}
+		// this case isn't allowed by validation (VirtualServerValidator)
 		return nil
 	}
 

--- a/internal/k8s/configuration_test.go
+++ b/internal/k8s/configuration_test.go
@@ -21,13 +21,14 @@ func createTestConfiguration() *Configuration {
 	appProtectEnabled := false
 	internalRoutesEnabled := false
 	isTLSPassthroughEnabled := true
+	isWildcardTLSSecretEnabled := false
 	snippetsEnabled := true
 	return NewConfiguration(
 		lbc.HasCorrectIngressClass,
 		isPlus,
 		appProtectEnabled,
 		internalRoutesEnabled,
-		validation.NewVirtualServerValidator(isTLSPassthroughEnabled),
+		validation.NewVirtualServerValidator(isTLSPassthroughEnabled, isWildcardTLSSecretEnabled),
 		validation.NewGlobalConfigurationValidator(map[int]bool{
 			80:  true,
 			443: true,


### PR DESCRIPTION
This PR ensures that if the tls section is configured in a VirtualServer, than the secret field must not be empty, unless the wildcard TLS secret is enabled via the -wildcard-tls-secret cli argument.
