### PR TITLE
Update docs to reflect DNS01 Issuer support

### DIFF
--- a/docs/content/configuration/virtualserver-and-virtualserverroute-resources.md
+++ b/docs/content/configuration/virtualserver-and-virtualserverroute-resources.md
@@ -98,7 +98,7 @@ basedOn: scheme
 
 ### VirtualServer.TLS.CertManager
 
-The cert-manager field configures x509 automated Certificate management for VirtualServer resources using cert-manager (cert-manager.io). Please see the [cert-manager configuration documentation](https://cert-manager.io/docs/configuration/) for more information on deploying and configuring Issuers (Please note that ACME Issuers are not yet supported). Example:
+The cert-manager field configures x509 automated Certificate management for VirtualServer resources using cert-manager (cert-manager.io). Please see the [cert-manager configuration documentation](https://cert-manager.io/docs/configuration/) for more information on deploying and configuring Issuers (Please note that HTTP01 type ACME Issuers are not yet supported). Example:
 ```yaml
 cert-manager:
   cluster-issuer: "my-issuer-name"

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -13,7 +13,7 @@ docs: "DOCS-616"
 
 OVERVIEW:
 
-* Support for automatic provisioning and management of Certificate resources for VirtualServer resources using [cert-manager](https://cert-manager.io/docs/). Examples for configuring cert-manager with NGINX Ingress Controller can be found [here](https://github.com/nginxinc/kubernetes-ingress/tree/v2.2.0/examples/custom-resources/certmanager). Please note that ACME type Issuers are not yet supported for use with VirtualServer resources.
+* Support for automatic provisioning and management of Certificate resources for VirtualServer resources using [cert-manager](https://cert-manager.io/docs/). Examples for configuring cert-manager with NGINX Ingress Controller can be found [here](https://github.com/nginxinc/kubernetes-ingress/tree/v2.2.0/examples/custom-resources/certmanager). Please note that HTTP01 type ACME Issuers are not yet supported for use with VirtualServer resources.
 
 * Full support for IPv6 using the NGINX Ingress Controller [VirtualServer and VirtualServerRoute](https://docs.nginx.com/nginx-ingress-controller/configuration/virtualserver-and-virtualserverroute-resources) custom resources, and Ingress resources.
 


### PR DESCRIPTION
### Proposed changes
DNS01 ACME type cert-manager Issuers are supported using VirtualServer resources. This commit updates the docs to make this clearer by specifying that only HTTP01 type ACME Issuers are not yet supported.
