### PR TITLE
Restore binary upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,12 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: build --snapshot --rm-dist --id kubernetes-ingress --single-target
+          args: build --snapshot --rm-dist --single-target
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GOPATH: ${{ needs.check.outputs.go_path }}
+          GOPATH: ${{ needs.checks.outputs.go_path }}
+          AWS_PRODUCT_CODE: ${{ secrets.AWS_PRODUCT_CODE }}
+          AWS_PUB_KEY: ${{ secrets.AWS_PUB_KEY }}
       - name: Store Artifacts in Cache
         uses: actions/cache@v3
         with:
@@ -277,14 +279,23 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ needs.checks.outputs.go_version }}
+      - name: Publish Release Notes on new tag
+        uses: release-drafter/release-drafter@v5
+        with:
+            publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Build binaries
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: build --rm-dist --id kubernetes-ingress ${{ github.event_name == 'pull_request' && '--single-target' || '' }} ${{ !startsWith(github.ref, 'refs/tags/') && '--snapshot' || '' }}
+          args: ${{ startsWith(github.ref, 'refs/tags/') && 'release' || 'build --snapshot' }} ${{ github.event_name == 'pull_request' && '--single-target' || '' }} --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GOPATH: ${{ needs.check.outputs.go_path }}
+          GOPATH: ${{ needs.checks.outputs.go_path }}
+          AWS_PRODUCT_CODE: ${{ secrets.AWS_PRODUCT_CODE }}
+          AWS_PUB_KEY: ${{ secrets.AWS_PUB_KEY }}
       - name: Store Artifacts in Cache
         uses: actions/cache@v3
         with:
@@ -600,16 +611,3 @@ jobs:
           git -c user.name='${{ env.GIT_NAME }}' -c user.email='${{ env.GIT_MAIL }}' \
           commit -m "NGINX Ingress Controller - Release ${{ needs.package-helm.outputs.type }} ${{ needs.package-helm.outputs.version }}"
           git push -u origin master
-
-  publish-release-notes:
-    name: Publish Release Notes
-    runs-on: ubuntu-20.04
-    needs: release-helm
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    steps:
-      - name: Publish Release Notes
-        uses: release-drafter/release-drafter@v5
-        with:
-            publish: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     flags:
       - -trimpath
     gcflags:
@@ -32,12 +33,19 @@ builds:
     asmflags:
       - all=-trimpath={{.Env.GOPATH}}
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.productCode={{.Env.PRODUCT_CODE}} -X main.pubKeyString={{.Env.PUB_KEY}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.productCode={{.Env.AWS_PRODUCT_CODE}} -X main.pubKeyString={{.Env.AWS_PUB_KEY}}
     main: ./cmd/nginx-ingress/
     binary: nginx-ingress
     tags:
       - aws
 archives:
-- format: binary
+  - id: kubernetes-ingress
+    format: binary
+    builds: [kubernetes-ingress]
+  - id: aws
+    format: binary
+    builds: [aws]
 changelog:
   skip: true
+release:
+  ids: [kubernetes-ingress]


### PR DESCRIPTION
Restores binary upload that was reverted in https://github.com/nginxinc/kubernetes-ingress/pull/2335

The problem was that it's not possible to build only a specific binary on release, so we need to build both.