### PR TITLE
Update validation regex for path spec

### DIFF
--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -66,7 +66,7 @@ const (
 const (
 	commaDelimiter     = ","
 	annotationValueFmt = `([^"$\\]|\\[^$])*`
-	pathFmt            = `/[^\s{};]*`
+	pathFmt            = `/[^\s{};\\$]*`
 	jwtTokenValueFmt   = "\\$" + annotationValueFmt
 )
 

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -2594,6 +2594,80 @@ func TestValidateIngressSpec(t *testing.T) {
 				field.ErrorTypeInvalid,
 			},
 			msg: "test invalid characters in path",
+		}, {
+			spec: &networking.IngressSpec{
+				Rules: []networking.IngressRule{
+					{
+						Host: "foo.example.com",
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
+									{
+										Path: `/tea\{custom_value}`,
+										Backend: networking.IngressBackend{
+											Service: &networking.IngressServiceBackend{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []field.ErrorType{
+				field.ErrorTypeInvalid,
+			},
+			msg: "test invalid characters in path",
+		},
+		{
+			spec: &networking.IngressSpec{
+				Rules: []networking.IngressRule{
+					{
+						Host: "foo.example.com",
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
+									{
+										Path: `/tea\`,
+										Backend: networking.IngressBackend{
+											Service: &networking.IngressServiceBackend{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []field.ErrorType{
+				field.ErrorTypeInvalid,
+			},
+			msg: "test invalid characters in path",
+		},
+		{
+			spec: &networking.IngressSpec{
+				Rules: []networking.IngressRule{
+					{
+						Host: "foo.example.com",
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
+									{
+										Path: `/tea\n`,
+										Backend: networking.IngressBackend{
+											Service: &networking.IngressServiceBackend{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []field.ErrorType{
+				field.ErrorTypeInvalid,
+			},
+			msg: "test invalid characters in path",
 		},
 		{
 			spec: &networking.IngressSpec{

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -1296,7 +1296,7 @@ func validateRegexPath(path string, fieldPath *field.Path) field.ErrorList {
 }
 
 const (
-	pathFmt    = `/[^\s{};]*`
+	pathFmt    = `/[^\s{};\\$]*`
 	pathErrMsg = "must start with / and must not include any whitespace character, `{`, `}` or `;`"
 )
 

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -1531,6 +1531,8 @@ func TestValidatePath(t *testing.T) {
 		"/{",
 		"/}",
 		"/abc;",
+		`/path\`,
+		`/path\n`,
 	}
 
 	for _, path := range invalidPaths {


### PR DESCRIPTION
### Proposed changes
This change updates the regex used to validated the path spec for Ingress and VirtualServer resources

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
