### PR TITLE
Fix grpc health check validation

### DIFF
--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -1252,7 +1252,7 @@ func validateGrpcService(service string, fieldPath *field.Path) field.ErrorList 
 	allErrs := field.ErrorList{}
 
 	if service == "" {
-		return append(allErrs, field.Required(fieldPath, ""))
+		return allErrs
 	}
 
 	if !grpcRegexp.MatchString(service) {

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -2354,33 +2354,46 @@ func TestValidateUpstreamHealthCheck(t *testing.T) {
 }
 
 func TestValidateGrpcUpstreamHealthCheck(t *testing.T) {
-	hc := &v1.HealthCheck{
-		Enable:   true,
-		Interval: "4s",
-		Jitter:   "2s",
-		Fails:    3,
-		Passes:   2,
-		Port:     8080,
-		TLS: &v1.UpstreamTLS{
-			Enable: true,
-		},
-		ConnectTimeout: "1s",
-		ReadTimeout:    "1s",
-		SendTimeout:    "1s",
-		Headers: []v1.Header{
-			{
-				Name:  "Host",
-				Value: "my.service",
+	tests := []struct {
+		hc *v1.HealthCheck
+	}{
+		{
+			hc: &v1.HealthCheck{
+				Enable:   true,
+				Interval: "4s",
+				Jitter:   "2s",
+				Fails:    3,
+				Passes:   2,
+				Port:     8080,
+				TLS: &v1.UpstreamTLS{
+					Enable: true,
+				},
+				ConnectTimeout: "1s",
+				ReadTimeout:    "1s",
+				SendTimeout:    "1s",
+				Headers: []v1.Header{
+					{
+						Name:  "Host",
+						Value: "my.service",
+					},
+				},
+				GRPCStatus:  createPointerFromInt(12),
+				GRPCService: "tea-servicev2",
 			},
 		},
-		GRPCStatus:  createPointerFromInt(12),
-		GRPCService: "tea-servicev2",
+		{
+			hc: &v1.HealthCheck{
+				Enable: true,
+			},
+		},
 	}
 
-	allErrs := validateUpstreamHealthCheck(hc, "grpc", field.NewPath("healthCheck"))
+	for _, test := range tests {
+		allErrs := validateUpstreamHealthCheck(test.hc, "grpc", field.NewPath("healthCheck"))
 
-	if len(allErrs) != 0 {
-		t.Errorf("validateUpstreamHealthCheck() returned errors for valid input %v", hc)
+		if len(allErrs) != 0 {
+			t.Errorf("validateUpstreamHealthCheck() returned errors for valid input %v", test.hc)
+		}
 	}
 }
 


### PR DESCRIPTION
### Proposed changes
`grpcService` is not required for enabling gRPC healthchecks. This commit makes it an optional parameter.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
