### PR TITLE
sorting test results for deterministic results

### DIFF
--- a/internal/k8s/appprotectdos/app_protect_dos_configuration_test.go
+++ b/internal/k8s/appprotectdos/app_protect_dos_configuration_test.go
@@ -1311,18 +1311,18 @@ func TestGetDosProtectedThatReferencedDosLogConf(t *testing.T) {
 			policyNamespace: "dev",
 			policyName:      "dosLogConfTwo",
 			expected: []*v1beta1.DosProtectedResource{
-				dosProtectedWithLogConfTwo,
 				anotherDosProtectedWithLogConfTwo,
+				dosProtectedWithLogConfTwo,
 			},
 			msg: "return two referenced objects, from log conf reference with mixed namespaces",
 		},
 	}
 	for _, test := range tests {
 		resources := dosConf.GetDosProtectedThatReferencedDosLogConf(test.policyNamespace + "/" + test.policyName)
+		sort.SliceStable(resources, func(i, j int) bool {
+			return resources[i].Name < resources[j].Name
+		})
 		if diff := cmp.Diff(test.expected, resources); diff != "" {
-			sort.SliceStable(resources, func(i, j int) bool {
-				return resources[i].Name < resources[j].Name
-			})
 			t.Errorf("GetDosProtectedThatReferencedDosLogConf() returned unexpected result for the case of: %v (-want +got):\n%s", test.msg, diff)
 		}
 	}


### PR DESCRIPTION
### Proposed changes
moves the sort so the results are deterministic.

The reason the unit test was failing was that the results of the function were return in a non determined order. Unfortunately `cmp` library does not have an option to compare ignoring order.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
