### PR TITLE
Generate error page warnings for gRPC upstreams

### DIFF
--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -340,6 +340,28 @@ server {
             {{ end }}
         {{ end }}
 
+            {{ if $l.GRPCPass }}
+        error_page 400 = @grpc_internal;
+        error_page 401 = @grpc_unauthenticated;
+        error_page 403 = @grpc_permission_denied;
+        error_page 404 = @grpc_unimplemented;
+        error_page 429 = @grpc_unavailable;
+        error_page 502 = @grpc_unavailable;
+        error_page 503 = @grpc_unavailable;
+        error_page 504 = @grpc_unavailable;
+        error_page 405 = @grpc_internal;
+        error_page 408 = @grpc_deadline_exceeded;
+        error_page 413 = @grpc_resource_exhausted;
+        error_page 414 = @grpc_resource_exhausted;
+        error_page 415 = @grpc_internal;
+        error_page 426 = @grpc_internal;
+        error_page 495 = @grpc_unauthenticated;
+        error_page 496 = @grpc_unauthenticated;
+        error_page 497 = @grpc_internal;
+        error_page 500 = @grpc_internal;
+        error_page 501 = @grpc_internal;
+            {{ end }}
+
         {{ range $e := $l.ErrorPages }}
         error_page {{ $e.Codes }} {{ if ne 0 $e.ResponseCode }}={{ $e.ResponseCode }}{{ end }} "{{ $e.Name }}";
         {{ end }}
@@ -371,28 +393,6 @@ server {
             {{ end }}
             {{ if $l.ProxyBufferSize }}
         {{ $proxyOrGRPC }}_buffer_size {{ $l.ProxyBufferSize }};
-            {{ end }}
-        
-            {{ if $l.GRPCPass }}
-        error_page 400 = @grpc_internal;
-        error_page 401 = @grpc_unauthenticated;
-        error_page 403 = @grpc_permission_denied;
-        error_page 404 = @grpc_unimplemented;
-        error_page 429 = @grpc_unavailable;
-        error_page 502 = @grpc_unavailable;
-        error_page 503 = @grpc_unavailable;
-        error_page 504 = @grpc_unavailable;
-        error_page 405 = @grpc_internal;
-        error_page 408 = @grpc_deadline_exceeded;
-        error_page 413 = @grpc_resource_exhausted;
-        error_page 414 = @grpc_resource_exhausted;
-        error_page 415 = @grpc_internal;
-        error_page 426 = @grpc_internal;
-        error_page 495 = @grpc_unauthenticated;
-        error_page 496 = @grpc_unauthenticated;
-        error_page 497 = @grpc_internal;
-        error_page 500 = @grpc_internal;
-        error_page 501 = @grpc_internal;
             {{ end }}
 
             {{ if not $l.GRPCPass }}

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -244,6 +244,28 @@ server {
         {{ $proxyOrGRPC }}_ssl_name {{ .SSLName }};
         {{ end }}
 
+            {{ if $l.GRPCPass }}
+        error_page 400 = @grpc_internal;
+        error_page 401 = @grpc_unauthenticated;
+        error_page 403 = @grpc_permission_denied;
+        error_page 404 = @grpc_unimplemented;
+        error_page 429 = @grpc_unavailable;
+        error_page 502 = @grpc_unavailable;
+        error_page 503 = @grpc_unavailable;
+        error_page 504 = @grpc_unavailable;
+        error_page 405 = @grpc_internal;
+        error_page 408 = @grpc_deadline_exceeded;
+        error_page 413 = @grpc_resource_exhausted;
+        error_page 414 = @grpc_resource_exhausted;
+        error_page 415 = @grpc_internal;
+        error_page 426 = @grpc_internal;
+        error_page 495 = @grpc_unauthenticated;
+        error_page 496 = @grpc_unauthenticated;
+        error_page 497 = @grpc_internal;
+        error_page 500 = @grpc_internal;
+        error_page 501 = @grpc_internal;
+            {{ end }}
+
         {{ range $e := $l.ErrorPages }}
         error_page {{ $e.Codes }} {{ if ne 0 $e.ResponseCode }}={{ $e.ResponseCode }}{{ end }} "{{ $e.Name }}";
         {{ end }}
@@ -275,28 +297,6 @@ server {
             {{ end }}
             {{ if $l.ProxyBufferSize }}
         {{ $proxyOrGRPC }}_buffer_size {{ $l.ProxyBufferSize }};
-            {{ end }}
-        
-            {{ if $l.GRPCPass }}
-        error_page 400 = @grpc_internal;
-        error_page 401 = @grpc_unauthenticated;
-        error_page 403 = @grpc_permission_denied;
-        error_page 404 = @grpc_unimplemented;
-        error_page 429 = @grpc_unavailable;
-        error_page 502 = @grpc_unavailable;
-        error_page 503 = @grpc_unavailable;
-        error_page 504 = @grpc_unavailable;
-        error_page 405 = @grpc_internal;
-        error_page 408 = @grpc_deadline_exceeded;
-        error_page 413 = @grpc_resource_exhausted;
-        error_page 414 = @grpc_resource_exhausted;
-        error_page 415 = @grpc_internal;
-        error_page 426 = @grpc_internal;
-        error_page 495 = @grpc_unauthenticated;
-        error_page 496 = @grpc_unauthenticated;
-        error_page 497 = @grpc_internal;
-        error_page 500 = @grpc_internal;
-        error_page 501 = @grpc_internal;
             {{ end }}
 
             {{ if not $l.GRPCPass }}

--- a/tests/data/virtual-server-grpc/virtual-server-error-page.yaml
+++ b/tests/data/virtual-server-grpc/virtual-server-error-page.yaml
@@ -1,0 +1,29 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  tls:
+    secret: virtual-server-tls-grpc-secret
+  upstreams:
+  - name: grpc1
+    service: grpc1-svc
+    port: 50051
+    type: grpc
+  - name: grpc2
+    service: grpc2-svc
+    port: 50051
+    type: grpc
+  routes:
+  - path: "/helloworld.Greeter"
+    action:
+      pass: grpc1
+    errorPages:
+    - codes: [404]
+      return:
+        code: 200
+        body: "Original resource not found, but success!"
+  - path: "/notimplemented"
+    action:
+      pass: grpc2


### PR DESCRIPTION
### Proposed changes
Generate an error when a user configures one or more gRPC Upstreams in the VirtualServer resource with a custom error page which conflicts with the ones generated for a gRPC upstream (one of 400, 401, 403, 404, 405, 408, 413, 414, 415, 426, 429, 495, 496, 497, 500, 501, 502, 503, 504)

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
