### PR TITLE
docs: Fix typo

### DIFF
--- a/docs/content/installation/installation-with-manifests.md
+++ b/docs/content/installation/installation-with-manifests.md
@@ -113,7 +113,7 @@ If you would like to use the App Protect Dos module, create the following additi
 
    ```
    $ kubectl apply -f common/crds/appprotectdos.f5.com_apdoslogconfs.yaml
-   $ kubectl apply -f common/crds/appprotectdos.f5.com_apdospolicies.yaml
+   $ kubectl apply -f common/crds/appprotectdos.f5.com_apdospolicy.yaml
    $ kubectl apply -f common/crds/appprotectdos.f5.com_dosprotectedresources.yaml
    ```
 


### PR DESCRIPTION
### Proposed changes
In the installation with manifests doc, `kubectl apply -f common/crds/appprotectdos.f5.com_apdospolicies.yaml`
should be `kubectl apply -f common/crds/appprotectdos.f5.com_apdospolicy.yaml`

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
