### PR TITLE
Make the resource comparison more informative in case of an error

### DIFF
--- a/internal/k8s/handlers.go
+++ b/internal/k8s/handlers.go
@@ -533,11 +533,11 @@ func areResourcesDifferent(oldresource, resource *unstructured.Unstructured) (bo
 		return false, err
 	}
 	spec, found, err := unstructured.NestedMap(resource.Object, "spec")
-	if !found {
-		return false, fmt.Errorf("Error, spec has unexpected format")
-	}
 	if err != nil {
 		return false, err
+	}
+	if !found {
+		return false, fmt.Errorf("Error, spec has unexpected format")
 	}
 	eq := reflect.DeepEqual(oldSpec, spec)
 	if eq {


### PR DESCRIPTION
### Proposed changes
In some rare cases, if an error occurred during comparison resources, this error might be overwritten by a less informative message "Error, spec has unexpected format". I think that giving more precisive information could help DevOps people to find the source of the error faster.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
