### PR TITLE
fix dos unit test

### DIFF
--- a/internal/k8s/appprotectdos/app_protect_dos_configuration_test.go
+++ b/internal/k8s/appprotectdos/app_protect_dos_configuration_test.go
@@ -1,6 +1,7 @@
 package appprotectdos
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1150,15 +1151,17 @@ func TestGetDosProtectedThatReferencedDosPolicy(t *testing.T) {
 			policyNamespace: "dev",
 			policyName:      "dosPolicyTwo",
 			expected: []*v1beta1.DosProtectedResource{
-				dosProtectedWithPolicyTwo,
 				anotherDosProtectedWithPolicyTwo,
+				dosProtectedWithPolicyTwo,
 			},
 			msg: "return two referenced objects, from policy reference with mixed namespaces",
 		},
 	}
 	for _, test := range tests {
 		resources := dosConf.GetDosProtectedThatReferencedDosPolicy(test.policyNamespace + "/" + test.policyName)
-
+		sort.SliceStable(resources, func(i, j int) bool {
+			return resources[i].Name < resources[j].Name
+		})
 		if diff := cmp.Diff(test.expected, resources); diff != "" {
 			t.Errorf("GetDosProtectedThatReferencedDosPolicy() returned unexpected result for the case of: %v (-want +got):\n%s", test.msg, diff)
 		}


### PR DESCRIPTION
…est to make it deterministic

### Proposed changes
sorted the result of GetDosProtectedThatReferencedDosPolicy in unit test that compares arrays to make the results deterministic.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
