### PR TITLE
Remove archived repos from sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -35,11 +35,10 @@ jobs:
       matrix:
         repo:
           - nginxinc/kubernetes-ingress
-          - nginxinc/nginx-ingress-operator
+          - nginxinc/nginx-ingress-helm-operator
           - nginxinc/nginx-prometheus-exporter
           - nginxinc/nginx-plus-go-client
           - nginxinc/nginx-asg-sync
-          - nginxinc/nginx-ns1-gslb
     runs-on: ubuntu-20.04
     if: ${{ github.event.repository.fork == false }}
     steps:


### PR DESCRIPTION
- Removes `nginxinc/nginx-asg-sync`
- Updates Operator to new repo

