### PR TITLE
Check if refresh token is `undefined` and do not store it in this case

### DIFF
--- a/internal/configs/oidc/openid_connect.js
+++ b/internal/configs/oidc/openid_connect.js
@@ -83,7 +83,8 @@ function auth(r) {
                         r.variables.session_jwt = tokenset.id_token; // Update key-value store
 
                         // Update refresh token (if we got a new one)
-                        if (r.variables.refresh_token != tokenset.refresh_token) {
+                        // 12.2021 - In rare cases the IdP does not include the refresh-token in the response. The rt will be undefined in this case.
+                        if (r.variables.refresh_token != tokenset.refresh_token && tokenset.refresh_token != undefined) {
                             r.log("OIDC replacing previous refresh token (" + r.variables.refresh_token + ") with new value: " + tokenset.refresh_token);
                             r.variables.refresh_token = tokenset.refresh_token; // Update key-value store
                         }


### PR DESCRIPTION
### Proposed changes
In some cases the token response from the Identity Provider (IdP) does not contain a refresh token. In this case the variable `tokenset.refresh_token` will be `undefined`. As `undefined` is unequal to the current refresh-token undefined is stored as the tokens value in the key-value store. This results in a deletion of the token from the key-value-store.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [X ] I have added tests that prove my fix is effective or that my feature works
- [ X] I have checked that all unit tests pass after adding my changes
- [ X] I have updated necessary documentation
- [ X ] I have rebased my branch onto master
- [ X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
