### PR TITLE
[FIX] Add terminationGracePeriodSeconds to deployment

### DIFF
--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -66,6 +66,7 @@ spec:
       priorityClassName: {{ .Values.controller.priorityClassName }}
 {{- end }}
       serviceAccountName: {{ include "nginx-ingress.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
       containers:
       - image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"


### PR DESCRIPTION
### Proposed changes
Since `terminationGracePeriodSeconds` option is defined in the `values.yaml` and used in the `daemonset` resource, it makes sense to add it to the `deployment` resource to make this attribute customizable

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] I have checked that all unit tests pass after adding my changes
- [ X] I have updated necessary documentation
- [ X] I have rebased my branch onto main
- [ X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
