### PR TITLE
Add support for s390x on UBI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
           platforms: ["linux/arm, linux/arm64, linux/amd64, linux/ppc64le, linux/s390x"]
           include:
             - image: ubi
-              platforms: "linux/arm64, linux/amd64"
+              platforms: "linux/arm64, linux/amd64, linux/s390x"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/docs/content/technical-specifications.md
+++ b/docs/content/technical-specifications.md
@@ -34,7 +34,7 @@ All images include NGINX 1.21.5.
 |Alpine-based image with OpenTracing | ``nginx:1.21.5-alpine``, which is based on ``alpine:3.15`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:2.1.0-alpine-ot`` | arm/v7, arm64, amd64, ppc64le, s390x |
 |Debian-based image | ``nginx:1.21.5``, which is based on ``debian:bullseye-slim`` |  | ``nginx/nginx-ingress:2.1.0`` | arm/v7, arm64, amd64, ppc64le, s390x |
 |Debian-based image with OpenTracing | ``nginx:1.21.5``, which is based on ``debian:bullseye-slim`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:2.1.0-ot`` | arm/v7, arm64, amd64, ppc64le, s390x |
-|Ubi-based image | ``redhat/ubi8`` |  | ``nginx/nginx-ingress:2.1.0-ubi`` | arm64, amd64 |
+|Ubi-based image | ``redhat/ubi8`` |  | ``nginx/nginx-ingress:2.1.0-ubi`` | arm64, amd64, s390x |
 {{% /table %}}
 
 ### Images with NGINX Plus


### PR DESCRIPTION
NGINX now builds for `s390x` for CentOS/RHEL so now we can too.