### PR TITLE
Add minReadySeconds & strategy support

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -232,6 +232,8 @@ Parameter | Description | Default
 `controller.readyStatus.enable` | Enables the readiness endpoint `"/nginx-ready"`. The endpoint returns a success code when NGINX has loaded all the config after the startup. This also configures a readiness probe for the Ingress Controller pods that uses the readiness endpoint. | true
 `controller.readyStatus.port` | The HTTP port for the readiness endpoint. | 8081
 `controller.enableLatencyMetrics` | Enable collection of latency metrics for upstreams. Requires `prometheus.create`. | false
+`controller.minReadySeconds` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0
+`controller.strategy` | Specifies the strategy used to replace old Pods by new ones. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | {}
 `rbac.create` | Configures RBAC. | true
 `prometheus.create` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | false
 `prometheus.port` | Configures the port to scrape the metrics. | 9113

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -208,3 +208,10 @@ spec:
       initContainers: {{ toYaml .Values.controller.initContainers | nindent 8 }}
 {{- end }}
 {{- end }}
+{{- if .Values.controller.strategy }}
+  strategy:
+{{ toYaml .Values.controller.strategy | indent 4 }}
+{{- end }}
+{{- if .Values.controller.minReadySeconds }}
+  minReadySeconds: {{ .Values.controller.minReadySeconds }}
+{{- end }}

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -209,7 +209,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- if .Values.controller.strategy }}
-  strategy:
+  updateStrategy:
 {{ toYaml .Values.controller.strategy | indent 4 }}
 {{- end }}
 {{- if .Values.controller.minReadySeconds }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -207,3 +207,10 @@ spec:
       initContainers: {{ toYaml .Values.controller.initContainers | nindent 8 }}
 {{- end }}
 {{- end }}
+{{- if .Values.controller.strategy }}
+  strategy:
+{{ toYaml .Values.controller.strategy | indent 4 }}
+{{- end }}
+{{- if .Values.controller.minReadySeconds }}
+  minReadySeconds: {{ .Values.controller.minReadySeconds }}
+{{- end }}

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -136,6 +136,12 @@ controller:
   #   image: busybox:1.34
   #   command: ['sh', '-c', 'echo this is initial setup!']
 
+  ## The minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available.
+  minReadySeconds: 0
+
+    ## Strategy used to replace old Pods by new ones. .spec.strategy.type can be "Recreate" or "RollingUpdate". "RollingUpdate" is the default value.
+  strategy: {}
+
   ## Extra containers for the Ingress Controller pods.
   extraContainers: []
   # - name: container


### PR DESCRIPTION
### Proposed changes
Adding support for deployment strategy and minReadySeconds to helm chart.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
