### PR TITLE
Cherry-pick updates to pull-ingress-controller-image doc to release branch (#2530)

### DIFF
--- a/docs/content/installation/pulling-ingress-controller-image.md
+++ b/docs/content/installation/pulling-ingress-controller-image.md
@@ -6,22 +6,22 @@ doctypes: [""]
 toc: true
 ---
 
-This document explains how to pull an NGINX Plus Ingress Controller image from the F5 Docker registry using your NGINX Ingress Controller subscription certificate and key. **Please note that an NGINX Plus subscription certificate and key will not work with the F5 Docker registry.** You can also get the image using alternative methods:
+This document explains how to pull an NGINX Plus Ingress Controller image from the F5 Docker registry using your NGINX Ingress Controller subscription certificate and key. **Please note that an NGINX Plus subscription certificate and key will not work with the F5 Docker registry.** You can also get the image using the following alternate methods:
 
-* Please see [here](/nginx-ingress-controller/installation/using-the-jwt-token-docker-secret) for details on how to use the JWT token to use the image directly in your Kubernetes cluster.
-* Please see [here](/nginx-ingress-controller/installation/building-ingress-controller-image) for information on how to build an Ingress Controller image using the source code from this repository and your NGINX Plus subscription certificate and key.
-* For NGINX Ingress Controller based on NGINX OSS, we provide the image through DockerHub.
+* [Install using a JWT token in a Docker Config Secret]({{< relref "using-the-jwt-token-docker-secret" >}})
+* [Build the Ingress Controller image]({{< relref "building-ingress-controller-image" >}}) using the source code from the GitHub repository and your NGINX Plus subscription certificate and key.
+* For NGINX Ingress Controller based on NGINX OSS, you can pull the [nginx/nginx-ingress image](https://hub.docker.com/r/nginx/nginx-ingress/) from DockerHub.
 
 ## Prerequisites
 
 Before you can pull the image, make sure that the following software is installed on your machine:
 * [Docker](https://www.docker.com/products/docker) v18.09+
-* For NGINX Ingress Controller, you must have the NGINX Ingress Controller subscription -- download the NGINX Plus Ingress Controller (per instance) certificate (`nginx-repo.crt`) and the key (`nginx-repo.key`) from [MyF5](https://myf5.com).
+* For NGINX Ingress Controller, you must have the NGINX Ingress Controller subscription -- download the NGINX Plus Ingress Controller (per instance) certificate (`nginx-repo.crt`) and the key (`nginx-repo.key`) from [MyF5](https://my.f5.com).
 
 ## Pulling the Image using Docker and Pushing It to the Private Registry
 
 1. First, configure the Docker environment to use certificate-based client-server authentication with the F5 Container registry - `private-registry.nginx.com`.
-   To do so in a Linux based environment, create a `private-registry.nginx.com` directory under `/etc/docker/certs.d` and create a certificate `client.cert` (using `nginx-repo.crt` - please note that the certificate MUST have the `.cert` suffix, not `.crt`) and a key `client.key` (using `nginx-repo.key`). See [this document](https://docs.docker.com/engine/security/certificates/) for more details.
+   To do so in a Linux based environment, create a `private-registry.nginx.com` directory under `/etc/docker/certs.d` and create a certificate `client.cert` (using `nginx-repo.crt` - please note that the certificate MUST have the `.cert` suffix, not `.crt`) and a key `client.key` (using `nginx-repo.key`). See  the [Docker Engine Security documentation](https://docs.docker.com/engine/security/certificates/) for more details.
 
    ```
    # mkdir /etc/docker/certs.d/private-registry.nginx.com
@@ -29,20 +29,20 @@ Before you can pull the image, make sure that the following software is installe
    # cp nginx-repo.key /etc/docker/certs.d/private-registry.nginx.com/client.key
    ```
 
-    > **Note**: The preceding example is operating-system specific and is for illustrative purposes only. You should consult your operating system documentation for creating an os-provided bundled certificate chain. For example, to configure this for Docker Desktop for Mac or Docker Desktop for Windows, see [this document](https://docs.docker.com/docker-for-mac/#add-client-certificates) or [this document](https://docs.docker.com/docker-for-windows/#how-do-i-add-client-certificates) for more details.
+    > **Note**: The preceding example is operating-system specific and is for illustrative purposes only. You should consult your operating system documentation for creating an os-provided bundled certificate chain. For example, to configure this for Docker Desktop for Mac or Docker Desktop for Windows, see the [Docker for Mac documentation](https://docs.docker.com/docker-for-mac/#add-client-certificates) or [Docker for Windows documentation](https://docs.docker.com/docker-for-windows/#how-do-i-add-client-certificates) for more details.
 
-2. Use docker to pull the required image from `private-registry.nginx.com`. Choose the image from the available images listed [here](nginx-ingress-controller/technical-specifications/#images-with-nginx-plus).
-   For NGINX Plus Ingress Controller, pull from `private-registry.nginx.com/nginx-ic/nginx-plus-ingress`, e.g.:
+2. Use Docker to pull the required image from `private-registry.nginx.com`. Choose the image from the available images listed in the [tech specs guide]({{< relref "technical-specifications#images-with-nginx-plus" >}}).
+   For NGINX Plus Ingress Controller, pull from `private-registry.nginx.com/nginx-ic/nginx-plus-ingress`. For example:
    ```
    $ docker pull private-registry.nginx.com/nginx-ic/nginx-plus-ingress:2.1.1
    ```
 
-   For NGINX Plus Ingress Controller with App Protect, pull from `private-registry.nginx.com/nginx-ic-nap/nginx-plus-ingress`, e.g.:
+   For NGINX Plus Ingress Controller with App Protect, pull from `private-registry.nginx.com/nginx-ic-nap/nginx-plus-ingress`. For example:
    ```
    $ docker pull private-registry.nginx.com/nginx-ic-nap/nginx-plus-ingress:2.1.1
    ```
 
-   To list the available image tags for the repositories, you can also use the Docker registry API, e.g.:
+   To list the available image tags for the repositories, you can also use the Docker registry API. For example:
    ```
    $ curl https://private-registry.nginx.com/v2/nginx-ic/nginx-plus-ingress/tags/list --key <path-to-client.key> --cert <path-to-client.cert> | jq
    {
@@ -66,7 +66,10 @@ Before you can pull the image, make sure that the following software is installe
    ```
 
 3. Tag and push the image to your private registry.
-   Make sure to run the `docker login` command first to log in to the registry.
+
+   - Make sure to run the `docker login <my-docker-registry>` command first to log in to the registry.
+   - Replace `<my-docker-registry>` in the examples below with the correct path to your private Docker registry.
+
    ```
    $ docker tag private-registry.nginx.com/nginx-ic/nginx-plus-ingress:2.1.1 <my-docker-registry>/nginx-ic/nginx-plus-ingress:2.1.1
    $ docker push <my-docker-registry>/nginx-ic/nginx-plus-ingress:2.1.1


### PR DESCRIPTION
Cherry-pick from main: 6ca56c604dd99bd148ba8a2fb91f19a1338402fb

- Fix broken links reported by field
- Update link target text so that instead of using "here", they have descriptions of the target documents. This is especially important when linking out to external locations (like the Docker docs)
- Use hugo `relref` for internal doc links -- when these are used, hugo build will fail if the link is broken
- Change "e.g." to "for example" -- brings us into compliance with internal style guide

### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
