### PR TITLE
Use concurrency groups to cancel running workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ env:
   GIT_NAME: NGINX Kubernetes Team
   GIT_MAIL: kubernetes@nginx.com
 
+concurrency:
+  group: ${{ github.ref_name }}-ci
+  cancel-in-progress: true
+
 jobs:
 
   checks:
@@ -44,10 +48,6 @@ jobs:
       go_version: ${{ steps.vars.outputs.go_version }}
       go_path: ${{ steps.go.outputs.go_path }}
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Cache Go controller tools

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '36 6 * * 4'
 
+concurrency:
+  group: ${{ github.ref_name }}-codeql
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
@@ -20,10 +24,6 @@ jobs:
         language: [ 'go', 'python' ]
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout repository
       uses: actions/checkout@v2
 

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -6,14 +6,16 @@ on:
     paths:
       - README.md
       - .github/workflows/dockerhub-description.yml
+
+concurrency:
+  group: ${{ github.ref_name }}-dockerhub
+  cancel-in-progress: true
+
+
 jobs:
   dockerHubDescription:
     runs-on: ubuntu-20.04
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
 
       - name: Modify readme for DockerHub

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -9,16 +9,16 @@ on:
       - 'examples/**'
       - '**.md'
 
+concurrency:
+  group: ${{ github.ref_name }}-fossa
+  cancel-in-progress: true
+
 jobs:
 
   scan:
     name: Fossa
     runs-on: ubuntu-20.04
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Scan

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,16 +20,16 @@ defaults:
 env:
   GOLANGCI_TIMEOUT: 10m0s
 
+concurrency:
+  group: ${{ github.ref_name }}-lint
+  cancel-in-progress: true
+
 jobs:
 
   lint:
     name: Lint
     runs-on: ubuntu-20.04
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Lint Code

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,15 +8,15 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.ref_name }}-sync
+  cancel-in-progress: true
+
 jobs:
   # This job sync this repo to our internal repo
   repo-sync:
     runs-on: ubuntu-20.04
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Repo Sync
         uses: wei/git-sync@v3
         with:

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -13,6 +13,10 @@ env:
   DOCKER_BUILDKIT: 1
   K8S_TIMEOUT: 75s
 
+concurrency:
+  group: ${{ github.ref_name }}-update
+  cancel-in-progress: true
+
 jobs:
 
   variables:


### PR DESCRIPTION
There's a native option in the workflow to cancel concurrently running jobs, meaning that if there's a new push for a branch where the old run is not completed, it will be canceled and only the new version will run.

This replaces the action that we are currently using.

https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency