### PR TITLE
Temp allow failures when the problem is syslog in AP log tests

### DIFF
--- a/tests/data/appprotect/logconf.yaml
+++ b/tests/data/appprotect/logconf.yaml
@@ -1,11 +1,11 @@
 apiVersion: appprotect.f5.com/v1beta1
 kind: APLogConf
-metadata: 
+metadata:
   name: logconf
 spec:
-  content: 
+  content:
     format: default
     max_message_size: 64k
     max_request_size: any
-  filter: 
-    request_types: all
+  filter:
+    request_type: all


### PR DESCRIPTION
### Proposed changes
The most common app protect errors we are seeing at the moment seem to involve syslog not starting correctly. This requires more investigation, but for now I think we should allow these tests to fail when this exact scenario occurs. This commit also adds in some some more waits to try and increase the chance that it will become ready in time.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
