### PR TITLE
tests: Remove unnecessary library from tests

### DIFF
--- a/perf-tests/requirements.txt
+++ b/perf-tests/requirements.txt
@@ -2,7 +2,6 @@ PyYAML==6.0
 requests==2.28.1
 kubernetes==24.2.0
 pytest==7.1.2
-ipaddress==1.0.23 # >= 1.0.17
 cffi==1.15.1
 certifi==2022.6.15
 urllib3==1.26.11

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,6 @@ requests==2.28.1
 forcediphttpsadapter==1.0.2
 kubernetes==24.2.0
 pytest==7.1.2
-ipaddress==1.0.23 # >= 1.0.17
 cffi==1.15.1
 pyOpenSSL==22.0.0
 certifi==2022.6.15

--- a/tests/suite/test_transport_server_udp_load_balance.py
+++ b/tests/suite/test_transport_server_udp_load_balance.py
@@ -25,7 +25,10 @@ def chk_endpoint(endp):
     endpoint. Otherwise, return unmodified endpoint.
     """
     ip = endp[:endp.rfind(":")]
-    address = ipaddress.ip_address(ip)
+    try:
+        address = ipaddress.ip_address(ip)
+    except ValueError:
+        return endp
     if address.version == 6:
         port = endp[endp.rfind(":"):]
         return f"[{ip}]{port}"
@@ -37,11 +40,14 @@ def ipfamily_from_host(host):
     Return socket type (AF_INET or AF_INET6) based on
     IP address type from host
     """
-    address = ipaddress.ip_address(host)
-    if address.version == 6:
-        return socket.AF_INET6
-    else:
-        return socket.AF_INET
+    sock = socket.AF_INET
+    try:
+        address = ipaddress.ip_address(host)
+        if address.version == 6:
+            sock = socket.AF_INET6
+    except ValueError:
+        pass
+    return sock
 
 @pytest.mark.ts
 @pytest.mark.skip_for_loadbalancer


### PR DESCRIPTION
### Proposed changes
This CVE is being flagged against the project: https://www.mend.io/vulnerability-database/CVE-2020-14422. It's potentially a false positive because the library we are importing is actually https://github.com/phihag/ipaddress but we don't need that library anyway so this commit removes it from the requirements. This commit also updates the TransportServer tests to work locally using Kind. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
