### PR TITLE
Release drafter can't have empty template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -30,3 +30,4 @@ autolabeler:
       - 'vendor*'
     branch:
       - '/deps\/.+/'
+template: "not used, but required"


### PR DESCRIPTION
Even if we use release drafter only for labeling the PRs, we need to have the template set.
