### PR TITLE
Add string validation to sticky-cookie-services annotation

### DIFF
--- a/docs/content/configuration/ingress-resources/advanced-configuration-with-annotations.md
+++ b/docs/content/configuration/ingress-resources/advanced-configuration-with-annotations.md
@@ -87,7 +87,6 @@ The following Ingress annotations currently have limited or no validation:
 - `nginx.com/jwt-realm`,
 - `nginx.com/jwt-token`,
 - `nginx.com/jwt-login-url`,
-- `nginx.com/sticky-cookie-services`,
 - `appprotect.f5.com/app-protect-policy`,
 - `appprotect.f5.com/app-protect-security-log`.
 

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -327,7 +327,7 @@ func parseStickyService(service string) (serviceName string, stickyCookie string
 	}
 
 	stickyCookieParameters := parts[1]
-	if !stickCookieRegex.MatchString(stickyCookieParameters) {
+	if !stickyCookieRegex.MatchString(stickyCookieParameters) {
 		return "", "", fmt.Errorf("invalid sticky-cookie parameters: %s", stickyCookieParameters)
 	}
 
@@ -359,10 +359,10 @@ func parseRewrites(service string) (serviceName string, rewrite string, err erro
 }
 
 var (
-	threshEx         = regexp.MustCompile(`high=([1-9]|[1-9][0-9]|100) low=([1-9]|[1-9][0-9]|100)\b`)
-	threshExR        = regexp.MustCompile(`low=([1-9]|[1-9][0-9]|100) high=([1-9]|[1-9][0-9]|100)\b`)
-	pathRegexp       = regexp.MustCompile("^" + `/[^\s{};$]*` + "$")
-	stickCookieRegex = regexp.MustCompile("^" + `([^"$\\]|\\[^$])*` + "$")
+	threshEx          = regexp.MustCompile(`high=([1-9]|[1-9][0-9]|100) low=([1-9]|[1-9][0-9]|100)\b`)
+	threshExR         = regexp.MustCompile(`low=([1-9]|[1-9][0-9]|100) high=([1-9]|[1-9][0-9]|100)\b`)
+	pathRegexp        = regexp.MustCompile("^" + `/[^\s{};$]*` + "$")
+	stickyCookieRegex = regexp.MustCompile("^" + `([^"$\\]|\\[^$])*` + "$")
 )
 
 // VerifyAppProtectThresholds ensures that threshold values are set correctly

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -318,12 +318,17 @@ func parseStickyService(service string) (serviceName string, stickyCookie string
 	parts := strings.SplitN(service, " ", 2)
 
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Invalid sticky-cookie service format: %s", service)
+		return "", "", fmt.Errorf("invalid sticky-cookie service format: %s. Must be a semicolon-separated list of sticky services", service)
 	}
 
 	svcNameParts := strings.Split(parts[0], "=")
 	if len(svcNameParts) != 2 {
-		return "", "", fmt.Errorf("Invalid sticky-cookie service format: %s", svcNameParts)
+		return "", "", fmt.Errorf("invalid sticky-cookie service format: %s", svcNameParts)
+	}
+
+	stickyCookieParameters := parts[1]
+	if !stickCookieRegex.MatchString(stickyCookieParameters) {
+		return "", "", fmt.Errorf("invalid sticky-cookie parameters: %s", stickyCookieParameters)
 	}
 
 	return svcNameParts[1], parts[1], nil
@@ -354,9 +359,10 @@ func parseRewrites(service string) (serviceName string, rewrite string, err erro
 }
 
 var (
-	threshEx   = regexp.MustCompile(`high=([1-9]|[1-9][0-9]|100) low=([1-9]|[1-9][0-9]|100)\b`)
-	threshExR  = regexp.MustCompile(`low=([1-9]|[1-9][0-9]|100) high=([1-9]|[1-9][0-9]|100)\b`)
-	pathRegexp = regexp.MustCompile("^" + `/[^\s{};$]*` + "$")
+	threshEx         = regexp.MustCompile(`high=([1-9]|[1-9][0-9]|100) low=([1-9]|[1-9][0-9]|100)\b`)
+	threshExR        = regexp.MustCompile(`low=([1-9]|[1-9][0-9]|100) high=([1-9]|[1-9][0-9]|100)\b`)
+	pathRegexp       = regexp.MustCompile("^" + `/[^\s{};$]*` + "$")
+	stickCookieRegex = regexp.MustCompile("^" + `([^"$\\]|\\[^$])*` + "$")
 )
 
 // VerifyAppProtectThresholds ensures that threshold values are set correctly

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -582,7 +582,7 @@ func validateServiceListAnnotation(context *annotationValidationContext) field.E
 func validateStickyServiceListAnnotation(context *annotationValidationContext) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if _, err := configs.ParseStickyServiceList(context.value); err != nil {
-		return append(allErrs, field.Invalid(context.fieldPath, context.value, "must be a semicolon-separated list of sticky services"))
+		return append(allErrs, field.Invalid(context.fieldPath, context.value, err.Error()))
 	}
 	return allErrs
 }

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -2270,6 +2270,76 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 		},
 		{
 			annotations: map[string]string{
+				"nginx.com/sticky-cookie-services": `serviceName=service-1 srv_id expires=1h path=/service-1\;serviceName=service-2 srv_id expires=2h path=/service-2`,
+			},
+			specServices:          map[string]bool{},
+			isPlus:                true,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors: []string{
+				`annotations.nginx.com/sticky-cookie-services: Invalid value: "serviceName=service-1 srv_id expires=1h path=/service-1\\;serviceName=service-2 srv_id expires=2h path=/service-2": invalid sticky-cookie parameters: srv_id expires=1h path=/service-1\`,
+			},
+			msg: `invalid sticky-cookie parameters: srv_id expires=1h path=/service-1\`,
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/sticky-cookie-services": `serviceName=service-1 srv_id expires=1h path=/service-1;serviceName=service-2 srv_id expires=2h path=/service-2\`,
+			},
+			specServices:          map[string]bool{},
+			isPlus:                true,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors: []string{
+				`annotations.nginx.com/sticky-cookie-services: Invalid value: "serviceName=service-1 srv_id expires=1h path=/service-1;serviceName=service-2 srv_id expires=2h path=/service-2\\": invalid sticky-cookie parameters: srv_id expires=2h path=/service-2\`,
+			},
+			msg: `invalid sticky-cookie parameters: srv_id expires=2h path=/service-2\`,
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/sticky-cookie-services": `serviceName=service-1 srv_id expires=1h path=/service-1\`,
+			},
+			specServices:          map[string]bool{},
+			isPlus:                true,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors: []string{
+				`annotations.nginx.com/sticky-cookie-services: Invalid value: "serviceName=service-1 srv_id expires=1h path=/service-1\\": invalid sticky-cookie parameters: srv_id expires=1h path=/service-1\`,
+			},
+			msg: `invalid sticky-cookie parameters: srv_id expires=1h path=/service-1\`,
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/sticky-cookie-services": `serviceName=service-1 srv_id expires=1h path=/service-1$`,
+			},
+			specServices:          map[string]bool{},
+			isPlus:                true,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors: []string{
+				`annotations.nginx.com/sticky-cookie-services: Invalid value: "serviceName=service-1 srv_id expires=1h path=/service-1$": invalid sticky-cookie parameters: srv_id expires=1h path=/service-1$`,
+			},
+			msg: `invalid sticky-cookie parameters: srv_id expires=1h path=/service-1$`,
+		},
+		{
+			annotations: map[string]string{
+				"nginx.com/sticky-cookie-services": `serviceName=service-1 srv_id expires=1h path=/service-1;serviceName=service-2 srv_id expires=2h path=/service-2$`,
+			},
+			specServices:          map[string]bool{},
+			isPlus:                true,
+			appProtectEnabled:     false,
+			appProtectDosEnabled:  false,
+			internalRoutesEnabled: false,
+			expectedErrors: []string{
+				`annotations.nginx.com/sticky-cookie-services: Invalid value: "serviceName=service-1 srv_id expires=1h path=/service-1;serviceName=service-2 srv_id expires=2h path=/service-2$": invalid sticky-cookie parameters: srv_id expires=2h path=/service-2$`,
+			},
+			msg: `invalid sticky-cookie parameters: srv_id expires=2h path=/service-2$`,
+		},
+		{
+			annotations: map[string]string{
 				"nginx.com/sticky-cookie-services": "not_a_rewrite",
 			},
 			specServices:          map[string]bool{},
@@ -2278,7 +2348,7 @@ func TestValidateNginxIngressAnnotations(t *testing.T) {
 			appProtectDosEnabled:  false,
 			internalRoutesEnabled: false,
 			expectedErrors: []string{
-				`annotations.nginx.com/sticky-cookie-services: Invalid value: "not_a_rewrite": must be a semicolon-separated list of sticky services`,
+				`annotations.nginx.com/sticky-cookie-services: Invalid value: "not_a_rewrite": invalid sticky-cookie service format: not_a_rewrite. Must be a semicolon-separated list of sticky services`,
 			},
 			msg: "invalid nginx.com/sticky-cookie-services annotation",
 		},


### PR DESCRIPTION
### Proposed changes
This change adds string validation to the `nginx.com/sticky-cookie-services` annotation for the Ingress resource

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
