### PR TITLE
Fix CVE and remove unnecessary package installs for debian

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,8 +9,8 @@ FROM nginx:1.21.6 AS debian
 
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y libcap2-bin \
-	# temp fix for CVE-2022-0891, CVE-2021-33574, CVE-2021-3997 and CVE-2022-23308
-	&& apt-get install -y libtiff5 libc6 libc-bin libxml2 libsystemd0 libudev1 \
+	# temp fix for CVE-2018-25032
+	&& apt-get install -y zlib1g \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& echo $NGINX_VERSION > nginx_version
 
@@ -46,8 +46,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
 	apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https libcap2-bin \
-	# temp fix for CVE-2021-33574 and CVE-2021-3997
-	&& apt-get install -y libc6 libc-bin libsystemd0 libudev1 \
+	# temp fix for CVE-2018-25032
+	&& apt-get install -y zlib1g \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
 	&& DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \


### PR DESCRIPTION
See https://avd.aquasec.com/nvd/2018/cve-2018-25032/ for details
