### PR TITLE
fix: Change alpine version grab to include a colon in the updater

### DIFF
--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -47,7 +47,7 @@ jobs:
         id: versions
         run: |
           nginx=library/$(grep -m1 "FROM nginx:" < build/Dockerfile | awk -F" " '{print $2}')
-          nginx_alpine=library/nginx:$(grep -m1 "FROM.*nginx.*alpine" < build/Dockerfile | awk -F"[ :]" '{print $3}')
+          nginx_alpine=library/nginx:$(grep -m1 "FROM.*nginx:.*alpine" < build/Dockerfile | awk -F"[ :]" '{print $3}')
           nginx_ubi=$(grep "FROM redhat" < build/Dockerfile | awk -F" " '{print $2}')
           echo "::set-output name=matrix::[{\"version\": \"${nginx}\", \"distro\": \"debian\"}, {\"version\": \"${nginx_alpine}\", \"distro\": \"alpine\"}, {\"version\": \"${nginx_ubi}\", \"distro\": \"ubi\"}]"
       - name: Set other variables


### PR DESCRIPTION
### Proposed changes
See https://github.com/nginxinc/kubernetes-ingress/runs/7316328564?check_suite_focus=true

The grep pulls the version from the opentracing image instead of the alpine image at the moment (resulting in an image tag of `nginx-1.23.0-alpine` instead of `1.23.0-alpine`) causing failures.

The fix is to put a colon in so that get the right image tag.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
