### PR TITLE
Bump syslog server image version in tests

### DIFF
--- a/tests/data/ap-waf-grpc/syslog.yaml
+++ b/tests/data/ap-waf-grpc/syslog.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: syslog
-          image: balabit/syslog-ng:3.31.2-buster
+          image: balabit/syslog-ng:3.35.1
           ports:
             - containerPort: 514
             - containerPort: 601

--- a/tests/data/ap-waf/syslog.yaml
+++ b/tests/data/ap-waf/syslog.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: syslog
-          image: balabit/syslog-ng:3.31.2-buster
+          image: balabit/syslog-ng:3.35.1
           ports:
             - containerPort: 514
             - containerPort: 601

--- a/tests/data/appprotect/syslog.yaml
+++ b/tests/data/appprotect/syslog.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: syslog
-        image: balabit/syslog-ng:3.31.2-buster
+        image: balabit/syslog-ng:3.35.1
         ports:
         - containerPort: 514
         - containerPort: 601

--- a/tests/data/appprotect/syslog2.yaml
+++ b/tests/data/appprotect/syslog2.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: syslog2
-        image: balabit/syslog-ng:3.31.2-buster
+        image: balabit/syslog-ng:3.35.1
         ports:
         - containerPort: 514
         - containerPort: 601

--- a/tests/data/dos/dos-syslog.yaml
+++ b/tests/data/dos/dos-syslog.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: syslog
-          image: balabit/syslog-ng:3.31.2-buster
+          image: balabit/syslog-ng:3.35.1
           ports:
             - containerPort: 514
             - containerPort: 601

--- a/tests/data/virtual-server-dos/syslog.yaml
+++ b/tests/data/virtual-server-dos/syslog.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: syslog
-          image: balabit/syslog-ng:3.31.2-buster
+          image: balabit/syslog-ng:3.35.1
           ports:
             - containerPort: 514
             - containerPort: 601


### PR DESCRIPTION
### Proposed changes
The syslog image we were using has disappeared from dockerhub. This commit moves us to a newer version.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
