### PR TITLE
Show coverage report in HTML format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ test: ## Run tests
 cover: ## Generate coverage report
 	@./hack/test-cover.sh
 
+cover-html: ## Generate and show coverage report in HTML format
+	go test -shuffle=on -race ./... -count=1 -cover -covermode=atomic -coverprofile=coverage.out
+	go tool cover -html coverage.out
+
 .PHONY: verify-codegen
 verify-codegen: ## Verify code generation
 	./hack/verify-codegen.sh


### PR DESCRIPTION
### Proposed changes

Add a make target ```make cover-html``` for running tests with coverage and displaying reports in HTML format in local browser. When test execution is completed test coverage report is automatically opened in default web browser.

Example:
```bash
➜  kubernetes-ingress git:(local-coverage-check) make cover-html
go test -shuffle=on -race ./... -count=1 -cover -covermode=atomic -coverprofile=coverage.out
ok  	github.com/nginxinc/kubernetes-ingress/cmd/nginx-ingress	2.535s	coverage: 6.8% of statements
ok  	github.com/nginxinc/kubernetes-ingress/internal/configs	1.873s	coverage: 66.6% of statements
[...]
go tool cover -html coverage.out

```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
