### PR TITLE
Fix goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: ${{ !startsWith(github.ref, 'refs/tags/') && 'build --snapshot' || 'release' }} ${{ github.event_name == 'pull_request' && '--single-target' || '' }} --rm-dist --id kubernetes-ingress
+          args: ${{ !startsWith(github.ref, 'refs/tags/') && 'build --snapshot' || 'release' }} ${{ github.event_name == 'pull_request' && '--single-target' || '' }} --rm-dist ${{ !startsWith(github.ref, 'refs/tags/') && '--id kubernetes-ingress' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOPATH: ${{ needs.check.outputs.go_path }}


### PR DESCRIPTION
### Proposed changes
There's a bug in the pipeline when we push a tag - goreleaser won't work with the "--id" flag when we are releasing the binaries. See https://github.com/nginxinc/kubernetes-ingress/runs/4727732721?check_suite_focus=true for the failed run.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

