### PR TITLE
fix: DOCOPS-560 add DOCS-XXX metadata to KIC docs

### DIFF
--- a/docs/content/app-protect-dos/configuration.md
+++ b/docs/content/app-protect-dos/configuration.md
@@ -1,10 +1,11 @@
 ---
 title: Configuration
 
-description:
+description: "This document describes how to configure the NGINX App Protect Dos module."
 weight: 1900
 doctypes: [""]
 toc: true
+docs: "DOCS-580"
 ---
 
 This document describes how to configure the NGINX App Protect Dos module

--- a/docs/content/app-protect-dos/dos-protected.md
+++ b/docs/content/app-protect-dos/dos-protected.md
@@ -1,10 +1,11 @@
 ---
 title: Dos Protected Resource
 
-description: 
+description: "Dos Protected Resource Specification"
 weight: 1800
 doctypes: [""]
 toc: true
+docs: "DOCS-581"
 ---
 
 > Note: This feature is only available in NGINX Plus with AppProtectDos.

--- a/docs/content/app-protect-dos/installation-with-helm-dos-arbitrator.md
+++ b/docs/content/app-protect-dos/installation-with-helm-dos-arbitrator.md
@@ -4,6 +4,7 @@ description:
 weight: 1900
 doctypes: [""]
 toc: true
+docs: "DOCS-582"
 ---
 
 ## Prerequisites

--- a/docs/content/app-protect-dos/installation.md
+++ b/docs/content/app-protect-dos/installation.md
@@ -1,9 +1,10 @@
 ---
 title: Installation with NGINX App Protect Dos
-description:
+description: "This document provides an overview of the steps required to use NGINX App Protect Dos with your NGINX Ingress Controller deployment."
 weight: 1800
 doctypes: [""]
 toc: true
+docs: "DOCS-583"
 ---
 
 > **Note**: The NGINX Kubernetes Ingress Controller integration with NGINX App Protect requires the use of NGINX Plus.

--- a/docs/content/app-protect/configuration.md
+++ b/docs/content/app-protect/configuration.md
@@ -1,10 +1,11 @@
 ---
 title: Configuration
 
-description:
+description: "This document describes how to configure the NGINX App Protect module"
 weight: 1900
 doctypes: [""]
 toc: true
+docs: "DOCS-578"
 ---
 
 This document describes how to configure the NGINX App Protect module

--- a/docs/content/app-protect/installation.md
+++ b/docs/content/app-protect/installation.md
@@ -1,9 +1,10 @@
 ---
 title: Installation with NGINX App Protect
-description:
+description: "This document provides an overview of the steps required to use NGINX App Protect with your NGINX Ingress Controller deployment."
 weight: 1800
 doctypes: [""]
 toc: true
+docs: "DOCS-579"
 ---
 
 > **Note**: The NGINX Kubernetes Ingress Controller integration with NGINX App Protect requires the use of NGINX Plus.

--- a/docs/content/configuration/configuration-examples.md
+++ b/docs/content/configuration/configuration-examples.md
@@ -1,10 +1,11 @@
 ---
 title: Configuration Examples
 
-description:
+description: "NGINX Ingress Controller configuration examples."
 weight: 2000
 doctypes: [""]
 toc: true
+docs: "DOCS-584"
 ---
 
 

--- a/docs/content/configuration/global-configuration/command-line-arguments.md
+++ b/docs/content/configuration/global-configuration/command-line-arguments.md
@@ -4,6 +4,7 @@ description:
 weight: 1700
 doctypes: [""]
 toc: true
+docs: "DOCS-585"
 ---
 
 

--- a/docs/content/configuration/global-configuration/configmap-resource.md
+++ b/docs/content/configuration/global-configuration/configmap-resource.md
@@ -1,10 +1,11 @@
 ---
 title: ConfigMap Resource
 
-description:
+description: "The ConfigMap resources allows you to customize or fine tune NGINX behavior."
 weight: 1600
 doctypes: [""]
 toc: true
+docs: "DOCS-586"
 ---
 
 

--- a/docs/content/configuration/global-configuration/custom-templates.md
+++ b/docs/content/configuration/global-configuration/custom-templates.md
@@ -5,6 +5,7 @@ description:
 weight: 1800
 doctypes: [""]
 toc: true
+docs: "DOCS-587"
 ---
 
 

--- a/docs/content/configuration/global-configuration/globalconfiguration-resource.md
+++ b/docs/content/configuration/global-configuration/globalconfiguration-resource.md
@@ -1,10 +1,11 @@
 ---
 title: GlobalConfiguration Resource
 
-description: 
+description: "The GlobalConfiguration resource allows you to define the global configuration parameters of the Ingress Controller."
 weight: 2000
 doctypes: [""]
 toc: true
+docs: "DOCS-588"
 ---
 
 

--- a/docs/content/configuration/global-configuration/reporting-resources-status.md
+++ b/docs/content/configuration/global-configuration/reporting-resources-status.md
@@ -7,6 +7,7 @@ doctypes: [""]
 aliases:
     - /report-ingress-status/
 toc: true
+docs: "DOCS-589"
 ---
 
 

--- a/docs/content/configuration/handling-host-and-listener-collisions.md
+++ b/docs/content/configuration/handling-host-and-listener-collisions.md
@@ -1,9 +1,10 @@
 ---
 title: Handling Host and Listener Collisions
-description:
+description: "This document explains how the Ingress Controller handles host and listener collisions among resources."
 weight: 1700
 doctypes: [""]
 toc: true
+docs: "DOCS-590"
 ---
 
 

--- a/docs/content/configuration/ingress-resources/advanced-configuration-with-annotations.md
+++ b/docs/content/configuration/ingress-resources/advanced-configuration-with-annotations.md
@@ -1,9 +1,10 @@
 ---
 title: Advanced Configuration with Annotations
-description:
+description: "This document explains how to use advanced features using annotations."
 weight: 1700
 doctypes: [""]
 toc: true
+docs: "DOCS-591"
 ---
 
 

--- a/docs/content/configuration/ingress-resources/advanced-configuration-with-snippets.md
+++ b/docs/content/configuration/ingress-resources/advanced-configuration-with-snippets.md
@@ -1,9 +1,10 @@
 ---
 title: Advanced Configuration with Snippets
-description:
+description: "Snippets allow you to insert raw NGINX config into different contexts of the NGINX configurations that the Ingress Controller generates."
 weight: 1800
 doctypes: [""]
 toc: true
+docs: "DOCS-592"
 ---
 
 

--- a/docs/content/configuration/ingress-resources/basic-configuration.md
+++ b/docs/content/configuration/ingress-resources/basic-configuration.md
@@ -1,10 +1,11 @@
 ---
 title: Basic Configuration
 
-description:
+description: "The example in this document shows a basic Ingress resource definition."
 weight: 1600
 doctypes: [""]
 toc: true
+docs: "DOCS-593"
 ---
 
 

--- a/docs/content/configuration/ingress-resources/cross-namespace-configuration.md
+++ b/docs/content/configuration/ingress-resources/cross-namespace-configuration.md
@@ -1,10 +1,11 @@
 ---
 title: Cross-namespace Configuration
 
-description:
+description: "This document explains how to spread Ingress configuration across different namespaces."
 weight: 2000
 doctypes: [""]
 toc: true
+docs: "DOCS-594"
 ---
 
 

--- a/docs/content/configuration/ingress-resources/custom-annotations.md
+++ b/docs/content/configuration/ingress-resources/custom-annotations.md
@@ -1,12 +1,13 @@
 ---
 title: Custom Annotations
 
-description:
+description: "Custom annotations enable you to quickly extend the Ingress resource to support many advanced features of NGINX, such as rate limiting, caching, etc."
 weight: 1900
 doctypes: [""]
 aliases:
     - /custom-annotations/
 toc: true
+docs: "DOCS-595"
 ---
 
 

--- a/docs/content/configuration/policy-resource.md
+++ b/docs/content/configuration/policy-resource.md
@@ -1,10 +1,11 @@
 ---
 title: Policy Resource
 
-description:
+description: "The Policy resource allows you to configure features like access control and rate-limiting."
 weight: 1800
 doctypes: [""]
 toc: true
+docs: "DOCS-596"
 ---
 
 

--- a/docs/content/configuration/security.md
+++ b/docs/content/configuration/security.md
@@ -1,9 +1,10 @@
 ---
 title: Security
-description: 
+description: "NGINX Ingress controller security recommendations."
 weight: 1500
 doctypes: [""]
 toc: true
+docs: "DOCS-597"
 ---
 
 

--- a/docs/content/configuration/transportserver-resource.md
+++ b/docs/content/configuration/transportserver-resource.md
@@ -1,9 +1,10 @@
 ---
 title: TransportServer Resource
-description:
+description: "The TransportServer resource allows you to configure TCP, UDP, and TLS Passthrough load balancing."
 weight: 1900
 doctypes: [""]
 toc: true
+docs: "DOCS-598"
 ---
 
 

--- a/docs/content/configuration/virtualserver-and-virtualserverroute-resources.md
+++ b/docs/content/configuration/virtualserver-and-virtualserverroute-resources.md
@@ -1,11 +1,12 @@
 ---
 title: VirtualServer and VirtualServerRoute Resources
-description:
+description: "The VirtualServer and VirtualServerRoute resources are new load balancing configuration offered as an alternative to the Ingress resource."
 weight: 1600
 doctypes: [""]
 aliases:
     - /virtualserver-and-virtualserverroute/
 toc: true
+docs: "DOCS-599"
 ---
 
 

--- a/docs/content/f5-ingresslink.md
+++ b/docs/content/f5-ingresslink.md
@@ -5,6 +5,7 @@ description: |
 weight: 1800
 doctypes: ["concept"]
 toc: true
+docs: "DOCS-600"
 ---
 
 

--- a/docs/content/installation/building-ingress-controller-image.md
+++ b/docs/content/installation/building-ingress-controller-image.md
@@ -1,9 +1,10 @@
 ---
 title: Building the Ingress Controller Image
-description:
+description: "This document explains how to build an Ingress Controller image using the source code."
 weight: 2200
 doctypes: [""]
 toc: true
+docs: "DOCS-601"
 ---
 
 This document explains how to build an Ingress Controller image using the source code. You can also use pre-built images: please see [here](/nginx-ingress-controller/installation/using-the-jwt-token-docker-secret) and [here](/nginx-ingress-controller/installation/pulling-ingress-controller-image) for details on how to pull the NGINX Ingress Controller based on NGINX Plus from the F5 Docker registry; for NGINX Ingress Controller based on NGINX OSS, we provide the images through [DockerHub](https://hub.docker.com/r/nginx/nginx-ingress/) and [GitHub Container](https://github.com/nginxinc/kubernetes-ingress/pkgs/container/kubernetes-ingress).

--- a/docs/content/installation/installation-with-helm.md
+++ b/docs/content/installation/installation-with-helm.md
@@ -1,9 +1,10 @@
 ---
 title: Installation with Helm
-description:
+description: "This document describes how to install the NGINX Ingress Controller in your Kubernetes cluster using Helm." 
 weight: 1900
 doctypes: [""]
 toc: true
+docs: "DOCS-602"
 ---
 
 

--- a/docs/content/installation/installation-with-manifests.md
+++ b/docs/content/installation/installation-with-manifests.md
@@ -1,11 +1,12 @@
 ---
 title: Installation with Manifests
-description:
+description: "This document describes how to install the NGINX Ingress Controller in your Kubernetes cluster using Kubernetes manifests."
 weight: 1800
 doctypes: [""]
 aliases:
     - /installation/
 toc: true
+docs: "DOCS-603"
 ---
 
 

--- a/docs/content/installation/installation-with-operator.md
+++ b/docs/content/installation/installation-with-operator.md
@@ -1,10 +1,11 @@
 ---
 title: Installation with the NGINX Ingress Operator
 
-description:
+description: "This document describes how to install the NGINX Ingress Controller in your Kubernetes cluster using the NGINX Ingress Operator." 
 weight: 2000
 doctypes: [""]
 toc: true
+docs: "DOCS-604"
 ---
 
 

--- a/docs/content/installation/pulling-ingress-controller-image.md
+++ b/docs/content/installation/pulling-ingress-controller-image.md
@@ -1,9 +1,10 @@
 ---
 title: Pulling the Ingress Controller Image
-description:
+description: "This document explains how to pull an NGINX Plus Ingress Controller image from the F5 Docker registry."
 weight: 1700
 doctypes: [""]
 toc: true
+docs: "DOCS-605"
 ---
 
 This document explains how to pull an NGINX Plus Ingress Controller image from the F5 Docker registry using your NGINX Ingress Controller subscription certificate and key. **Please note that an NGINX Plus subscription certificate and key will not work with the F5 Docker registry.** You can also get the image using alternative methods:

--- a/docs/content/installation/running-multiple-ingress-controllers.md
+++ b/docs/content/installation/running-multiple-ingress-controllers.md
@@ -1,12 +1,13 @@
 ---
 title: Running Multiple Ingress Controllers
 
-description: 
+description: "This document explains how to run multiple NGINX Ingress controllers."
 weight: 2100
 doctypes: [""]
 aliases:
     - /multiple-ingress-controllers/
 toc: true
+docs: "DOCS-606"
 ---
 
 

--- a/docs/content/installation/using-aws-marketplace-image.md
+++ b/docs/content/installation/using-aws-marketplace-image.md
@@ -1,9 +1,10 @@
 ---
 title: Using the AWS Marketplace Ingress Controller Image
-description: 
+description: "This document will walk you through the steps needed to use the NGINX Ingress Controller through the AWS Marketplace."
 weight: 2300
 doctypes: [""]
 toc: true
+docs: "DOCS-607"
 ---
 
 This document will walk you through the steps needed to use the NGINX Ingress Controller through the AWS Marketplace. There are additional steps that must be followed in order for the AWS Marketplace NGINX Ingress Controller to work properly.

--- a/docs/content/installation/using-the-jwt-token-docker-secret.md
+++ b/docs/content/installation/using-the-jwt-token-docker-secret.md
@@ -1,9 +1,10 @@
 ---
 title: Using the NGINX IC Plus JWT token in a Docker Config Secret
-description:
+description: "This document explains how to use the NGINX Plus Ingress Controller image from the F5 Docker registry in your Kubernetes cluster by using your NGINX Ingress Controller subscription JWT token."
 weight: 1600
 doctypes: [""]
 toc: true
+docs: "DOCS-608"
 ---
 
 This document explains how to use the NGINX Plus Ingress Controller image from the F5 Docker registry in your Kubernetes cluster by using your NGINX Ingress Controller subscription JWT token. **Please note that an NGINX Plus subscription certificate and key will not work with the F5 Docker registry.** You can also get the image using alternative methods:

--- a/docs/content/intro/how-nginx-ingress-controller-works.md
+++ b/docs/content/intro/how-nginx-ingress-controller-works.md
@@ -1,9 +1,10 @@
 ---
 title: How NGINX Ingress Controller Works
-description: 
+description: "This document explains how NGINX Ingress Controller works."
 weight: 300
 doctypes: [""]
 toc: true
+docs: "DOCS-609"
 ---
 
 

--- a/docs/content/intro/nginx-ingress-controllers.md
+++ b/docs/content/intro/nginx-ingress-controllers.md
@@ -5,6 +5,7 @@ weight: 200
 draft: true
 doctypes: ["concept"]
 toc: true
+docs: "DOCS-610"
 aliases:
   - /nginx-ingress-controllers/
 ---

--- a/docs/content/intro/nginx-plus.md
+++ b/docs/content/intro/nginx-plus.md
@@ -1,9 +1,10 @@
 ---
 title: NGINX Ingress Controller with NGINX Plus
-description:
+description: "This document explains the key characteristics that NGINX Plus brings on top of NGINX into the NGINX Ingress controller."
 weight: 400
 doctypes: ["concept"]
 toc: true
+docs: "DOCS-611"
 aliases:
   - /nginx-plus/
 ---

--- a/docs/content/intro/overview.md
+++ b/docs/content/intro/overview.md
@@ -4,6 +4,7 @@ description: Overview of the NGINX Ingress Controller
 weight: 100
 doctypes: [""]
 toc: true
+docs: "DOCS-612"
 ---
 
 

--- a/docs/content/logging-and-monitoring/logging.md
+++ b/docs/content/logging-and-monitoring/logging.md
@@ -1,10 +1,11 @@
 ---
 title: Logging
 
-description: 
+description: "This document gives an overview of logging provided by NGINX Ingress Controller."
 weight: 1800
 doctypes: [""]
 toc: true
+docs: "DOCS-613"
 ---
 
 

--- a/docs/content/logging-and-monitoring/prometheus.md
+++ b/docs/content/logging-and-monitoring/prometheus.md
@@ -1,12 +1,13 @@
 ---
 title: Prometheus
 
-description: 
+description: "The Ingress Controller exposes a number of metrics in the Prometheus format."
 weight: 2000
 doctypes: [""]
 aliases:
     - /prometheus/
 toc: true
+docs: "DOCS-614"
 ---
 
 

--- a/docs/content/logging-and-monitoring/status-page.md
+++ b/docs/content/logging-and-monitoring/status-page.md
@@ -1,10 +1,11 @@
 ---
 title: Status Page
 
-description: 
+description: "This document explains how to get access to the stub status in NGINX and the dashboard in NGINX Plus."
 weight: 1900
 doctypes: [""]
 toc: true
+docs: "DOCS-615"
 ---
 
 

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -1,9 +1,10 @@
 ---
 title: Releases
-description:
+description: "NGINX Ingress Controller Release Notes."
 weight: 1900
 doctypes: ["concept"]
 toc: true
+docs: "DOCS-616"
 ---
 
 ## NGINX Ingress Controller 2.1.0

--- a/docs/content/technical-specifications.md
+++ b/docs/content/technical-specifications.md
@@ -1,9 +1,10 @@
 ---
 title: Technical Specifications
-description:
+description: "NGINX Ingress Controller Technical Specifications."
 weight: 2000
 doctypes: ["concept"]
 toc: true
+docs: "DOCS-617"
 ---
 
 

--- a/docs/content/third-party-modules/opentracing.md
+++ b/docs/content/third-party-modules/opentracing.md
@@ -1,11 +1,12 @@
 ---
 title: OpenTracing
-description:
+description: "This document explains how to use OpenTracing with the Ingress Controller."
 weight: 2000
 doctypes: [""]
 aliases:
   - /opentracing/
 toc: true
+docs: "DOCS-618"
 ---
 
 

--- a/docs/content/troubleshooting/troubleshoot-ingress-controller.md
+++ b/docs/content/troubleshooting/troubleshoot-ingress-controller.md
@@ -2,7 +2,7 @@
 title: "Troubleshooting Common Issues"
 date: 2021-07-13T21:01:29-06:00
 draft: true
-description: ""
+description: "This document describes how to troubleshoot problems with the Ingress Controller."
 # Assign weights in increments of 100
 weight: 100
 draft: false
@@ -12,6 +12,7 @@ tags: [ "docs" ]
 # These are pre-populated with all available terms for your convenience.
 # Remove all terms that do not apply.
 doctypes: ["troubleshooting"]
+docs: "DOCS-619"
 ---
 
 ## Overview

--- a/docs/content/troubleshooting/troubleshooting-with-app-protect-dos.md
+++ b/docs/content/troubleshooting/troubleshooting-with-app-protect-dos.md
@@ -1,11 +1,12 @@
 ---
 title: Troubleshooting with NGINX App Protect Dos
-description:
+description: "This document describes how to troubleshoot problems with the Ingress Controller with the App Protect Dos module enabled." 
 weight: 2000
 doctypes: [""]
 aliases:
 - /app-protect/troubleshooting/
 toc: true
+docs: "DOCS-620"
 ---
 
 This document describes how to troubleshoot problems with the Ingress Controller with the App Protect Dos module enabled.

--- a/docs/content/troubleshooting/troubleshooting-with-app-protect.md
+++ b/docs/content/troubleshooting/troubleshooting-with-app-protect.md
@@ -1,11 +1,12 @@
 ---
 title: Troubleshooting with NGINX App Protect
-description: 
+description: "This document describes how to troubleshoot problems with the Ingress Controller with the App Protect module enabled."
 weight: 2000
 doctypes: [""]
 aliases:
     - /app-protect/troubleshooting/
 toc: true
+docs: "DOCS-621"
 ---
 
 This document describes how to troubleshoot problems with the Ingress Controller with the [App Protect](/nginx-app-protect/) module enabled.


### PR DESCRIPTION
### Proposed changes
Add the DOCS-XXX metadata to KIC documentation. 
Add most of the missing `description` metadata fields.

More information: 
https://nginxsoftware.atlassian.net/wiki/spaces/ENGUSEMEA/pages/1811873873/Watchdocs+-+Documentation+Catalog+and+Audit

Closes DOCOPS-560