### PR TITLE
Add missing minReadySeconds & strategy chart values in Helm Installation documentation

### DIFF
--- a/docs/content/installation/installation-with-helm.md
+++ b/docs/content/installation/installation-with-helm.md
@@ -230,8 +230,8 @@ The following tables lists the configurable parameters of the NGINX Ingress Cont
 |``controller.readyStatus.enable`` | Enables the readiness endpoint `"/nginx-ready"`. The endpoint returns a success code when NGINX has loaded all the config after the startup. This also configures a readiness probe for the Ingress Controller pods that uses the readiness endpoint. | true |
 |``controller.readyStatus.port`` | The HTTP port for the readiness endpoint. | 8081 |
 |``controller.enableLatencyMetrics`` | Enable collection of latency metrics for upstreams. Requires ``prometheus.create``. | false |
-``controller.minReadySeconds`` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0
-``controller.strategy`` | Specifies the strategy used to replace old Pods by new ones. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | {}
+``controller.minReadySeconds`` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
+``controller.strategy`` | Specifies the strategy used to replace old Pods by new ones. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | {} |
 |``rbac.create`` | Configures RBAC. | true |
 |``prometheus.create`` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | false |
 |``prometheus.port`` | Configures the port to scrape the metrics. | 9113 |

--- a/docs/content/installation/installation-with-helm.md
+++ b/docs/content/installation/installation-with-helm.md
@@ -230,7 +230,7 @@ The following tables lists the configurable parameters of the NGINX Ingress Cont
 |``controller.readyStatus.enable`` | Enables the readiness endpoint `"/nginx-ready"`. The endpoint returns a success code when NGINX has loaded all the config after the startup. This also configures a readiness probe for the Ingress Controller pods that uses the readiness endpoint. | true |
 |``controller.readyStatus.port`` | The HTTP port for the readiness endpoint. | 8081 |
 |``controller.enableLatencyMetrics`` | Enable collection of latency metrics for upstreams. Requires ``prometheus.create``. | false |
-|``controller.minReadySeconds`` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
+|``controller.minReadySeconds`` | Specifies the minimum number of seconds for which a newly created Pod should be ready, without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
 |``controller.strategy`` | Specifies the strategy used to replace old Pods by new ones. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | {} |
 |``rbac.create`` | Configures RBAC. | true |
 |``prometheus.create`` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | false |

--- a/docs/content/installation/installation-with-helm.md
+++ b/docs/content/installation/installation-with-helm.md
@@ -231,7 +231,7 @@ The following tables lists the configurable parameters of the NGINX Ingress Cont
 |``controller.readyStatus.port`` | The HTTP port for the readiness endpoint. | 8081 |
 |``controller.enableLatencyMetrics`` | Enable collection of latency metrics for upstreams. Requires ``prometheus.create``. | false |
 |``controller.minReadySeconds`` | Specifies the minimum number of seconds for which a newly created Pod should be ready, without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
-|``controller.strategy`` | Specifies the strategy used to replace old Pods by new ones. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | {} |
+|``controller.strategy`` | Specifies the strategy used to replace old Pods with new ones. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | {} |
 |``rbac.create`` | Configures RBAC. | true |
 |``prometheus.create`` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | false |
 |``prometheus.port`` | Configures the port to scrape the metrics. | 9113 |

--- a/docs/content/installation/installation-with-helm.md
+++ b/docs/content/installation/installation-with-helm.md
@@ -230,6 +230,8 @@ The following tables lists the configurable parameters of the NGINX Ingress Cont
 |``controller.readyStatus.enable`` | Enables the readiness endpoint `"/nginx-ready"`. The endpoint returns a success code when NGINX has loaded all the config after the startup. This also configures a readiness probe for the Ingress Controller pods that uses the readiness endpoint. | true |
 |``controller.readyStatus.port`` | The HTTP port for the readiness endpoint. | 8081 |
 |``controller.enableLatencyMetrics`` | Enable collection of latency metrics for upstreams. Requires ``prometheus.create``. | false |
+``controller.minReadySeconds`` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0
+``controller.strategy`` | Specifies the strategy used to replace old Pods by new ones. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | {}
 |``rbac.create`` | Configures RBAC. | true |
 |``prometheus.create`` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | false |
 |``prometheus.port`` | Configures the port to scrape the metrics. | 9113 |

--- a/docs/content/installation/installation-with-helm.md
+++ b/docs/content/installation/installation-with-helm.md
@@ -230,8 +230,8 @@ The following tables lists the configurable parameters of the NGINX Ingress Cont
 |``controller.readyStatus.enable`` | Enables the readiness endpoint `"/nginx-ready"`. The endpoint returns a success code when NGINX has loaded all the config after the startup. This also configures a readiness probe for the Ingress Controller pods that uses the readiness endpoint. | true |
 |``controller.readyStatus.port`` | The HTTP port for the readiness endpoint. | 8081 |
 |``controller.enableLatencyMetrics`` | Enable collection of latency metrics for upstreams. Requires ``prometheus.create``. | false |
-``controller.minReadySeconds`` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
-``controller.strategy`` | Specifies the strategy used to replace old Pods by new ones. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | {} |
+|``controller.minReadySeconds`` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
+|``controller.strategy`` | Specifies the strategy used to replace old Pods by new ones. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | {} |
 |``rbac.create`` | Configures RBAC. | true |
 |``prometheus.create`` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | false |
 |``prometheus.port`` | Configures the port to scrape the metrics. | 9113 |


### PR DESCRIPTION
### Proposed changes
Adds missing minReadySeconds & strategy helm chart values reported in #2852 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
