### PR TITLE
allow configuring topologySpreadConstraints in Helm chart

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -172,6 +172,7 @@ Parameter | Description | Default
 `controller.terminationGracePeriodSeconds` | The termination grace period of the Ingress Controller pod. | 30
 `controller.tolerations` | The tolerations of the Ingress Controller pods. | []
 `controller.affinity` | The affinity of the Ingress Controller pods. | {}
+`controller.topologySpreadConstraints` | The topology spread constraints of the Ingress controller pods. | {}
 `controller.volumes` | The volumes of the Ingress Controller pods. | []
 `controller.volumeMounts` | The volumeMounts of the Ingress Controller pods. | []
 `controller.initContainers` | InitContainers for the Ingress Controller pods. | []

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -50,6 +50,10 @@ spec:
       affinity:
 {{ toYaml .Values.controller.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.controller.topologySpreadConstraints | indent 8 }}
+{{- end }}
 {{- if or (.Values.controller.volumes) (.Values.nginxServiceMesh.enable) }}
       volumes:
 {{- end }}

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -118,6 +118,9 @@ controller:
   ## The affinity of the Ingress Controller pods.
   affinity: {}
 
+  ## The topology spread constraints of the Ingress controller pods.
+  topologySpreadConstraints: {}
+
   ## The volumes of the Ingress Controller pods.
   volumes: []
   # - name: extra-conf


### PR DESCRIPTION
### Proposed changes
This allows a user of the Helm chart to add topologySpreadConstraints to the ingress pots, for example in order to ensure even distribution among availability zones.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork


Fixes #2629