### PR TITLE
Add handling of multiple log destinations

### DIFF
--- a/deployments/common/crds/k8s.nginx.org_policies.yaml
+++ b/deployments/common/crds/k8s.nginx.org_policies.yaml
@@ -156,6 +156,18 @@ spec:
                           type: boolean
                         logDest:
                           type: string
+                    securityLogs:
+                      type: array
+                      items:
+                        description: SecurityLog defines the security log of a WAF policy.
+                        type: object
+                        properties:
+                          apLogConf:
+                            type: string
+                          enable:
+                            type: boolean
+                          logDest:
+                            type: string
             status:
               description: PolicyStatus is the status of the policy resource
               type: object

--- a/deployments/helm-chart/crds/k8s.nginx.org_policies.yaml
+++ b/deployments/helm-chart/crds/k8s.nginx.org_policies.yaml
@@ -156,6 +156,18 @@ spec:
                           type: boolean
                         logDest:
                           type: string
+                    securityLogs:
+                      type: array
+                      items:
+                        description: SecurityLog defines the security log of a WAF policy.
+                        type: object
+                        properties:
+                          apLogConf:
+                            type: string
+                          enable:
+                            type: boolean
+                          logDest:
+                            type: string
             status:
               description: PolicyStatus is the status of the policy resource
               type: object

--- a/docs/content/configuration/policy-resource.md
+++ b/docs/content/configuration/policy-resource.md
@@ -355,17 +355,20 @@ For `kubectl get` and similar commands, you can also use the short name `pol` in
 
 The WAF policy configures NGINX Plus to secure client requests using App Protect policies.
 
-For example, the following policy will enable the referenced APPolicy and APLogConf with the configured log destination:
+For example, the following policy will enable the referenced APPolicy. You can configure multiple APLogConfs with log destinations:
 ```yaml
 waf:
   enable: true
   apPolicy: "default/dataguard-alarm"
-  securityLog:
-    enable: true
+  securityLogs:
+  - enable: true
     apLogConf: "default/logconf"
     logDest: "syslog:server=syslog-svc.default:514"
+  - enable: true
+    apLogConf: "default/logconf"
+    logDest: "syslog:server=syslog-svc-secondary.default:514"    
 ```
-
+> Note: The field `waf.securityLog` is deprecated and will be removed in future releases.It will be ignored if `waf.securityLogs` is populated.
 > Note: The feature is implemented using the NGINX Plus [NGINX App Protect Module](https://docs.nginx.com/nginx-app-protect/configuration/).
 
 {{% table %}}

--- a/examples/custom-resources/waf/waf.yaml
+++ b/examples/custom-resources/waf/waf.yaml
@@ -6,7 +6,7 @@ spec:
   waf:
     enable: true
     apPolicy: "default/dataguard-alarm"
-    securityLog:
-      enable: true
+    securityLogs:
+    - enable: true
       apLogConf: "default/logconf"
       logDest: "syslog:server=syslog-svc.default:514"

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -76,7 +76,8 @@ type MergeableIngresses struct {
 }
 
 func generateNginxCfg(ingEx *IngressEx, apResources *AppProtectResources, dosResource *appProtectDosResource, isMinion bool,
-	baseCfgParams *ConfigParams, isPlus bool, isResolverConfigured bool, staticParams *StaticConfigParams, isWildcardEnabled bool) (version1.IngressNginxConfig, Warnings) {
+	baseCfgParams *ConfigParams, isPlus bool, isResolverConfigured bool, staticParams *StaticConfigParams, isWildcardEnabled bool,
+) (version1.IngressNginxConfig, Warnings) {
 	hasAppProtect := staticParams.MainAppProtectLoadModule
 	hasAppProtectDos := staticParams.MainAppProtectDosLoadModule
 
@@ -290,7 +291,8 @@ func generateNginxCfg(ingEx *IngressEx, apResources *AppProtectResources, dosRes
 }
 
 func generateJWTConfig(owner runtime.Object, secretRefs map[string]*secrets.SecretReference, cfgParams *ConfigParams,
-	redirectLocationName string) (*version1.JWTAuth, *version1.JWTRedirectLocation, Warnings) {
+	redirectLocationName string,
+) (*version1.JWTAuth, *version1.JWTRedirectLocation, Warnings) {
 	warnings := newWarnings()
 
 	secretRef := secretRefs[cfgParams.JWTKey]
@@ -326,7 +328,8 @@ func generateJWTConfig(owner runtime.Object, secretRefs map[string]*secrets.Secr
 }
 
 func addSSLConfig(server *version1.Server, owner runtime.Object, host string, ingressTLS []networking.IngressTLS,
-	secretRefs map[string]*secrets.SecretReference, isWildcardEnabled bool) Warnings {
+	secretRefs map[string]*secrets.SecretReference, isWildcardEnabled bool,
+) Warnings {
 	warnings := newWarnings()
 
 	var tlsEnabled bool
@@ -427,7 +430,8 @@ func upstreamRequiresQueue(name string, ingEx *IngressEx, cfg *ConfigParams) (n 
 }
 
 func createUpstream(ingEx *IngressEx, name string, backend *networking.IngressBackend, stickyCookie string, cfg *ConfigParams,
-	isPlus bool, isResolverConfigured bool, isLatencyMetricsEnabled bool) version1.Upstream {
+	isPlus bool, isResolverConfigured bool, isLatencyMetricsEnabled bool,
+) version1.Upstream {
 	var ups version1.Upstream
 	labels := version1.UpstreamLabels{
 		Service:           backend.Service.Name,
@@ -534,8 +538,8 @@ func upstreamMapToSlice(upstreams map[string]version1.Upstream) []version1.Upstr
 
 func generateNginxCfgForMergeableIngresses(mergeableIngs *MergeableIngresses, apResources *AppProtectResources,
 	dosResource *appProtectDosResource, baseCfgParams *ConfigParams, isPlus bool, isResolverConfigured bool,
-	staticParams *StaticConfigParams, isWildcardEnabled bool) (version1.IngressNginxConfig, Warnings) {
-
+	staticParams *StaticConfigParams, isWildcardEnabled bool,
+) (version1.IngressNginxConfig, Warnings) {
 	var masterServer version1.Server
 	var locations []version1.Location
 	var upstreams []version1.Upstream

--- a/internal/configs/version1/templates_test.go
+++ b/internal/configs/version1/templates_test.go
@@ -39,7 +39,6 @@ var (
 )
 
 var ingCfg = IngressNginxConfig{
-
 	Servers: []Server{
 		{
 			Name:         "test.example.com",

--- a/internal/configs/version2/http.go
+++ b/internal/configs/version2/http.go
@@ -123,7 +123,7 @@ type WAF struct {
 	Enable              string
 	ApPolicy            string
 	ApSecurityLogEnable bool
-	ApLogConf           string
+	ApLogConf           []string
 }
 
 // Dos defines Dos configuration.

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -191,7 +191,9 @@ server {
 
         {{ if .ApSecurityLogEnable }}
     app_protect_security_log_enable on;
-    app_protect_security_log {{ .ApLogConf }};
+        {{ range $logconf := .ApLogConf }}
+    app_protect_security_log {{ $logconf }};
+        {{ end }}
         {{ end }}
     {{ end }}
 
@@ -370,7 +372,9 @@ server {
 
             {{ if .ApSecurityLogEnable }}
         app_protect_security_log_enable on;
-        app_protect_security_log {{ .ApLogConf }};
+            {{ range $logconf := .ApLogConf }}
+        app_protect_security_log {{ $logconf }};
+            {{ end }}
             {{ end }}
         {{ end }}
 

--- a/internal/configs/version2/templates_test.go
+++ b/internal/configs/version2/templates_test.go
@@ -150,7 +150,7 @@ var virtualServerCfg = VirtualServerConfig{
 		WAF: &WAF{
 			ApPolicy:            "/etc/nginx/waf/nac-policies/default-dataguard-alarm",
 			ApSecurityLogEnable: true,
-			ApLogConf:           "/etc/nginx/waf/nac-logconfs/default-logconf",
+			ApLogConf:           []string{"/etc/nginx/waf/nac-logconfs/default-logconf"},
 		},
 		Snippets: []string{"# server snippet"},
 		InternalRedirectLocations: []InternalRedirectLocation{

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -2938,7 +2938,7 @@ func TestGeneratePolicies(t *testing.T) {
 					Enable:              "on",
 					ApPolicy:            "/etc/nginx/waf/nac-policies/default-dataguard-alarm",
 					ApSecurityLogEnable: true,
-					ApLogConf:           "/etc/nginx/waf/nac-logconfs/default-logconf syslog:server=127.0.0.1:514",
+					ApLogConf:           []string{"/etc/nginx/waf/nac-logconfs/default-logconf syslog:server=127.0.0.1:514"},
 				},
 			},
 			msg: "WAF reference",
@@ -6723,7 +6723,6 @@ func TestGenerateHealthCheck(t *testing.T) {
 		msg          string
 	}{
 		{
-
 			upstream: conf_v1.Upstream{
 				HealthCheck: &conf_v1.HealthCheck{
 					Enable:         true,
@@ -6905,7 +6904,6 @@ func TestGenerateGrpcHealthCheck(t *testing.T) {
 		msg          string
 	}{
 		{
-
 			upstream: conf_v1.Upstream{
 				HealthCheck: &conf_v1.HealthCheck{
 					Enable:         true,
@@ -8248,7 +8246,6 @@ func TestAddWafConfig(t *testing.T) {
 		msg          string
 	}{
 		{
-
 			wafInput: &conf_v1.WAF{
 				Enable: true,
 			},
@@ -8265,7 +8262,6 @@ func TestAddWafConfig(t *testing.T) {
 			msg:      "valid waf config, default App Protect config",
 		},
 		{
-
 			wafInput: &conf_v1.WAF{
 				Enable:   true,
 				ApPolicy: "dataguard-alarm",
@@ -8288,13 +8284,42 @@ func TestAddWafConfig(t *testing.T) {
 			wafConfig: &version2.WAF{
 				ApPolicy:            "/etc/nginx/waf/nac-policies/default-dataguard-alarm",
 				ApSecurityLogEnable: true,
-				ApLogConf:           "/etc/nginx/waf/nac-logconfs/default-logconf",
+				ApLogConf:           []string{"/etc/nginx/waf/nac-logconfs/default-logconf"},
 			},
 			expected: &validationResults{isError: false},
 			msg:      "valid waf config",
 		},
 		{
-
+			wafInput: &conf_v1.WAF{
+				Enable:   true,
+				ApPolicy: "dataguard-alarm",
+				SecurityLogs: []*conf_v1.SecurityLog{
+					{
+						Enable:    true,
+						ApLogConf: "logconf",
+						LogDest:   "syslog:server=127.0.0.1:514",
+					},
+				},
+			},
+			polKey:       "default/waf-policy",
+			polNamespace: "default",
+			apResources: &appProtectResourcesForVS{
+				Policies: map[string]string{
+					"default/dataguard-alarm": "/etc/nginx/waf/nac-policies/default-dataguard-alarm",
+				},
+				LogConfs: map[string]string{
+					"default/logconf": "/etc/nginx/waf/nac-logconfs/default-logconf",
+				},
+			},
+			wafConfig: &version2.WAF{
+				ApPolicy:            "/etc/nginx/waf/nac-policies/default-dataguard-alarm",
+				ApSecurityLogEnable: true,
+				ApLogConf:           []string{"/etc/nginx/waf/nac-logconfs/default-logconf"},
+			},
+			expected: &validationResults{isError: false},
+			msg:      "valid waf config",
+		},
+		{
 			wafInput: &conf_v1.WAF{
 				Enable:   true,
 				ApPolicy: "default/dataguard-alarm",
@@ -8315,7 +8340,7 @@ func TestAddWafConfig(t *testing.T) {
 			wafConfig: &version2.WAF{
 				ApPolicy:            "/etc/nginx/waf/nac-policies/default-dataguard-alarm",
 				ApSecurityLogEnable: true,
-				ApLogConf:           "/etc/nginx/waf/nac-logconfs/default-logconf",
+				ApLogConf:           []string{"/etc/nginx/waf/nac-logconfs/default-logconf"},
 			},
 			expected: &validationResults{
 				isError: true,
@@ -8326,7 +8351,6 @@ func TestAddWafConfig(t *testing.T) {
 			msg: "invalid waf config, apLogConf references non-existing log conf",
 		},
 		{
-
 			wafInput: &conf_v1.WAF{
 				Enable:   true,
 				ApPolicy: "default/dataguard-alarm",
@@ -8346,7 +8370,7 @@ func TestAddWafConfig(t *testing.T) {
 			wafConfig: &version2.WAF{
 				ApPolicy:            "/etc/nginx/waf/nac-policies/default-dataguard-alarm",
 				ApSecurityLogEnable: true,
-				ApLogConf:           "/etc/nginx/waf/nac-logconfs/default-logconf",
+				ApLogConf:           []string{"/etc/nginx/waf/nac-logconfs/default-logconf"},
 			},
 			expected: &validationResults{
 				isError: true,
@@ -8357,7 +8381,6 @@ func TestAddWafConfig(t *testing.T) {
 			msg: "invalid waf config, apLogConf references non-existing ap conf",
 		},
 		{
-
 			wafInput: &conf_v1.WAF{
 				Enable:   true,
 				ApPolicy: "ns1/dataguard-alarm",
@@ -8380,13 +8403,12 @@ func TestAddWafConfig(t *testing.T) {
 			wafConfig: &version2.WAF{
 				ApPolicy:            "/etc/nginx/waf/nac-policies/ns1-dataguard-alarm",
 				ApSecurityLogEnable: true,
-				ApLogConf:           "/etc/nginx/waf/nac-logconfs/ns2-logconf",
+				ApLogConf:           []string{"/etc/nginx/waf/nac-logconfs/ns2-logconf"},
 			},
 			expected: &validationResults{},
 			msg:      "valid waf config, cross ns reference",
 		},
 		{
-
 			wafInput: &conf_v1.WAF{
 				Enable:   false,
 				ApPolicy: "dataguard-alarm",

--- a/internal/k8s/configuration.go
+++ b/internal/k8s/configuration.go
@@ -1190,7 +1190,8 @@ func createResourceChangesForHosts(removedHosts []string, updatedHosts []string,
 }
 
 func createResourceChangesForListeners(removedListeners []string, updatedListeners []string, addedListeners []string, oldListeners map[string]*TransportServerConfiguration,
-	newListeners map[string]*TransportServerConfiguration) []ResourceChange {
+	newListeners map[string]*TransportServerConfiguration,
+) []ResourceChange {
 	var changes []ResourceChange
 	var deleteChanges []ResourceChange
 
@@ -1597,7 +1598,8 @@ func detectChangesInHosts(oldHosts map[string]Resource, newHosts map[string]Reso
 }
 
 func detectChangesInListeners(oldListeners map[string]*TransportServerConfiguration, newListeners map[string]*TransportServerConfiguration) (removedListeners []string,
-	updatedListeners []string, addedListeners []string) {
+	updatedListeners []string, addedListeners []string,
+) {
 	for _, l := range getSortedTransportServerConfigurationKeys(oldListeners) {
 		_, exists := newListeners[l]
 		if !exists {

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -445,9 +445,10 @@ type OIDC struct {
 
 // WAF defines an WAF policy.
 type WAF struct {
-	Enable      bool         `json:"enable"`
-	ApPolicy    string       `json:"apPolicy"`
-	SecurityLog *SecurityLog `json:"securityLog"`
+	Enable       bool           `json:"enable"`
+	ApPolicy     string         `json:"apPolicy"`
+	SecurityLog  *SecurityLog   `json:"securityLog"`
+	SecurityLogs []*SecurityLog `json:"securityLogs"`
 }
 
 // SecurityLog defines the security log of a WAF policy.

--- a/pkg/apis/configuration/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/configuration/v1/zz_generated.deepcopy.go
@@ -1166,6 +1166,17 @@ func (in *WAF) DeepCopyInto(out *WAF) {
 		*out = new(SecurityLog)
 		**out = **in
 	}
+	if in.SecurityLogs != nil {
+		in, out := &in.SecurityLogs, &out.SecurityLogs
+		*out = make([]*SecurityLog, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(SecurityLog)
+				**out = **in
+			}
+		}
+	}
 	return
 }
 

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -1490,7 +1490,8 @@ func (vsv *VirtualServerValidator) ValidateVirtualServerRouteForVirtualServer(vi
 }
 
 func (vsv *VirtualServerValidator) validateVirtualServerRouteSpec(spec *v1.VirtualServerRouteSpec, fieldPath *field.Path, virtualServerHost string, vsPath string,
-	namespace string) field.ErrorList {
+	namespace string,
+) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateVirtualServerRouteHost(spec.Host, virtualServerHost, fieldPath.Child("host"))...)

--- a/tests/data/ap-waf/syslog-1.yaml
+++ b/tests/data/ap-waf/syslog-1.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: syslog-1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: syslog-1
+  template:
+    metadata:
+      labels:
+        app: syslog-1
+    spec:
+      containers:
+        - name: syslog
+          image: balabit/syslog-ng:3.35.1
+          ports:
+            - containerPort: 514
+            - containerPort: 601
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/syslog-ng/syslog-ng.conf
+            subPath: syslog-ng.conf
+      volumes:
+        - name: config-volume
+          configMap:
+            name: syslog-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: syslog-svc-1
+spec:
+  ports:
+    - port: 514
+      targetPort: 514
+      protocol: TCP
+  selector:
+    app: syslog-1


### PR DESCRIPTION
### Proposed changes
Add a field to policy crd which allows for specifying multiple log destinations. If the old field is used with the new field the old field is ignored. Otherwise old OR new fields work

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
