### PR TITLE
Remove deprecated go linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,6 @@ linters-settings:
 linters:
     enable:
     - asciicheck
-    - deadcode
     - errcheck
     - errorlint
     - gocyclo
@@ -53,12 +52,10 @@ linters:
     - promlinter
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - wastedassign
     disable-all: true
 issues:


### PR DESCRIPTION
The linters have not been updated in 3-6 years and have been deprecated.
https://github.com/golangci/golangci-lint/pull/3125

