### PR TITLE
Fix for CVE-2022-24407 in Debian

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y libcap2-bin \
 	# temporary fix for CVE-2022-22822
 	&& apt-get install -y libexpat1 \
+	# temporary fix for CVE-2022-24407
+	&& apt-get install -y libsasl2-2 \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& echo $NGINX_VERSION > nginx_version
 
@@ -46,6 +48,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https libcap2-bin \
 	# temporary fix for CVE-2022-22822
 	&& apt-get install -y libexpat1 \
+	# temporary fix for CVE-2022-24407
+	&& apt-get install -y libsasl2-2 \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
 	&& DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \


### PR DESCRIPTION
### Proposed changes
https://avd.aquasec.com/nvd/2022/cve-2022-24407/

The fix is now available for Debian images
