### PR TITLE
fix: update footer for NMS

### DIFF
--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/footer.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/footer.html
@@ -45,8 +45,7 @@
                   <li><a title="NGINX Plus" aria-label="NGINX Plus" href="https://www.nginx.com/products/nginx/">NGINX Plus</a></li>
                   <li><a title="NGINX App Protect" aria-label="NGINX App Protect" href="https://www.nginx.com/products/nginx-app-protect/">NGINX App Protect</a></li>
                   <li><a title="NGINX Amplify" aria-label="NGINX Amplify" href="https://www.nginx.com/products/nginx-amplify/">NGINX Amplify</a></li>
-                  <li><a title="NGINX Instance Manager" aria-label="NGINX Instance Manager" href="https://www.nginx.com/products/nginx-instance-manager/">NGINX Instance Manager</a></li>
-                  <li><a title="NGINX Controller" aria-label="NGINX Controller" href="https://www.nginx.com/products/nginx-controller/">NGINX Controller</a></li>
+                  <li><a title="NGINX Management Suite" aria-label="NGINX Management Suite" href="https://www.nginx.com/products/nginx-management-suite/">NGINX Management Suite</a></li>
                   <li><a title="NGINX Ingress Controller" aria-label="NGINX Ingress Controller" href="https://www.nginx.com/products/nginx-ingress-controller/">NGINX Ingress Controller</a></li>
                   <li><a title="NGINX Service Mesh" aria-label="NGINX Service Mesh" href="https://www.nginx.com/products/nginx-service-mesh/">NGINX Service Mesh</a></li>
                   <li><a title="NGINX Unit" aria-label="NGINX Unit" href="https://www.nginx.com/products/nginx-unit/">NGINX Unit</a></li>

--- a/docs/_vendor/modules.txt
+++ b/docs/_vendor/modules.txt
@@ -1,1 +1,1 @@
-# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.1
+# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.2

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/nginxinc/kubernetes-ingress/docs
 
 go 1.15
 
-require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.1 // indirect
+require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.2 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -24,3 +24,5 @@ gitlab.com/f5/nginx/controller/poc/f5-hugo v0.20.0 h1:6i2v1cWQ1IA5DbbOC/qYd+UADF
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.20.0/go.mod h1:Y9Ez7EKgsbFXNsflK0tGLe6FWqlPToWFGZyrkduYdM4=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.1 h1:SKPsQzWo5xBDmXoIi3ti8TAZtdex943bkL/RqCRQ3YM=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.1/go.mod h1:Y9Ez7EKgsbFXNsflK0tGLe6FWqlPToWFGZyrkduYdM4=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.2 h1:NTQmkbyS8/SA4p8c2J6idx/KQhky36PYNsTJHxH9Vig=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.2/go.mod h1:Y9Ez7EKgsbFXNsflK0tGLe6FWqlPToWFGZyrkduYdM4=


### PR DESCRIPTION
### Proposed changes
This MR updates the Hugo theme to pick up the updated footer that includes NMS in the products.

No documentation changes.

Cherry-pick to `release-3.22` 
