### PR TITLE
Use go-version-file in setup-go Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
     name: Checks and variables
     runs-on: ubuntu-20.04
     outputs:
-      go_version: ${{ steps.vars.outputs.go_version }}
       go_path: ${{ steps.go.outputs.go_path }}
       k8s_latest: ${{ steps.vars.outputs.k8s_latest }}
     steps:
@@ -63,12 +62,11 @@ jobs:
       - name: Output Variables
         id: vars
         run: |
-          echo "::set-output name=go_version::$(grep "go 1." go.mod | cut -d " " -f 2)"
           echo "::set-output name=k8s_latest::$(grep -m1 'FROM kindest/node' <tests/docker/Dockerfile | awk -F'[:v]' '{print $3}')"
       - name: Setup Golang Environment
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.vars.outputs.go_version }}
+          go-version-file: go.mod
       - name: Determine GOPATH
         id: go
         run: echo "::set-output name=go_path::$(go env GOPATH)"
@@ -102,7 +100,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ needs.checks.outputs.go_version }}
+          go-version-file: go.mod
       - name: Build binary
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -138,7 +136,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ needs.checks.outputs.go_version }}
+          go-version-file: go.mod
       - name: Run Tests
         run: make cover
       - name: Upload coverage to Codecov
@@ -278,7 +276,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ needs.checks.outputs.go_version }}
+          go-version-file: go.mod
 
       - uses: actions/setup-node@v3
       - run: npm install js-yaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,13 +29,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      - name: Output Variables
-        id: vars
-        run: echo "::set-output name=go_version::$(grep "go 1." go.mod | cut -d " " -f 2)"
       - name: Setup Golang Environment
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.vars.outputs.go_version }}
+          go-version-file: go.mod
       - name: Lint Code
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -27,7 +27,6 @@ jobs:
       versions: ${{ steps.versions.outputs.matrix }}
       sha_short: ${{ steps.vars.outputs.sha_short }}
       sha_long: ${{ steps.vars.outputs.sha_long }}
-      go_version: ${{ steps.vars.outputs.go_version }}
       k8s_version: ${{ steps.vars.outputs.k8s_version }}
     steps:
       - name: Checkout Repository
@@ -55,7 +54,6 @@ jobs:
         run: |
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           echo "::set-output name=sha_long::$(git rev-parse HEAD)"
-          echo "::set-output name=go_version::$(grep "go 1." go.mod | cut -d " " -f 2)"
           echo "::set-output name=k8s_version::$(grep -m1 'FROM kindest/node' <tests/docker/Dockerfile | awk -F'[:v]' '{print $3}')"
 
   check:
@@ -108,7 +106,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ needs.variables.outputs.go_version }}
+          go-version-file: go.mod
       - name: Determine GOPATH
         id: go
         run: echo "::set-output name=go_path::$(go env GOPATH)"


### PR DESCRIPTION
The `setup-go` action now accepts a file to read the version from, so we don't need all the logic to do that anymore 🎉 
