### PR TITLE
Add `content-type header` to grpc error locations

### DIFF
--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -447,6 +447,7 @@ server {
         {{ if $ssl.HTTP2 }}
 	location @grpc_deadline_exceeded {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 4;
         add_header grpc-message 'deadline exceeded';
         return 204;
@@ -454,6 +455,7 @@ server {
 
     location @grpc_permission_denied {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 7;
         add_header grpc-message 'permission denied';
         return 204;
@@ -461,6 +463,7 @@ server {
 
     location @grpc_resource_exhausted {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 8;
         add_header grpc-message 'resource exhausted';
         return 204;
@@ -468,6 +471,7 @@ server {
 
     location @grpc_unimplemented {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 12;
         add_header grpc-message unimplemented;
         return 204;
@@ -475,6 +479,7 @@ server {
 
     location @grpc_internal {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 13;
         add_header grpc-message 'internal error';
         return 204;
@@ -482,6 +487,7 @@ server {
 
     location @grpc_unavailable {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 14;
         add_header grpc-message unavailable;
         return 204;
@@ -489,6 +495,7 @@ server {
 
     location @grpc_unauthenticated {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 16;
         add_header grpc-message unauthenticated;
         return 204;

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -342,6 +342,7 @@ server {
         {{ if $ssl.HTTP2 }}
 	location @grpc_deadline_exceeded {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 4;
         add_header grpc-message 'deadline exceeded';
         return 204;
@@ -349,6 +350,7 @@ server {
 
     location @grpc_permission_denied {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 7;
         add_header grpc-message 'permission denied';
         return 204;
@@ -356,6 +358,7 @@ server {
 
     location @grpc_resource_exhausted {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 8;
         add_header grpc-message 'resource exhausted';
         return 204;
@@ -363,6 +366,7 @@ server {
 
     location @grpc_unimplemented {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 12;
         add_header grpc-message unimplemented;
         return 204;
@@ -370,6 +374,7 @@ server {
 
     location @grpc_internal {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 13;
         add_header grpc-message 'internal error';
         return 204;
@@ -377,6 +382,7 @@ server {
 
     location @grpc_unavailable {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 14;
         add_header grpc-message unavailable;
         return 204;
@@ -384,6 +390,7 @@ server {
 
     location @grpc_unauthenticated {
         default_type application/grpc;
+        add_header content-type application/grpc;
         add_header grpc-status 16;
         add_header grpc-message unauthenticated;
         return 204;


### PR DESCRIPTION
### Proposed changes
The gRPC Go client shows errors when handling error pages returned from the IC (e.g. when a backend is unavailable). This resolves one of the issues (malformed header response), e.g.:

Current error:
`./grpc_client -address virtual-server.example.com:443
2021/11/30 14:32:41 could not greet: rpc error: code = Unknown desc = unexpected HTTP status code received from server: 204 (No Content); malformed header: missing HTTP content-type`

After this commit:
`./grpc_client -address virtual-server.example.com:443
2021/11/30 14:21:05 could not greet: rpc error: code = Unknown desc = unexpected HTTP status code received from server: 204 (No Content)`

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
