### PR TITLE
feat: DOCOPS-474 F5-hugo theme bump December 2021

### DIFF
--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/f5-hugo.css
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/f5-hugo.css
@@ -169,9 +169,14 @@ ol > li > ol {
 
 .card-title {
     overflow-wrap: normal;
+
+}
+.products-card > .card-title {
     padding-left: 52px;
     text-indent: -52px;
 }
+
+
 
 h3.card-title a {
     color: #000;

--- a/docs/_vendor/modules.txt
+++ b/docs/_vendor/modules.txt
@@ -1,2 +1,2 @@
-# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6
+# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.7
 # github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/nginxinc/kubernetes-ingress/docs
 
 go 1.15
 
-require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6 // indirect
+require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.7 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -12,3 +12,5 @@ gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.3 h1:cDf5OAzX/6Qg2gbSJGAkMHHWOA
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.3/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6 h1:jN+79xD+xUD3nDvZWoubwoUxzgI/G/e7RIf+K3kOPRQ=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.7 h1:O75I8D2xLjbQ5rYZAflXMcnEPFJ12YhLpyn5auO4EUI=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.7/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=


### PR DESCRIPTION
Update the f5-hugo theme to v0.15.7 (December release), including the following fixes:
- Hide table of contents if there are no H2/H3 headers
- Product landing page cards have the same size in narrow viewports