### PR TITLE
feat: Cherry-Pick DOCOPS-474 F5-hugo theme bump December 2021

### DIFF
--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/f5-hugo.css
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/f5-hugo.css
@@ -169,9 +169,14 @@ ol > li > ol {
 
 .card-title {
     overflow-wrap: normal;
+
+}
+.products-card > .card-title {
     padding-left: 52px;
     text-indent: -52px;
 }
+
+
 
 h3.card-title a {
     color: #000;

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/f5-hugo.css
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/f5-hugo.css
@@ -88,6 +88,7 @@ ol > li > ol {
     border: 1px solid #f8f9f9;
     box-sizing: border-box;
     border-radius: 4px;
+    height: 100%;
   }
   
   a.products-card {
@@ -168,6 +169,8 @@ ol > li > ol {
 
 .card-title {
     overflow-wrap: normal;
+    padding-left: 52px;
+    text-indent: -52px;
 }
 
 h3.card-title a {

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/_default/docs.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/_default/docs.html
@@ -20,9 +20,11 @@
     
   </main>
   {{ if and (gt .WordCount 200 ) (.Params.toc) }}
-  <div class="col-md-3 d-none d-xl-block d-print-none nginx-toc align-top">
-  {{ partial "toc.html" . }}
-  </div>
+    {{ if (add  (len (findRE "<h3" .Content)) (len (findRE "<h2" .Content))) }}
+      <div class="col-md-3 d-none d-xl-block d-print-none nginx-toc align-top">
+      {{ partial "toc.html" . }}
+      </div>
+    {{ end }}
   {{ end }}
 </div>
 <!-- If there is a script defined in the page metadata, load it  -->

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/feedback-form.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/feedback-form.html
@@ -1,13 +1,13 @@
 <div class="card">
     <form name="submit-feedback" method="POST" data-netlify="true" action="/success">
         <div class="form-group">
-            <label for="feedbackFormName1">Your Name<sup>*</sup></label>
-            <input type="text" class="form-control" id="feedbackFormName1" name="name" required> 
+            <label for="feedbackFormName1">Your Name</label>
+            <input type="text" class="form-control" id="feedbackFormName1" name="name"> 
         </div>
 
         <div class="form-group">
-            <label for="feedbackFormEmail1">Email address<sup>*</sup></label>
-            <input type="email" class="form-control" id="feedbackFormEmail1" aria-describedby="emailHelp" name="email" required>
+            <label for="feedbackFormEmail1">Email address</label>
+            <input type="email" class="form-control" id="feedbackFormEmail1" aria-describedby="emailHelp" name="email">
             <small id="emailHelp" class="form-text text-muted">We'll never share your email with anyone else.</small>
         </div>
 

--- a/docs/_vendor/modules.txt
+++ b/docs/_vendor/modules.txt
@@ -1,2 +1,2 @@
-# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.3
+# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6
 # github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f

--- a/docs/_vendor/modules.txt
+++ b/docs/_vendor/modules.txt
@@ -1,2 +1,2 @@
-# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6
+# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.7
 # github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/nginxinc/kubernetes-ingress/docs
 
 go 1.15
 
-require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6 // indirect
+require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.7 // indirect

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/nginxinc/kubernetes-ingress/docs
 
 go 1.15
 
-require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.3 // indirect
+require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -12,3 +12,5 @@ gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.3 h1:cDf5OAzX/6Qg2gbSJGAkMHHWOA
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.3/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6 h1:jN+79xD+xUD3nDvZWoubwoUxzgI/G/e7RIf+K3kOPRQ=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.7 h1:O75I8D2xLjbQ5rYZAflXMcnEPFJ12YhLpyn5auO4EUI=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.7/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -10,3 +10,5 @@ gitlab.com/f5/nginx/controller/poc/f5-hugo v0.14.1-0.20211019184158-5e5bd366bfcd
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.14.1-0.20211019184158-5e5bd366bfcd/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.3 h1:cDf5OAzX/6Qg2gbSJGAkMHHWOA1RDDigTKVBIGzR2Gw=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.3/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6 h1:jN+79xD+xUD3nDvZWoubwoUxzgI/G/e7RIf+K3kOPRQ=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.15.6/go.mod h1:G+e4mnMJBHCT04TKm3Bbnm5I5OGVoeLlmbaDFF3GPBc=


### PR DESCRIPTION
Update the f5-hugo theme to v0.15.7 (December release), including the following fixes:
- Hide table of contents if there are no H2/H3 headers
- Product landing page cards have the same size in narrow viewports
