### PR TITLE
tests: add VSR gRPC WAF tests

### DIFF
--- a/tests/data/ap-waf-grpc/virtual-server-route-waf.yaml
+++ b/tests/data/ap-waf-grpc/virtual-server-route-waf.yaml
@@ -1,0 +1,17 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServerRoute
+metadata:
+  name: helloworld.greeter
+spec:
+  host: virtual-server.example.com
+  upstreams:
+  - name: grpc1
+    service: grpc1-svc
+    port: 50051
+    type: grpc
+  subroutes:
+  - path: "~* /helloworld.greeter/"
+    action:
+      pass: grpc1
+    policies:
+    - name: waf-policy

--- a/tests/data/ap-waf-grpc/vsr-virtual-server-spec.yaml
+++ b/tests/data/ap-waf-grpc/vsr-virtual-server-spec.yaml
@@ -1,0 +1,11 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server-route
+spec:
+  host: virtual-server.example.com
+  tls:
+    secret: virtual-server-tls-grpc-secret
+  routes:
+  - path: "~* /helloworld.greeter/"
+    route: helloworld.greeter


### PR DESCRIPTION
### Proposed changes
Add VSR gRPC WAF tests. Uses case insensitive regex for the subroute as we can't set capitals in subdomains (throws a validation error - see https://pkg.go.dev/k8s.io/apimachinery@v0.22.4/pkg/util/validation#IsDNS1123Subdomain) but the gRPC client sends a request to "helloworld.Greeter/SayHello".

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
