### PR TITLE
Install latest libgmp10 in Debian

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,9 @@ ARG DEBIAN_VERSION=bullseye-slim
 FROM nginx:1.21.4 AS debian
 
 RUN apt-get update \
-	&& apt-get install --no-install-recommends --no-install-suggests -y libcap2-bin \
+	&& apt-get install --no-install-recommends --no-install-suggests -y libcap2-bin libgmp10 \
+	# temporary fix for CVE-2021-43618
+	&& apt-get install --no-install-recommends --no-install-suggests -y libgmp10 \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& echo $NGINX_VERSION > nginx_version
 
@@ -47,6 +49,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
 	apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https libcap2-bin \
+	# temporary fix for CVE-2021-43618
+	&& apt-get install --no-install-recommends --no-install-suggests -y libgmp10 \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
 	&& DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \


### PR DESCRIPTION
### Proposed changes
CVE-2021-43618 - Vulnerability in libgmp10 in Debian 11.1

https://avd.aquasec.com/nvd/cve-2021-43618
https://nvd.nist.gov/vuln/detail/CVE-2021-43618

Fix: Upgrade to libgmp10 2:6.2.1+dfsg-1+deb11u1 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
