### PR TITLE
Show available make targets

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,26 +13,43 @@ SHOW_IC_LOGS = no
 PYTEST_ARGS =
 DOCKERFILEPATH = docker/Dockerfile
 
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+default: help
+
+.PHONY: help ## Show this help
+help: ## Show available make targets
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
 .PHONY: build
-build:
+build: ## Run build
 	docker build -t $(PREFIX):$(TAG) -f $(DOCKERFILEPATH) ..
 
 .PHONY: run-tests
-run-tests:
+run-tests: ## Run tests
 	docker run --rm -v $(KUBE_CONFIG_FOLDER):/root/.kube $(PREFIX):$(TAG) --context=$(CONTEXT) --image=$(BUILD_IMAGE) --image-pull-policy=$(PULL_POLICY) --deployment-type=$(DEPLOYMENT_TYPE) --ic-type=$(IC_TYPE) --service=$(SERVICE) --node-ip=$(NODE_IP) --show-ic-logs=$(SHOW_IC_LOGS) $(PYTEST_ARGS)
 
 .PHONY: run-tests-in-kind
-run-tests-in-kind:
+run-tests-in-kind: ## Run tests in Kind
 	$(eval KIND_CLUSTER_IP=$(shell docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane))
 	sed -i "" "s|server:.*|server: https://$(KIND_CLUSTER_IP):6443|" $(KIND_KUBE_CONFIG_FOLDER)/config
 	docker run --network=kind --rm -v $(KIND_KUBE_CONFIG_FOLDER):/root/.kube $(PREFIX):$(TAG) --context=kind-kind --image=$(BUILD_IMAGE) --image-pull-policy=$(PULL_POLICY) --deployment-type=$(DEPLOYMENT_TYPE) --ic-type=$(IC_TYPE) --service=nodeport --node-ip=$(KIND_CLUSTER_IP) --show-ic-logs=$(SHOW_IC_LOGS) $(PYTEST_ARGS)
 
 .PHONY: create-kind-cluster
-create-kind-cluster:
+create-kind-cluster: ## Create Kind cluster
 	$(eval K8S_VERSION=$(shell grep "K8S_VERSION:" ../.github/workflows/ci.yml | awk -F" " '{print $$2}'))
 	kind create cluster --image kindest/node:v$(K8S_VERSION)
 	kind export kubeconfig --kubeconfig $(KIND_KUBE_CONFIG_FOLDER)/config
 
 .PHONY: delete-kind-cluster
-delete-kind-cluster:
+delete-kind-cluster: ## Delete Kind cluster
 	kind delete cluster


### PR DESCRIPTION
### Proposed changes

```make``` command defaults to target ```help```. This behaviour aligns with make command in the root folder of the project.

Example:
```bash
➜  tests git:(acceptance-tests) ✗ make
help                 Show available make targets
build                Run build
run-tests            Run tests
run-tests-in-kind    Run tests in Kind
create-kind-cluster  Create Kind cluster
delete-kind-cluster  Delete Kind cluster
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
