### PR TITLE
AP: log-conf escaping chars

### DIFF
--- a/deployments/common/crds/appprotect.f5.com_aplogconfs.yaml
+++ b/deployments/common/crds/appprotect.f5.com_aplogconfs.yaml
@@ -33,6 +33,15 @@ spec:
               properties:
                 content:
                   properties:
+                    escaping_characters:
+                      items:
+                        properties:
+                          from:
+                            type: string
+                          to:
+                            type: string
+                        type: object
+                      type: array
                     format:
                       enum:
                         - splunk
@@ -42,6 +51,12 @@ spec:
                         - grpc
                       type: string
                     format_string:
+                      type: string
+                    list_delimiter:
+                      type: string
+                    list_prefix:
+                      type: string
+                    list_suffix:
                       type: string
                     max_message_size:
                       pattern: ^([1-9]|[1-5][0-9]|6[0-4])k$

--- a/deployments/helm-chart/crds/appprotect.f5.com_aplogconfs.yaml
+++ b/deployments/helm-chart/crds/appprotect.f5.com_aplogconfs.yaml
@@ -33,6 +33,15 @@ spec:
               properties:
                 content:
                   properties:
+                    escaping_characters:
+                      items:
+                        properties:
+                          from:
+                            type: string
+                          to:
+                            type: string
+                        type: object
+                      type: array
                     format:
                       enum:
                         - splunk
@@ -42,6 +51,12 @@ spec:
                         - grpc
                       type: string
                     format_string:
+                      type: string
+                    list_delimiter:
+                      type: string
+                    list_prefix:
+                      type: string
+                    list_suffix:
                       type: string
                     max_message_size:
                       pattern: ^([1-9]|[1-5][0-9]|6[0-4])k$

--- a/tests/data/ap-waf/logconf-esc.yaml
+++ b/tests/data/ap-waf/logconf-esc.yaml
@@ -1,0 +1,19 @@
+apiVersion: appprotect.f5.com/v1beta1
+kind: APLogConf
+metadata:
+  name: logconf-esc
+spec:
+  content:
+    format: user-defined
+    max_message_size: 64k
+    max_request_size: any
+    format_string: "{\"my_attack_type\": \"%attack_type%\"}"
+    escaping_characters:
+      - from: '"'
+        to: '\"'
+    list_prefix: "["
+    list_delimiter: ","
+    list_suffix: "]" 
+  
+  filter:
+    request_type: all


### PR DESCRIPTION
### Proposed changes
Add [fields](https://docs.nginx.com/nginx-app-protect/configuration-guide/configuration/#log-with-escaped-character-and-custom-list-prefix--delimiter--suffix) related to security log formatting missing from the logconf CRD.


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
