### PR TITLE
initial workaound for IPv6 workload support

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -48,7 +48,7 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	&& apt-get install -y bsdutils mount util-linux libuuid1 libmount1 libblkid1 libsmartcols1 \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
-	&& DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \
+	&& DEBIAN_VERSION=bullseye \
 	&& printf "%s\n" "Acquire::https::pkgs.nginx.com::User-Agent \"k8s-ic-$IC_VERSION${BUILD_OS##debian-plus}-apt\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
 	&& printf "%s\n" "deb https://pkgs.nginx.com/plus/${NGINX_PLUS_VERSION^^}/debian ${DEBIAN_VERSION} nginx-plus" > /etc/apt/sources.list.d/nginx-plus.list \
 	&& apt-get update \
@@ -57,7 +57,16 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	&& rm -rf /var/lib/apt/lists/*
 
 
-############################################# Base image for Debian with NGINX Plus and App Protect WAF/DoS #############################################
+
+#RUN \
+#	DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \
+#	&& ls -l /etc/ \
+#	&& cat /etc/os-release \
+#	&& echo "Debug"
+#
+
+
+############################################# Base image for Debian with NGINX Plus and App Protect #############################################
 FROM debian-plus as debian-plus-nap
 ARG NGINX_PLUS_VERSION
 ARG NAP_MODULES

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -2,6 +2,7 @@ package configs
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -456,10 +457,16 @@ func createUpstream(ingEx *IngressEx, name string, backend *networking.IngressBa
 		}
 
 		for _, endp := range endps {
-			pos := strings.LastIndex(endp, ":")
+			addr, port, err := net.SplitHostPort(endp)
+
+			if err != nil {
+				glog.Warningf("invalid endpoint address: %s", err.Error())
+				continue
+			}
+
 			upsServers = append(upsServers, version1.UpstreamServer{
-				Address:     endp[:pos],
-				Port:        endp[pos+1:],
+				Address:     addr,
+				Port:        port,
 				MaxFails:    cfg.MaxFails,
 				MaxConns:    cfg.MaxConns,
 				FailTimeout: cfg.FailTimeout,

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -456,10 +456,10 @@ func createUpstream(ingEx *IngressEx, name string, backend *networking.IngressBa
 		}
 
 		for _, endp := range endps {
-			addressport := strings.Split(endp, ":")
+			pos := strings.LastIndex(endp, ":")
 			upsServers = append(upsServers, version1.UpstreamServer{
-				Address:     addressport[0],
-				Port:        addressport[1],
+				Address:     endp[:pos],
+				Port:        endp[pos+1:],
 				MaxFails:    cfg.MaxFails,
 				MaxConns:    cfg.MaxConns,
 				FailTimeout: cfg.FailTimeout,

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -22,12 +22,14 @@ upstream {{$upstream.Name}} {
 server {
 	{{if $server.SpiffeCerts}}
 	listen 443 ssl;
+	listen [::]:443 ssl;
 	ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
 	ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
 	{{else}}
 	{{if not $server.GRPCOnly}}
 	{{range $port := $server.Ports}}
 	listen {{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	listen [::]:{{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
 	{{- end}}
 	{{end}}
 
@@ -39,6 +41,7 @@ server {
 	{{else}}
 	{{- range $port := $server.SSLPorts}}
 	listen {{$port}} ssl{{if $server.HTTP2}} http2{{end}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	listen [::]:{{$port}} ssl{{if $server.HTTP2}} http2{{end}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
 	{{- end}}
 	{{end}}
 	{{if $server.SSLRejectHandshake}}

--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -149,6 +149,7 @@ http {
         set $service "";
 
         listen 80 default_server{{if .ProxyProtocol}} proxy_protocol{{end}};
+        listen [::]:80 default_server{{if .ProxyProtocol}} proxy_protocol{{end}};
 
         {{if .TLSPassthrough}}
         listen unix:/var/lib/nginx/passthrough-https.sock ssl default_server{{if .HTTP2}} http2{{end}} proxy_protocol;
@@ -156,6 +157,7 @@ http {
         real_ip_header proxy_protocol;
         {{else}}
         listen 443 ssl default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};
+        listen [::]:443 ssl default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};
         {{end}}
 
         {{if .SSLRejectHandshake}}
@@ -196,6 +198,7 @@ http {
     # NGINX Plus APIs
     server {
         listen {{.NginxStatusPort}};
+        listen [::]:{{.NginxStatusPort}};
 
         root /usr/share/nginx/html;
 
@@ -255,6 +258,7 @@ http {
     {{if .InternalRouteServer}}
     server {
         listen 443 ssl;
+        listen [::]:443 ssl;
         server_name {{.InternalRouteServerName}};
         ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
         ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
@@ -290,6 +294,7 @@ stream {
 
     server {
         listen 443;
+        listen [::]:443;
 
         ssl_preread on;
 

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -13,6 +13,7 @@ server {
 	{{if not $server.GRPCOnly}}
 	{{range $port := $server.Ports}}
 	listen {{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	listen [::]:{{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
 	{{- end}}
 	{{end}}
 
@@ -24,6 +25,7 @@ server {
 	{{else}}
 	{{- range $port := $server.SSLPorts}}
 	listen {{$port}} ssl{{if $server.HTTP2}} http2{{end}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
+	listen [::]:{{$port}} ssl{{if $server.HTTP2}} http2{{end}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
 	{{- end}}
 	{{end}}
 	{{if $server.SSLRejectHandshake}}

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -107,6 +107,7 @@ http {
         set $service "";
 
         listen 80 default_server{{if .ProxyProtocol}} proxy_protocol{{end}};
+        listen [::]:80 default_server{{if .ProxyProtocol}} proxy_protocol{{end}};
 
         {{if .TLSPassthrough}}
         listen unix:/var/lib/nginx/passthrough-https.sock ssl default_server{{if .HTTP2}} http2{{end}} proxy_protocol;
@@ -114,6 +115,7 @@ http {
         real_ip_header proxy_protocol;
         {{else}}
         listen 443 ssl default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};
+        listen [::]:443 ssl default_server{{if .HTTP2}} http2{{end}}{{if .ProxyProtocol}} proxy_protocol{{end}};
         {{end}}
 
         {{if .SSLRejectHandshake}}

--- a/internal/configs/version2/nginx-plus.transportserver.tmpl
+++ b/internal/configs/version2/nginx-plus.transportserver.tmpl
@@ -35,6 +35,7 @@ server {
     set_real_ip_from unix:;
     {{ else }}
     listen {{ $s.Port }}{{ if $s.UDP }} udp{{ end }};
+    listen [::]:{{ $s.Port }}{{ if $s.UDP }} udp{{ end }};
     {{ end }}
 
     status_zone {{ $s.StatusZone }};

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -59,6 +59,7 @@ match {{ $m.Name }} {
 {{ $s := .Server }}
 server {
     listen 80{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};
+    listen [::]:80{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};
 
     server_name {{ $s.ServerName }};
     status_zone {{ $s.StatusZone }};
@@ -89,6 +90,7 @@ server {
     real_ip_header proxy_protocol;
         {{ else }}
     listen 443 ssl{{ if $ssl.HTTP2 }} http2{{ end }}{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};
+    listen [::]:443 ssl{{ if $ssl.HTTP2 }} http2{{ end }}{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};
         {{ end }}
 
         {{ if $ssl.RejectHandshake }}

--- a/internal/configs/version2/nginx.transportserver.tmpl
+++ b/internal/configs/version2/nginx.transportserver.tmpl
@@ -23,6 +23,7 @@ server {
     set_real_ip_from unix:;
     {{ else }}
     listen {{ $s.Port }}{{ if $s.UDP }} udp{{ end }};
+    listen [::]:{{ $s.Port }}{{ if $s.UDP }} udp{{ end }};
     {{ end }}
 
     {{ if $s.ProxyRequests }}

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -41,6 +41,7 @@ limit_req_zone {{ $z.Key }} zone={{ $z.ZoneName }}:{{ $z.ZoneSize }} rate={{ $z.
 {{ $s := .Server }}
 server {
     listen 80{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};
+    listen [::]:80{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};
 
     server_name {{ $s.ServerName }};
 
@@ -56,6 +57,7 @@ server {
     real_ip_header proxy_protocol;
         {{ else }}
     listen 443 ssl{{ if $ssl.HTTP2 }} http2{{ end }}{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};
+    listen [::]:443 ssl{{ if $ssl.HTTP2 }} http2{{ end }}{{ if $s.ProxyProtocol }} proxy_protocol{{ end }};
         {{ end }}
 
         {{ if $ssl.RejectHandshake }}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -19,6 +19,8 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -2992,10 +2994,7 @@ func getEndpointsBySubselectedPods(targetPort int32, pods []*api_v1.Pod, svcEps 
 }
 
 func ipv6SafeAddrPort(addr string, port int32) string {
-	if strings.Count(addr, ":") > 1 && !strings.Contains(addr, "[") {
-		addr = "[" + addr + "]"
-	}
-	return fmt.Sprintf("%v:%v", addr, port) // why %v?
+	return net.JoinHostPort(addr, strconv.Itoa(int(port)))
 }
 
 func getPodName(pod *api_v1.ObjectReference) string {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,6 +12,15 @@ KIND_KUBE_CONFIG_FOLDER = $${HOME}/.kube/kind
 SHOW_IC_LOGS = no
 PYTEST_ARGS =
 DOCKERFILEPATH = docker/Dockerfile
+KIND_TEMPLATE_FILE_PATH=kind/kind-config-template.yaml
+IP_FAMILY ?= ipv4
+IP_ADDR_PROPERTY = .IPAddress
+IP_ADDR_FMT = "%s"
+
+ifeq (${IP_FAMILY}, ipv6)
+IP_ADDR_PROPERTY = .GlobalIPv6Address
+IP_ADDR_FMT = "[%s]"
+endif
 
 .PHONY: build
 build:
@@ -21,17 +30,36 @@ build:
 run-tests:
 	docker run --rm -v $(KUBE_CONFIG_FOLDER):/root/.kube $(PREFIX):$(TAG) --context=$(CONTEXT) --image=$(BUILD_IMAGE) --image-pull-policy=$(PULL_POLICY) --deployment-type=$(DEPLOYMENT_TYPE) --ic-type=$(IC_TYPE) --service=$(SERVICE) --node-ip=$(NODE_IP) --show-ic-logs=$(SHOW_IC_LOGS) $(PYTEST_ARGS)
 
+
+.PHONY: get-kind-cluster-ip
+get-kind-cluster-ip:	
+	$(eval KIND_CLUSTER_IP=$(shell docker inspect -f '{{range .NetworkSettings.Networks}}{{${IP_ADDR_PROPERTY}}}{{end}}' kind-control-plane ))
+	$(eval KIND_CLUSTER_IP=$(shell printf ${IP_ADDR_FMT} "${KIND_CLUSTER_IP}"))
+
+
+.PHONY: update-test-kind-config
+update-test-kind-config: get-kind-cluster-ip
+	sed -ir "s|server:.*|server: https://${KIND_CLUSTER_IP}:6443|" $(KIND_KUBE_CONFIG_FOLDER)/config
+
 .PHONY: run-tests-in-kind
-run-tests-in-kind:
-	$(eval KIND_CLUSTER_IP=$(shell docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane))
-	sed -i "" "s|server:.*|server: https://$(KIND_CLUSTER_IP):6443|" $(KIND_KUBE_CONFIG_FOLDER)/config
-	docker run --network=kind --rm -v $(KIND_KUBE_CONFIG_FOLDER):/root/.kube $(PREFIX):$(TAG) --context=kind-kind --image=$(BUILD_IMAGE) --image-pull-policy=$(PULL_POLICY) --deployment-type=$(DEPLOYMENT_TYPE) --ic-type=$(IC_TYPE) --service=nodeport --node-ip=$(KIND_CLUSTER_IP) --show-ic-logs=$(SHOW_IC_LOGS) $(PYTEST_ARGS)
+run-tests-in-kind: update-test-kind-config
+	docker run --network=kind --rm -v $(KIND_KUBE_CONFIG_FOLDER):/root/.kube $(PREFIX):$(TAG) \
+			--context=kind-kind \
+			--image=$(BUILD_IMAGE) --image-pull-policy=$(PULL_POLICY) \
+			--deployment-type=$(DEPLOYMENT_TYPE) \
+			--ic-type=$(IC_TYPE) \
+			--service=nodeport \
+			--node-ip=$(KIND_CLUSTER_IP) \
+			--show-ic-logs=$(SHOW_IC_LOGS) \
+			$(PYTEST_ARGS)
 
 .PHONY: create-kind-cluster
 create-kind-cluster:
 	$(eval K8S_VERSION=$(shell grep "K8S_VERSION:" ../.github/workflows/ci.yml | awk -F" " '{print $$2}'))
-	kind create cluster --image kindest/node:v$(K8S_VERSION)
+	cat ${KIND_TEMPLATE_FILE_PATH} | sed "s/{{.IPFamily}}/${IP_FAMILY}/" > kind-config.yaml
+	kind create cluster --image kindest/node:v$(K8S_VERSION) --config kind-config.yaml
 	kind export kubeconfig --kubeconfig $(KIND_KUBE_CONFIG_FOLDER)/config
+	kind load docker-image ${BUILD_IMAGE}
 
 .PHONY: delete-kind-cluster
 delete-kind-cluster:

--- a/tests/kind/kind-config-template.yaml
+++ b/tests/kind/kind-config-template.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: {{.IPFamily}}
+  #apiServerAddress: "127.0.0.1"
+  #apiServerPort: 6443
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker


### PR DESCRIPTION
### Proposed changes
IPv6 support in k8s is hitting mainstream and at some point IPv6 will become first class citizen in k8s deployments. 
Ingress Controller code currently assumes that all workload addresses are IPv4, leading to failures using IC in IPv6 enabled
clusters (or pure IPv6 clusters - see robin.io).

Theres a bug addressing this : https://github.com/nginxinc/kubernetes-ingress/issues/991

Turns out the fix is rather simple (at least when validated against a pure IPv6 cluster).

The use cases that this fix can address include:
1. IPv6 clusters where workloads (Service Endpoints mapped to upstreams)  are assigned IPv6 addresses. 
2. Dual Stack clusters where workloads are assigned IPv4/IPv6 addresses
   Note that the change below (and the underlying assumption of IC) wrt an endpoint having a single address will need to be tested
   


####Note
At this stage testing has been performed manually on an IPv6 cluster with a simple nginx deployment serving as the
workload. The test environment has shown that:
1. the initial nginx configuration generated includes the right format IP address for the upstreams 
2. scaling the deployment up and using the Plus API to add a new entry resulted in no error
3. scaling the deployment down and using the Plus API to remove the deleted entry resulted in no error

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works - TBD
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation - N/A ?
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
