### PR TITLE
Fix CVE-2022-24407

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -44,6 +44,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
 	apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https libcap2-bin \
+	# temporary fix for CVE-2022-22822
+	&& apt-get install -y libexpat1 \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
 	&& DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \
@@ -103,6 +105,8 @@ LABEL name="NGINX Ingress Controller" \
 	io.openshift.tags="nginx,ingress-controller,ingress,controller,kubernetes,openshift"
 
 RUN dnf --nodocs install -y shadow-utils ca-certificates \
+	# temporary fix for CVE-2022-24407
+	&& dnf --nodocs install -y cyrus-sasl-lib \
 	&& groupadd --system --gid 101 nginx \
 	&& useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx
 


### PR DESCRIPTION
### Proposed changes

See https://access.redhat.com/security/cve/CVE-2022-24407 for details on the `cyrus-sasl-lib` vulnerability.

See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22822 for details on the `libexpat1` vulberability.
