### PR TITLE
Update-codegen needs a specific path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,9 @@ jobs:
           make update-crds && git diff --name-only --exit-code deployments/common/crds* deployments/helm-chart/crds*
       - name: Check if Codegen changed
         run: |
+          cd ../.. && mkdir -p github.com/nginxinc && mv kubernetes-ingress/kubernetes-ingress github.com/nginxinc/ && cd github.com/nginxinc/kubernetes-ingress
           make update-codegen && git diff --name-only --exit-code pkg/**/zz_generated.deepcopy.go
+          cd ../../.. && mv github.com/nginxinc/kubernetes-ingress kubernetes-ingress/kubernetes-ingress
 
   binary:
     name: Build binary

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ update-codegen: ## Generate code
 .PHONY: update-crds
 update-crds: ## Update CRDs
 	go run sigs.k8s.io/controller-tools/cmd/controller-gen crd:crdVersions=v1 schemapatch:manifests=./deployments/common/crds/ paths=./pkg/apis/configuration/... output:dir=./deployments/common/crds
-	@cp -Rp deployments/common/crds/ deployments/helm-chart/crds
+	@cp -Rp deployments/common/crds/* deployments/helm-chart/crds/
 
 .PHONY: certificate-and-key
 certificate-and-key: ## Create default cert and key

--- a/foo
+++ b/foo
@@ -1,0 +1,1 @@
+nginx-ingress

--- a/foo
+++ b/foo
@@ -1,1 +1,0 @@
-nginx-ingress

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CODEGEN_VERSION=$(grep 'k8s.io/code-generator' go.sum | awk '{print $2}' | sed 's/\/go.mod//g' | tail -1)
-CODEGEN_PKG=$(echo `go env GOPATH`"/pkg/mod/k8s.io/code-generator@${CODEGEN_VERSION}")
+CODEGEN_PKG=$(echo $(go env GOPATH)"/pkg/mod/k8s.io/code-generator@${CODEGEN_VERSION}")
 
 if [[ ! -d ${CODEGEN_PKG} ]]; then
   echo "${CODEGEN_PKG} is missing. Running 'go mod download'."


### PR DESCRIPTION
The script only works if the path is exactly the same as the API, this moves the folder to the right place so we can catch changes.