### PR TITLE
add target for NGINX Plus Debian with opentracing and NAP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ export DOCKER_BUILDKIT = 1
 
 .PHONY: help
 help: ## Display this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "; printf "Usage:\n\n    make \033[36m<target>\033[0m [VARIABLE=value...]\n\nTargets:\n\n"}; {printf "    \033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "; printf "Usage:\n\n    make \033[36m<target>\033[0m [VARIABLE=value...]\n\nTargets:\n\n"}; {printf "    \033[36m%-35s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: all
 all: test lint verify-codegen update-crds debian-image
@@ -100,6 +100,10 @@ debian-image-opentracing: build ## Create Docker image for Ingress Controller (w
 .PHONY: debian-image-opentracing-plus
 debian-image-opentracing-plus: build ## Create Docker image for Ingress Controller (with opentracing and plus)
 	$(DOCKER_CMD) $(PLUS_ARGS) --build-arg BUILD_OS=opentracing-plus
+
+.PHONY: debian-image-opentracing-nap-plus
+debian-image-opentracing-nap-plus: build ## Create Docker image for Ingress Controller (nginx plus with opentracing and nap)
+	$(DOCKER_CMD) $(PLUS_ARGS) $(NAP_ARGS) --build-arg BUILD_OS=opentracing-plus-nap
 
 .PHONY: all-images ## Create all the Docker images for Ingress Controller
 all-images: alpine-image alpine-image-plus debian-image debian-image-plus debian-image-nap-plus debian-image-opentracing debian-image-opentracing-plus openshift-image openshift-image-plus openshift-image-nap-plus

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -178,6 +178,18 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 RUN --mount=type=bind,from=opentracing-lib,target=/tmp/ cp -av /tmp/usr/local/lib/libjaegertracing*so* /tmp/usr/local/lib/libzipkin*so* /tmp/usr/local/lib/libdd*so* /tmp/usr/local/lib/libyaml*so* /usr/local/lib/ \
 	&& ldconfig
 
+############################################# Build image for Opentracing with NGINX Plus and NAP ######################################
+FROM debian-plus-nap as opentracing-plus-nap
+
+RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
+	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
+	apt-get update \
+	&& apt-get install --no-install-recommends --no-install-suggests -y libcurl4 nginx-plus-module-opentracing \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=bind,from=opentracing-lib,target=/tmp/ cp -av /tmp/usr/local/lib/libjaegertracing*so* /tmp/usr/local/lib/libzipkin*so* /tmp/usr/local/lib/libdd*so* /tmp/usr/local/lib/libyaml*so* /usr/local/lib/ \
+	&& ldconfig
+
 
 ############################################# Create common files for NGINX Plus #############################################
 FROM $BUILD_OS as plus-common


### PR DESCRIPTION
### Proposed changes
Add build target for combined OpenTracing and NAP.
This PR is against release-2.0 because currently NAP doesn't support Debian 11.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ x] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
