### PR TITLE
Fix whitespace in default Make variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ VERSION = $(GIT_TAG)-SNAPSHOT-$(GIT_COMMIT_SHORT)
 PLUS_ARGS = --secret id=nginx-repo.crt,src=nginx-repo.crt --secret id=nginx-repo.key,src=nginx-repo.key
 
 # variables that can be overridden by the user
-PREFIX = nginx/nginx-ingress ## The name of the image. For example, nginx/nginx-ingress
-TAG = $(VERSION:v%=%) ## The tag of the image. For example, 2.0.0
-TARGET ?= local ## The target of the build. Possible values: local, container and download
+PREFIX = nginx/nginx-ingress## The name of the image. For example, nginx/nginx-ingress
+TAG = $(VERSION:v%=%)## The tag of the image. For example, 2.0.0
+TARGET ?= local## The target of the build. Possible values: local, container and download
 override DOCKER_BUILD_OPTIONS += --build-arg IC_VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg DATE=$(DATE) ## The options for the docker build command. For example, --pull.
 
 # final docker build command


### PR DESCRIPTION
### Proposed changes
There is whitespace at the end of some of the default Make variables including `TARGET ?= local ` because it is including the whitespace between the var and the comment on the same line. This means that `make build` is not doing anything without explicitly passing in the TARGET, e.g.`make build TARGET=local`. This commit removes the whitespace and returns the previous behaviour.

Current behaviour:
```
~/workspace/github/nginxinc/kubernetes-ingress master > make build
Docker version 20.10.10, build b485636
```

New behaviour:
```
~/workspace/github/nginxinc/kubernetes-ingress chore/fix-makefile-whitespace > make build
Docker version 20.10.10, build b485636
go version go1.17.1 darwin/amd64
CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build -trimpath -ldflags "-s -w -X main.version=v2.0.3-SNAPSHOT-b90d4e7 -X main.commit=b90d4e733e1a799b2e16105ad07a6e9ee9a3e989 -X main.date=2021-12-06T12:29:23Z" -o nginx-ingress github.com/nginxinc/kubernetes-ingress/cmd/nginx-ingress
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
