### PR TITLE
Add kind in Dockerfile to extract version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ defaults:
     shell: bash
 
 env:
-  K8S_VERSION: 1.23.4
-  K8S_TIMEOUT: 75s
   HELM_CHART_DIR: deployments/helm-chart
   GIT_NAME: NGINX Kubernetes Team
   GIT_MAIL: kubernetes@nginx.com
@@ -49,6 +47,7 @@ jobs:
     outputs:
       go_version: ${{ steps.vars.outputs.go_version }}
       go_path: ${{ steps.go.outputs.go_path }}
+      k8s_latest: ${{ steps.vars.outputs.k8s_latest }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -65,6 +64,7 @@ jobs:
         id: vars
         run: |
           echo "::set-output name=go_version::$(grep "go 1." go.mod | cut -d " " -f 2)"
+          echo "::set-output name=k8s_latest::$(grep -m1 'FROM kindest/node' <tests/docker/Dockerfile | awk -F'[:v]' '{print $3}')"
       - name: Setup Golang Environment
         uses: actions/setup-go@v2
         with:
@@ -147,7 +147,7 @@ jobs:
   setup-matrix:
     name: Setup Matrix for Smoke Tests
     runs-on: ubuntu-20.04
-    needs: [binary, unit-tests]
+    needs: [binary, unit-tests, checks]
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -164,9 +164,10 @@ jobs:
                                                 {\"image\": \"debian-plus\", \"marker\": \"ts\"}, \
                                                 {\"image\": \"alpine-plus\", \"marker\":\"ingresses\"}, \
                                                 {\"image\": \"opentracing-plus\", \"marker\": \"vsr\"}, \
-                                                {\"image\": \"ubi-plus\", \"marker\": \"policies\"}]}"
+                                                {\"image\": \"ubi-plus\", \"marker\": \"policies\"}], \
+                                              \"k8s\": [\"${{ needs.checks.outputs.k8s_latest }}\"]}"
           else
-            echo "::set-output name=matrix::{\"k8s\": [\"1.19.16\", \"1.20.15\", \"1.21.10\", \"1.22.7\", \"1.23.4\"]}"
+            echo "::set-output name=matrix::{\"k8s\": [\"1.19.16\", \"1.20.15\", \"1.21.10\", \"1.22.7\", \"${{ needs.checks.outputs.k8s_latest }}\"]}"
           fi
 
   smoke-tests:
@@ -185,7 +186,7 @@ jobs:
         with:
           image: ${{ matrix.images.image != '' && matrix.images.image || 'debian' }}
           marker: ${{ matrix.images.marker != '' && matrix.images.marker || '' }}
-          k8s-version: ${{ matrix.k8s != '' && matrix.k8s || env.K8S_VERSION }}
+          k8s-version: ${{ matrix.k8s }}
           nginx-crt: ${{ secrets.NGINX_CRT }}
           nginx-key: ${{ secrets.NGINX_KEY }}
       - name: Upload Test Results
@@ -198,7 +199,7 @@ jobs:
   helm-tests:
     name: Helm Tests
     runs-on: ubuntu-20.04
-    needs: [binary, unit-tests]
+    needs: [binary, unit-tests, checks]
     env:
       NGINX_HTTP_PORT: 8080
       NGINX_HTTPS_PORT: 8443
@@ -229,7 +230,7 @@ jobs:
       - name: Deploy Kubernetes
         id: k8s
         run: |
-          kind create cluster --name ${{ github.run_id }} --image=kindest/node:v${{ env.K8S_VERSION }} --wait ${{ env.K8S_TIMEOUT }}
+          kind create cluster --name ${{ github.run_id }} --image=kindest/node:v${{ needs.checks.outputs.k8s_latest }} --wait 75s
           kind load docker-image nginx-ingress:${{ github.sha }} --name ${{ github.run_id }}
       - name: Install Chart
         run: >

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -56,7 +56,7 @@ jobs:
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           echo "::set-output name=sha_long::$(git rev-parse HEAD)"
           echo "::set-output name=go_version::$(grep "go 1." go.mod | cut -d " " -f 2)"
-          echo "::set-output name=k8s_version::$(grep "K8S_VERSION:" .github/workflows/ci.yml | awk -F" " '{print $2}')"
+          echo "::set-output name=k8s_version::$(grep -m1 'FROM kindest/node' <tests/docker/Dockerfile | awk -F'[:v]' '{print $3}')"
 
   check:
     name: Check if updates are needed

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -46,8 +46,8 @@ run-tests-in-kind: ## Run tests in Kind
 
 .PHONY: create-kind-cluster
 create-kind-cluster: ## Create Kind cluster
-	$(eval K8S_VERSION=$(shell grep "K8S_VERSION:" ../.github/workflows/ci.yml | awk -F" " '{print $$2}'))
-	kind create cluster --image kindest/node:v$(K8S_VERSION)
+	$(eval KIND_IMAGE=$(shell grep -m1 'FROM kindest/node' <docker/Dockerfile | awk -F'[ ]' '{print $$2}'))
+	kind create cluster --image $(KIND_IMAGE)
 	kind export kubeconfig --kubeconfig $(KIND_KUBE_CONFIG_FOLDER)/config
 
 .PHONY: delete-kind-cluster

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,4 +1,7 @@
 # syntax=docker/dockerfile:1.3
+# this is here so we can grab the latest version of kind and have dependabot keep it up to date
+FROM kindest/node:v1.23.4
+
 FROM python:3.10
 
 RUN apt-get update \


### PR DESCRIPTION
Adds `kind` image in the tests Dockerfile so we can have dependabot keep it up to date. When building the Dockerfile the image won't be pulled since it's not needed by any other layer, it's just there for dependabot.