### PR TITLE
Fix: Fix Cert-manager RBAC in Helm

### DIFF
--- a/deployments/helm-chart/templates/rbac.yaml
+++ b/deployments/helm-chart/templates/rbac.yaml
@@ -129,6 +129,19 @@ rules:
   - watch
   - get
 {{- end }}
+{{- if .Values.controller.enableCertManager }}
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+  - create
+  - delete
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/custom-resources/certmanager/README.md
+++ b/examples/custom-resources/certmanager/README.md
@@ -8,7 +8,7 @@ Then, we deploy the NGINX or NGINX Plus Ingress controller, a simple web applica
 1. Deploy cert manager and all dependent resources:
 
     ```
-    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cert-manager.yaml
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml
     ```
 2. Deploy a self-signed certificate issuer:
 


### PR DESCRIPTION
### Proposed changes
Updating the Helm RBAC template with cert-manager permissions was missed in the original PR.

Also update example to use latest cert-manager deployment yaml.
