### PR TITLE
Revert lint changes from DOS PR

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,7 @@ linters-settings:
       - name: var-declaration
       - name: var-naming
   gocyclo:
-    min-complexity: 150
+    min-complexity: 15
 
 linters:
     enable:
@@ -64,7 +64,7 @@ linters:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  new: false
+  new: true
   exclude-use-default: false
 run:
   timeout: 5m


### PR DESCRIPTION
Reverts the change made in the DOS PR. We have a few issues in the codebase at the moment and we should only check for new issues in the modified files.