### PR TITLE
Use fixed variable in CI to use cache

### DIFF
--- a/.github/actions/smoke-tests/action.yaml
+++ b/.github/actions/smoke-tests/action.yaml
@@ -62,7 +62,9 @@ runs:
         tags: 'docker.io/nginx/${{ steps.ingress-type.outputs.name }}:${{ inputs.image }}-${{ github.sha }}'
         load: true
         pull: true
-        build-args: BUILD_OS=${{ inputs.image }}
+        build-args: |
+          BUILD_OS=${{ inputs.image }}
+          IC_VERSION=CI
         secrets: |
           "nginx-repo.crt=${{ inputs.nginx-crt }}"
           "nginx-repo.key=${{ inputs.nginx-key }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
           pull: true
           build-args: |
             BUILD_OS=${{ matrix.image }}
-            IC_VERSION=${{ steps.var.outputs.ic_version }}
+            IC_VERSION=${{ github.event_name != 'pull_request' && steps.var.outputs.ic_version || 'CI' }}
           secrets: |
             "nginx-repo.crt=${{ secrets.NGINX_CRT }}"
             "nginx-repo.key=${{ secrets.NGINX_KEY }}"
@@ -506,6 +506,7 @@ jobs:
           load: true
           build-args: |
             BUILD_OS=${{ matrix.image }}
+            IC_VERSION=CI
           secrets: |
             "nginx-repo.crt=${{ secrets.NGINX_CRT }}"
             "nginx-repo.key=${{ secrets.NGINX_KEY }}"


### PR DESCRIPTION
Using a different value for `IC_VERSION` in PRs would invalidate the cache. 
