### PR TITLE
Update documentation to remove preview policy requirement from TransportServer

### DIFF
--- a/docs/content/configuration/transportserver-resource.md
+++ b/docs/content/configuration/transportserver-resource.md
@@ -12,8 +12,6 @@ The TransportServer resource allows you to configure TCP, UDP, and TLS Passthrou
 
 This document is the reference documentation for the TransportServer resource. To see additional examples of using the resource for specific use cases, go to the [examples/custom-resources](https://github.com/nginxinc/kubernetes-ingress/tree/v2.1.1/examples/custom-resources) folder in our GitHub repo.
 
-> **Feature Status**: The TransportServer resource is available as a preview feature[^1]: We might introduce some backward-incompatible changes to the resource definition. The feature is disabled by default. To enable it, set the [enable-preview-policies](/nginx-ingress-controller/configuration/global-configuration/command-line-arguments/#cmdoption-enable-preview-policies) command-line argument of the Ingress Controller.
-
 ## Prerequisites
 
 * For TCP and UDP, the TransportServer resource must be used in conjunction with the [GlobalConfiguration resource](/nginx-ingress-controller/configuration/global-configuration/globalconfiguration-resource), which must be created separately.
@@ -378,9 +376,5 @@ The [ConfigMap](/nginx-ingress-controller/configuration/global-configuration/con
 
 ## Limitations
 
-The TransportServer resource is a preview feature. Currently, it comes with the following limitation:
+The TransportServer resource currently comes with the following limitation:
 * When using TLS Passthrough, it is not possible to configure [Proxy Protocol](https://github.com/nginxinc/kubernetes-ingress/tree/v2.0.1/examples/proxy-protocol) for port 443 both for regular HTTPS and TLS Passthrough traffic.
-
-## Footnotes
-
-[^1]: Capabilities labeled in preview status are fully supported.


### PR DESCRIPTION
### Proposed changes
TransportServer does not require the preview policy. This PR is to update the documentation to reflect the actual implementation. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
