### PR TITLE
fix: Fix ap watch namespace

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -271,7 +271,7 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 	}
 
 	if lbc.appProtectEnabled || lbc.appProtectDosEnabled {
-		lbc.dynInformerFactory = dynamicinformer.NewDynamicSharedInformerFactory(lbc.dynClient, 0)
+		lbc.dynInformerFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(lbc.dynClient, 0, lbc.namespace, nil)
 
 		if lbc.appProtectEnabled {
 			lbc.addAppProtectPolicyHandler(createAppProtectPolicyHandlers(lbc))


### PR DESCRIPTION
### Proposed changes
Recent changes made to fix app protect watching its own namespace were accidentally overwritten by the DOS PR. This commit rectifies the issue.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
