### PR TITLE
Fix for CVE-2022-0778 and CVE-2021-4160

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update \
 FROM docker.io/library/nginx:1.21.6-alpine AS alpine
 
 RUN apk add --no-cache libcap \
-    # Temp fix for CVE-2022-0778
-    && apk add libcrypto1.1~1.1.1n-r0 libssl1.1~1.1.1n-r0
+	# Temp fix for CVE-2022-0778 and CVE-2022-23308
+	&& apk upgrade --no-cache libcrypto1.1 libssl1.1 libxml2 libxslt
 
 
 ############################################# Base image for Alpine with NGINX Plus #############################################
@@ -35,8 +35,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/apk/cert.pem,mode=0644 \
 	wget -nv -O /etc/apk/keys/nginx_signing.rsa.pub https://cs.nginx.com/static/keys/nginx_signing.rsa.pub \
 	&& printf "%s\n" "https://pkgs.nginx.com/plus/alpine/v$(grep -E -o '^[0-9]+\.[0-9]+' /etc/alpine-release)/main" >> /etc/apk/repositories \
 	&& apk add --no-cache libcap nginx-plus~${NGINX_PLUS_VERSION#r} nginx-plus-module-njs~${NGINX_PLUS_VERSION#r} \
-    # Temp fix for CVE-2022-0778
-    && apk add libcrypto1.1~1.1.1n-r0 libssl1.1~1.1.1n-r0
+	# Temp fix for CVE-2022-0778
+	&& apk upgrade --no-cache libcrypto1.1 libssl1.1
 
 
 ############################################# Base image for Debian with NGINX Plus #############################################

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y libcap2-bin \
 	# temporary fix for CVE-2022-22822
 	&& apt-get install -y libexpat1 \
-	# temporary fix for CVE-2022-24407
-	&& apt-get install -y libsasl2-2 \
+	# temporary fix for CVE-2022-0778 and CVE-2021-4160
+	&& apt-get install -y libssl1.1 openssl \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& echo $NGINX_VERSION > nginx_version
 
@@ -22,8 +22,8 @@ RUN apt-get update \
 FROM docker.io/library/nginx:1.21.6-alpine AS alpine
 
 RUN apk add --no-cache libcap \
-    # Temp fix for CVE-2022-23308
-    && apk add --no-cache libxml2~2.9.13-r0
+    # Temp fix for CVE-2022-0778
+    && apk add libcrypto1.1~1.1.1n-r0 libssl1.1~1.1.1n-r0
 
 
 ############################################# Base image for Alpine with NGINX Plus #############################################
@@ -35,8 +35,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/apk/cert.pem,mode=0644 \
 	wget -nv -O /etc/apk/keys/nginx_signing.rsa.pub https://cs.nginx.com/static/keys/nginx_signing.rsa.pub \
 	&& printf "%s\n" "https://pkgs.nginx.com/plus/alpine/v$(grep -E -o '^[0-9]+\.[0-9]+' /etc/alpine-release)/main" >> /etc/apk/repositories \
 	&& apk add --no-cache libcap nginx-plus~${NGINX_PLUS_VERSION#r} nginx-plus-module-njs~${NGINX_PLUS_VERSION#r} \
-	# Temp fix for CVE-2022-23308
-    && apk add --no-cache libxml2~2.9.13-r0
+    # Temp fix for CVE-2022-0778
+    && apk add libcrypto1.1~1.1.1n-r0 libssl1.1~1.1.1n-r0
 
 
 ############################################# Base image for Debian with NGINX Plus #############################################
@@ -52,8 +52,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https libcap2-bin \
 	# temporary fix for CVE-2022-22822
 	&& apt-get install -y libexpat1 \
-	# temporary fix for CVE-2022-24407
-	&& apt-get install -y libsasl2-2 \
+	# temporary fix for CVE-2022-0778 and CVE-2021-4160
+	&& apt-get install -y libssl1.1 openssl \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
 	&& DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \


### PR DESCRIPTION
### Proposed changes

Fix for avd.aquasec.com/nvd/cve-2022-0778 and avd.aquasec.com/nvd/cve-2021-4160

Also removes unnecessary library installs for CVE-2022-24407 and CVE-2022-23308