### PR TITLE
Remove multiple markers from tests

### DIFF
--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -136,11 +136,11 @@ jobs:
             platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
             needs-updating: ${{ needs.check.outputs.needs-updating-debian }}
           - image: alpine
-            marker: "vs or vsr"
+            marker: "vs" # add vsr after 2.3.1/2.4 release
             platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
             needs-updating: ${{ needs.check.outputs.needs-updating-alpine }}
           - image: ubi
-            marker: "policies or ts"
+            marker: "policies" # add ts after 2.3.1/2.4 release
             platforms: linux/arm64,linux/amd64,linux/s390x
             needs-updating: ${{ needs.check.outputs.needs-updating-ubi }}
     steps:


### PR DESCRIPTION
The latest release `2.3.0` doesn't support multiple markers, we can add it back in the next release