### PR TITLE
Add Alpine image with OpenTracing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
             echo "::set-output name=matrix::{\"images\": \
                                                 [{\"image\": \"debian\", \"marker\": \"ingresses\"}, \
                                                 {\"image\": \"alpine\", \"marker\":\"vsr\"}, \
+                                                {\"image\": \"alpine-opentracing\", \"marker\":\"ingresses\"}, \
                                                 {\"image\": \"opentracing\", \"marker\": \"vs\"}, \
                                                 {\"image\": \"ubi\", \"marker\": \"ts\"}, \
                                                 {\"image\": \"debian\", \"marker\": \"policies\"}]}"
@@ -286,7 +287,7 @@ jobs:
     needs: build-binaries
     strategy:
         matrix:
-          image: [debian, alpine, opentracing]
+          image: [debian, alpine, opentracing, alpine-opentracing]
           platforms: ["linux/arm, linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"]
           include:
             - image: ubi
@@ -336,7 +337,7 @@ jobs:
             nginx/nginx-ingress
             ghcr.io/nginxinc/kubernetes-ingress
             public.ecr.aws/nginx/nginx-ingress
-          flavor: suffix=${{ matrix.image != 'debian' && '-' || '' }}${{ matrix.image != 'debian' && matrix.image != 'opentracing' && matrix.image || '' }}${{ matrix.image == 'opentracing' && 'ot' || '' }},onlatest=true
+          flavor: suffix=${{ matrix.image == 'ubi' && '-ubi' || '' }}${{ contains(matrix.image, 'alpine') && '-alpine' || '' }}${{ contains(matrix.image, 'opentracing') && '-ot' || '' }},onlatest=true
           tags: |
             type=edge
             type=ref,event=pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,9 @@ jobs:
             echo "::set-output name=matrix::{\"images\": \
                                                 [{\"image\": \"debian\", \"marker\": \"ingresses\"}, \
                                                 {\"image\": \"alpine\", \"marker\":\"vsr\"}, \
-                                                {\"image\": \"alpine-opentracing\", \"marker\":\"ingresses\"}, \
+                                                {\"image\": \"alpine-opentracing\", \"marker\":\"policies\"}, \
                                                 {\"image\": \"opentracing\", \"marker\": \"vs\"}, \
-                                                {\"image\": \"ubi\", \"marker\": \"ts\"}, \
-                                                {\"image\": \"debian\", \"marker\": \"policies\"}]}"
+                                                {\"image\": \"ubi\", \"marker\": \"ts\"}]}"
           else
             echo "::set-output name=matrix::{\"k8s\": [\"1.19.11\", \"1.20.7\", \"1.21.2\", \"1.22.2\"]}"
           fi

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ openshift-image-plus: build ## Create Docker image for Ingress Controller (UBI w
 openshift-image-nap-plus: build ## Create Docker image for Ingress Controller (UBI with NGINX Plus and App Protect WAF)
 	$(DOCKER_CMD) $(PLUS_ARGS) --secret id=rhel_license,src=rhel_license --build-arg BUILD_OS=ubi-plus-nap --build-arg UBI_VERSION=7
 
+.PHONY: alpine-image-opentracing
+alpine-image-opentracing: build ## Create Docker image for Ingress Controller (Alpine with OpenTracing)
+	$(DOCKER_CMD) --build-arg BUILD_OS=alpine-opentracing
+
 .PHONY: debian-image-opentracing
 debian-image-opentracing: build ## Create Docker image for Ingress Controller (Debian with OpenTracing)
 	$(DOCKER_CMD) --build-arg BUILD_OS=opentracing

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -163,11 +163,20 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 # RUN update-ca-trust extract
 
 
-############################################# Base image containing libs for Opentracing #############################################
+############################################# Base images containing libs for Opentracing #############################################
 FROM opentracing/nginx-opentracing:nginx-1.21.4 as opentracing-lib
+FROM docker.io/opentracing/nginx-opentracing:nginx-1.21.4-alpine as alpine-opentracing-lib
 
 
-############################################# Build image for Opentracing #############################################
+############################################# Build image for Alpine with Opentracing #############################################
+FROM alpine as alpine-opentracing
+
+RUN --mount=type=bind,from=alpine-opentracing-lib,target=/tmp/ cp -av /tmp/usr/local/lib/libopentracing.so* /tmp/usr/local/lib/libjaegertracing*so* /tmp/usr/local/lib/libzipkin*so* /tmp/usr/local/lib/libdd*so* /tmp/usr/local/lib/libyaml*so* /usr/local/lib/ \
+	&& cp -av /tmp/usr/lib/nginx/modules/ngx_http_opentracing_module.so /usr/lib/nginx/modules/ \
+	&& ldconfig /usr/local/lib/
+
+
+############################################# Build image for Debian with Opentracing #############################################
 FROM debian as opentracing
 
 RUN --mount=type=bind,from=opentracing-lib,target=/tmp/ cp -av /tmp/usr/local/lib/libopentracing.so* /tmp/usr/local/lib/libjaegertracing*so* /tmp/usr/local/lib/libzipkin*so* /tmp/usr/local/lib/libdd*so* /tmp/usr/local/lib/libyaml*so* /usr/local/lib/ \

--- a/docs/content/technical-specifications.md
+++ b/docs/content/technical-specifications.md
@@ -27,8 +27,9 @@ All images include NGINX 1.21.4.
 |Name | Base image | Third-party modules | DockerHub image | Architectures |
 | ---| ---| ---| --- | --- |
 |Alpine-based image | ``nginx:1.21.4-alpine``, which is based on ``alpine:3.14`` |  | ``nginx/nginx-ingress:2.0.3-alpine`` | arm/v7, arm64, amd64, ppc64le, s390x |
+|Alpine-based image with OpenTracing | ``nginx:1.21.4-alpine``, which is based on ``alpine:3.14`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:2.0.3-alpine-ot`` | arm/v7, arm64, amd64, ppc64le, s390x |
 |Debian-based image | ``nginx:1.21.4``, which is based on ``debian:bullseye-slim`` |  | ``nginx/nginx-ingress:2.0.3`` | arm/v7, arm64, amd64, ppc64le, s390x |
-|Debian-based image with Opentracing | ``nginx:1.21.4``, which is based on ``debian:bullseye-slim`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:2.0.3-ot`` | arm/v7, arm64, amd64, ppc64le, s390x |
+|Debian-based image with OpenTracing | ``nginx:1.21.4``, which is based on ``debian:bullseye-slim`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:2.0.3-ot`` | arm/v7, arm64, amd64, ppc64le, s390x |
 |Ubi-based image | ``redhat/ubi8-minimal`` |  | ``nginx/nginx-ingress:2.0.3-ubi`` | arm64, amd64 |
 {{% /table %}}
 
@@ -44,7 +45,7 @@ NGINX Plus images are available through the F5 Container registry `private-regis
 | ---| ---| --- | --- |
 |Alpine-based image | ``alpine:3.14`` | NGINX Plus JavaScript module | `nginx-ic/nginx-plus-ingress:2.0.3-alpine` |
 |Debian-based image | ``debian:bullseye-slim`` | NGINX Plus JavaScript module | `nginx-ic/nginx-plus-ingress:2.0.3` |
-|Debian-based image with Opentracing | ``debian:bullseye-slim`` | NGINX Plus OpenTracing module, OpenTracing tracers for Jaeger, Zipkin and Datadog; NGINX Plus JavaScript module | `nginx-ic/nginx-plus-ingress:2.0.3-ot` |
+|Debian-based image with OpenTracing | ``debian:bullseye-slim`` | NGINX Plus OpenTracing module, OpenTracing tracers for Jaeger, Zipkin and Datadog; NGINX Plus JavaScript module | `nginx-ic/nginx-plus-ingress:2.0.3-ot` |
 |Debian-based image with App Protect | ``debian:buster-slim`` | NGINX Plus App Protect module; NGINX Plus JavaScript module | `nginx-ic-nap/nginx-plus-ingress:2.0.3` |
 |Ubi-based image | ``redhat/ubi8-minimal`` | NGINX Plus JavaScript module | `nginx-ic/nginx-plus-ingress:2.0.3-ubi` |
 |Ubi-based image with App Protect | ``registry.access.redhat.com/ubi7/ubi`` | NGINX Plus App Protect module; NGINX Plus JavaScript module | `nginx-ic-nap/nginx-plus-ingress:2.0.3-ubi` |


### PR DESCRIPTION
After https://github.com/opentracing-contrib/nginx-opentracing/pull/209 and release https://github.com/opentracing-contrib/nginx-opentracing/releases/tag/v0.22.0 OpenTracing builds modules and tracers for Alpine based images.

This PR adds a new Alpine based Docker image that uses the new Alpine based OpenTracing libraries and tracers.
