### PR TITLE
Add runAsNonRoot in deployments

### DIFF
--- a/deployments/deployment/nginx-ingress.yaml
+++ b/deployments/deployment/nginx-ingress.yaml
@@ -39,6 +39,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: true
           runAsUser: 101 #nginx
+          runAsNonRoot: true
           capabilities:
             drop:
             - ALL

--- a/deployments/deployment/nginx-plus-ingress.yaml
+++ b/deployments/deployment/nginx-plus-ingress.yaml
@@ -39,6 +39,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: true
           runAsUser: 101 #nginx
+          runAsNonRoot: true
           capabilities:
             drop:
             - ALL

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -97,6 +97,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: true
           runAsUser: 101 #nginx
+          runAsNonRoot: true
           capabilities:
             drop:
             - ALL

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -97,6 +97,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: true
           runAsUser: 101 #nginx
+          runAsNonRoot: true
           capabilities:
             drop:
             - ALL


### PR DESCRIPTION
Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
