### PR TITLE
Support default client proxy headers to be overwritten in VirtualServer

### DIFF
--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -481,14 +481,33 @@ server {
         proxy_set_header Connection $vs_connection_header;
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
             {{ end }}
+
+        {{- $custom_headers := $l.ProxySetHeaders | headerListToCIMap }}
+
+        {{- if not ($custom_headers | hasCIKey "X-Real-IP") }}
         {{ $proxyOrGRPC }}_set_header X-Real-IP $remote_addr;
+        {{- end }}
+
+        {{- if not ($custom_headers | hasCIKey "X-Forwarded-For") }}
         {{ $proxyOrGRPC }}_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        {{- end }}
+
+        {{- if not ($custom_headers | hasCIKey "X-Forwarded-Host") }}
         {{ $proxyOrGRPC }}_set_header X-Forwarded-Host $host;
+        {{- end }}
+
+        {{- if not ($custom_headers | hasCIKey "X-Forwarded-Port") }}
         {{ $proxyOrGRPC }}_set_header X-Forwarded-Port $server_port;
+        {{- end }}
+
+        {{- if not ($custom_headers | hasCIKey "X-Forwarded-Proto") }}
         {{ $proxyOrGRPC }}_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
-            {{ range $h := $l.ProxySetHeaders }}
+        {{- end }}
+
+        {{- range $h := $l.ProxySetHeaders }}
         {{ $proxyOrGRPC }}_set_header {{ $h.Name }} "{{ $h.Value }}";
-            {{ end }}
+        {{- end }}
+
             {{ range $h := $l.ProxyHideHeaders }}
         {{ $proxyOrGRPC }}_hide_header {{ $h }};
             {{ end }}

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -318,14 +318,33 @@ server {
         proxy_set_header Connection $vs_connection_header;
         proxy_pass_request_headers {{ if $l.ProxyPassRequestHeaders }}on{{ else }}off{{ end }};
             {{ end }}
+
+        {{- $custom_headers := $l.ProxySetHeaders | headerListToCIMap }}
+
+        {{- if not ($custom_headers | hasCIKey "X-Real-IP") }}
         {{ $proxyOrGRPC }}_set_header X-Real-IP $remote_addr;
+        {{- end }}
+
+        {{- if not ($custom_headers | hasCIKey "X-Forwarded-For") }}
         {{ $proxyOrGRPC }}_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        {{- end }}
+
+        {{- if not ($custom_headers | hasCIKey "X-Forwarded-Host") }}
         {{ $proxyOrGRPC }}_set_header X-Forwarded-Host $host;
+        {{- end }}
+
+        {{- if not ($custom_headers | hasCIKey "X-Forwarded-Port") }}
         {{ $proxyOrGRPC }}_set_header X-Forwarded-Port $server_port;
+        {{- end }}
+
+        {{- if not ($custom_headers | hasCIKey "X-Forwarded-Proto") }}
         {{ $proxyOrGRPC }}_set_header X-Forwarded-Proto {{ with $s.TLSRedirect }}{{ .BasedOn }}{{ else }}$scheme{{ end }};
-            {{ range $h := $l.ProxySetHeaders }}
+        {{- end }}
+
+        {{- range $h := $l.ProxySetHeaders }}
         {{ $proxyOrGRPC }}_set_header {{ $h.Name }} "{{ $h.Value }}";
-            {{ end }}
+        {{- end }}
+
             {{ range $h := $l.ProxyHideHeaders }}
         {{ $proxyOrGRPC }}_hide_header {{ $h }};
             {{ end }}

--- a/internal/configs/version2/template_executor.go
+++ b/internal/configs/version2/template_executor.go
@@ -24,7 +24,7 @@ type TemplateExecutor struct {
 func NewTemplateExecutor(virtualServerTemplatePath string, transportServerTemplatePath string) (*TemplateExecutor, error) {
 	// template names  must be the base name of the template file https://golang.org/pkg/text/template/#Template.ParseFiles
 
-	vsTemplate, err := template.New(path.Base(virtualServerTemplatePath)).ParseFiles(virtualServerTemplatePath)
+	vsTemplate, err := template.New(path.Base(virtualServerTemplatePath)).Funcs(helperFunctions).ParseFiles(virtualServerTemplatePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/configs/version2/template_helper.go
+++ b/internal/configs/version2/template_helper.go
@@ -1,0 +1,26 @@
+package version2
+
+import (
+	"strings"
+	"text/template"
+)
+
+func headerListToCIMap(headers []Header) map[string]string {
+	ret := make(map[string]string)
+
+	for _, header := range headers {
+		ret[strings.ToLower(header.Name)] = header.Value
+	}
+
+	return ret
+}
+
+func hasCIKey(key string, d map[string]string) bool {
+	_, ok := d[strings.ToLower(key)]
+	return ok
+}
+
+var helperFunctions = template.FuncMap{
+	"headerListToCIMap": headerListToCIMap,
+	"hasCIKey":          hasCIKey,
+}


### PR DESCRIPTION
### Proposed changes
When using the VirtualServer CRD, it is not possible to override the default values of the following headers:
* `X-Real-IP`
* `X-Forwarded-For`
* `X-Forwarded-Host`
* `X-Forwarded-Port`
* `X-Forwarded-Proto`

For example:

```yaml
  - action:
      proxy:
        requestHeaders:
          set:
            - name: X-Forwarded-For
              value: ${http_cf_connecting_ip}
            - name: X-Forwarded-Proto
              value: ${scheme}-foo
```

Will result in the following:

```
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Port $server_port;
        proxy_set_header X-Forwarded-Proto $scheme;

        proxy_set_header X-Forwarded-For "${http_cf_connecting_ip}";

        proxy_set_header X-Forwarded-Proto "${scheme}-foo";
```

This causes the headers to be sent upstream twice: once with the default value and once with the overwritten value. This change prevents this behavior from happening.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
