### PR TITLE
Accept proxy protocol when TLS passthrough enabled

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -668,7 +668,7 @@ func processConfigMaps(kubeClient *kubernetes.Clientset, cfgParams *configs.Conf
 		if err != nil {
 			glog.Fatalf("Error when getting %v: %v", *nginxConfigMaps, err)
 		}
-		cfgParams = configs.ParseConfigMap(cfm, *nginxPlus, *appProtect, *appProtectDos)
+		cfgParams = configs.ParseConfigMap(cfm, *nginxPlus, *appProtect, *appProtectDos, *enableTLSPassthrough)
 		if cfgParams.MainServerSSLDHParamFileContent != nil {
 			fileName, err := nginxManager.CreateDHParam(*cfgParams.MainServerSSLDHParamFileContent)
 			if err != nil {

--- a/docs/content/configuration/transportserver-resource.md
+++ b/docs/content/configuration/transportserver-resource.md
@@ -373,8 +373,3 @@ Note how the events section includes a Warning event with the Rejected reason.
 ## Customization via ConfigMap
 
 The [ConfigMap](/nginx-ingress-controller/configuration/global-configuration/configmap-resource) keys (except for `stream-snippets` and `stream-log-format`) do not affect TransportServer resources.
-
-## Limitations
-
-The TransportServer resource currently comes with the following limitation:
-* When using TLS Passthrough, it is not possible to configure [Proxy Protocol](https://github.com/nginxinc/kubernetes-ingress/tree/v2.0.1/examples/proxy-protocol) for port 443 both for regular HTTPS and TLS Passthrough traffic.

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -158,10 +158,10 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool, hasAppProtect bool, hasA
 	if realIPHeader, exists := cfgm.Data["real-ip-header"]; exists {
 		if hasTLSPassthrough {
 			msg := "Configmap %s/%s: key real-ip-header is ignored, directive real_ip_header is automatically set to 'proxy_protocol' when TLS passthrough is enabled."
-			if realIPHeader != "proxy_protocol" {
-				glog.Warningf(msg, cfgm.GetNamespace(), cfgm.GetName())
-			} else {
+			if realIPHeader == "proxy_protocol" {
 				glog.Infof(msg, cfgm.GetNamespace(), cfgm.GetName())
+			} else {
+				glog.Warningf(msg, cfgm.GetNamespace(), cfgm.GetName())
 			}
 		} else {
 			cfgParams.RealIPHeader = realIPHeader

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -157,8 +157,12 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool, hasAppProtect bool, hasA
 
 	if realIPHeader, exists := cfgm.Data["real-ip-header"]; exists {
 		if hasTLSPassthrough {
-			// check correct value and return error
-			glog.Infof("Configmap %s/%s: real-ip-header is ignored. real_ip_header is automatically set to 'proxy_protocol' when TLS passthrough is enabled.", cfgm.GetNamespace(), cfgm.GetName())
+			msg := "Configmap %s/%s: key real-ip-header is ignored, directive real_ip_header is automatically set to 'proxy_protocol' when TLS passthrough is enabled."
+			if realIPHeader != "proxy_protocol" {
+				glog.Warningf(msg, cfgm.GetNamespace(), cfgm.GetName())
+			} else {
+				glog.Infof(msg, cfgm.GetNamespace(), cfgm.GetName())
+			}
 		} else {
 			cfgParams.RealIPHeader = realIPHeader
 		}

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -10,6 +10,8 @@ import (
 )
 
 // ParseConfigMap parses ConfigMap into ConfigParams.
+//
+//nolint:gocyclo
 func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool, hasAppProtect bool, hasAppProtectDos bool, hasTLSPassthrough bool) *ConfigParams {
 	cfgParams := NewDefaultConfigParams(nginxPlus)
 

--- a/internal/configs/configmaps.go
+++ b/internal/configs/configmaps.go
@@ -163,7 +163,7 @@ func ParseConfigMap(cfgm *v1.ConfigMap, nginxPlus bool, hasAppProtect bool, hasA
 			if realIPHeader == "proxy_protocol" {
 				glog.Infof(msg, cfgm.GetNamespace(), cfgm.GetName())
 			} else {
-				glog.Warningf(msg, cfgm.GetNamespace(), cfgm.GetName())
+				glog.Errorf(msg, cfgm.GetNamespace(), cfgm.GetName())
 			}
 		} else {
 			cfgParams.RealIPHeader = realIPHeader

--- a/internal/configs/configmaps_test.go
+++ b/internal/configs/configmaps_test.go
@@ -122,22 +122,22 @@ func TestParseConfigMapWithTLSPassthroughProxyProtocol(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		realIPheader string
-		expect       string
+		want         string
 		msg          string
 	}{
 		{
 			realIPheader: "proxy_protocol",
-			expect:       "",
-			msg:          "valid real-ip-header",
+			want:         "",
+			msg:          "valid realIPheader proxy_protocol, ignored when TLS Passthrough is enabled",
 		},
 		{
 			realIPheader: "X-Forwarded-For",
-			expect:       "",
-			msg:          "invalid real-ip-header",
+			want:         "",
+			msg:          "invalid realIPheader X-Forwarded-For, ignored when TLS Passthrough is enabled",
 		},
 		{
 			realIPheader: "",
-			expect:       "",
+			want:         "",
 			msg:          "empty real-ip-header",
 		},
 	}
@@ -146,15 +146,17 @@ func TestParseConfigMapWithTLSPassthroughProxyProtocol(t *testing.T) {
 	hasAppProtectDos := false
 	hasTLSPassthrough := true
 	for _, test := range tests {
-		cm := &v1.ConfigMap{
-			Data: map[string]string{
-				"real-ip-header": test.realIPheader,
-			},
-		}
-		result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
-		if result.RealIPHeader != test.expect {
-			t.Errorf("ParseConfigMap() returned %q but expected %q for the case %s", result.RealIPHeader, test.expect, test.msg)
-		}
+		t.Run(test.msg, func(t *testing.T) {
+			cm := &v1.ConfigMap{
+				Data: map[string]string{
+					"real-ip-header": test.realIPheader,
+				},
+			}
+			result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
+			if result.RealIPHeader != test.want {
+				t.Errorf("want %q, got %q", test.want, result.RealIPHeader)
+			}
+		})
 	}
 }
 
@@ -162,22 +164,22 @@ func TestParseConfigMapWithoutTLSPassthroughProxyProtocol(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		realIPheader string
-		expect       string
+		want         string
 		msg          string
 	}{
 		{
 			realIPheader: "proxy_protocol",
-			expect:       "proxy_protocol",
-			msg:          "valid real-ip-header",
+			want:         "proxy_protocol",
+			msg:          "valid real-ip-header proxy_protocol",
 		},
 		{
 			realIPheader: "X-Forwarded-For",
-			expect:       "X-Forwarded-For",
-			msg:          "valid real-ip-header",
+			want:         "X-Forwarded-For",
+			msg:          "valid real-ip-header X-Forwarded-For",
 		},
 		{
 			realIPheader: "",
-			expect:       "",
+			want:         "",
 			msg:          "empty real-ip-header",
 		},
 	}
@@ -186,14 +188,16 @@ func TestParseConfigMapWithoutTLSPassthroughProxyProtocol(t *testing.T) {
 	hasAppProtectDos := false
 	hasTLSPassthrough := false
 	for _, test := range tests {
-		cm := &v1.ConfigMap{
-			Data: map[string]string{
-				"real-ip-header": test.realIPheader,
-			},
-		}
-		result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
-		if result.RealIPHeader != test.expect {
-			t.Errorf("ParseConfigMap() returned %q but expected %q for the case %s", result.RealIPHeader, test.expect, test.msg)
-		}
+		t.Run(test.msg, func(t *testing.T) {
+			cm := &v1.ConfigMap{
+				Data: map[string]string{
+					"real-ip-header": test.realIPheader,
+				},
+			}
+			result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
+			if result.RealIPHeader != test.want {
+				t.Errorf("want %q, got %q", test.want, result.RealIPHeader)
+			}
+		})
 	}
 }

--- a/internal/configs/configmaps_test.go
+++ b/internal/configs/configmaps_test.go
@@ -37,13 +37,14 @@ func TestParseConfigMapWithAppProtectCompressedRequestsAction(t *testing.T) {
 	nginxPlus := true
 	hasAppProtect := true
 	hasAppProtectDos := false
+	hasTLSPassthrough := false
 	for _, test := range tests {
 		cm := &v1.ConfigMap{
 			Data: map[string]string{
 				"app-protect-compressed-requests-action": test.action,
 			},
 		}
-		result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, false)
+		result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
 		if result.MainAppProtectCompressedRequestsAction != test.expect {
 			t.Errorf("ParseConfigMap() returned %q but expected %q for the case %s", result.MainAppProtectCompressedRequestsAction, test.expect, test.msg)
 		}
@@ -105,13 +106,14 @@ func TestParseConfigMapWithAppProtectReconnectPeriod(t *testing.T) {
 	nginxPlus := true
 	hasAppProtect := true
 	hasAppProtectDos := false
+	hasTLSPassthrough := false
 	for _, test := range tests {
 		cm := &v1.ConfigMap{
 			Data: map[string]string{
 				"app-protect-reconnect-period-seconds": test.period,
 			},
 		}
-		result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, false)
+		result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
 		if result.MainAppProtectReconnectPeriod != test.expect {
 			t.Errorf("ParseConfigMap() returned %q but expected %q for the case %s", result.MainAppProtectReconnectPeriod, test.expect, test.msg)
 		}

--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -297,8 +297,8 @@ stream {
     }
 
     server {
-        listen 443;
-        listen [::]:443;
+        listen 443{{if .ProxyProtocol}} proxy_protocol{{end}};
+        listen [::]:443{{if .ProxyProtocol}} proxy_protocol{{end}};
 
         ssl_preread on;
 

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -236,8 +236,8 @@ stream {
     }
 
     server {
-        listen 443;
-        listen [::]:443;
+        listen 443{{if .ProxyProtocol}} proxy_protocol{{end}};
+        listen [::]:443{{if .ProxyProtocol}} proxy_protocol{{end}};
 
         ssl_preread on;
 

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -777,7 +777,7 @@ func (lbc *LoadBalancerController) updateAllConfigs() {
 	cfgParams := configs.NewDefaultConfigParams(lbc.isNginxPlus)
 
 	if lbc.configMap != nil {
-		cfgParams = configs.ParseConfigMap(lbc.configMap, lbc.isNginxPlus, lbc.appProtectEnabled, lbc.appProtectDosEnabled)
+		cfgParams = configs.ParseConfigMap(lbc.configMap, lbc.isNginxPlus, lbc.appProtectEnabled, lbc.appProtectDosEnabled, lbc.configuration.isTLSPassthroughEnabled)
 	}
 
 	resources := lbc.configuration.GetResources()

--- a/tests/data/transport-server-tls-passthrough/nginx-config.yaml
+++ b/tests/data/transport-server-tls-passthrough/nginx-config.yaml
@@ -1,0 +1,8 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-config
+data:
+  proxy-protocol: "True"
+  real-ip-header: "proxy_protocol"
+  set-real-ip-from: "0.0.0.0/0"

--- a/tests/suite/resources_utils.py
+++ b/tests/suite/resources_utils.py
@@ -933,6 +933,18 @@ def clear_file_contents(v1: CoreV1Api, file_path, pod_name, pod_namespace):
     )
 
 
+def get_nginx_template_conf(v1: CoreV1Api, ingress_namespace) -> str:
+    """
+    Get contents of /etc/nginx/nginx.conf in the pod
+    :param v1: CoreV1Api
+    :param ingress_namespace:
+    :return: str
+    """
+    ic_pod_name = get_first_pod_name(v1, ingress_namespace)
+    file_path = "/etc/nginx/nginx.conf"
+    return get_file_contents(v1, file_path, ic_pod_name, ingress_namespace)
+
+
 def get_ingress_nginx_template_conf(v1: CoreV1Api, ingress_namespace, ingress_name, pod_name, pod_namespace) -> str:
     """
     Get contents of /etc/nginx/conf.d/{namespace}-{ingress_name}.conf in the pod.

--- a/tests/suite/test_ts_tls_passthrough.py
+++ b/tests/suite/test_ts_tls_passthrough.py
@@ -155,10 +155,7 @@ class TestTransportServerTlsPassthrough:
             f"{TEST_DATA}/transport-server-tls-passthrough/nginx-config.yaml",
         )
         wait_before_test(1)
-        config = get_file_contents(kube_apis.v1,
-                                   config_path,
-                                   ic_pod_name,
-                                   ingress_controller_prerequisites.namespace)
+        config = get_file_contents(kube_apis.v1, config_path, ic_pod_name, ingress_controller_prerequisites.namespace)
         assert "listen 443 proxy_protocol;" in config
         assert "listen [::]:443 proxy_protocol;" in config
         std_cm_src = f"{DEPLOYMENTS}/common/nginx-config.yaml"

--- a/tests/suite/test_ts_tls_passthrough.py
+++ b/tests/suite/test_ts_tls_passthrough.py
@@ -7,8 +7,8 @@ from suite.fixtures import PublicEndpoint
 from suite.resources_utils import (
     create_items_from_yaml,
     delete_items_from_yaml,
-    get_file_contents,
     get_first_pod_name,
+    get_nginx_template_conf,
     replace_configmap_from_yaml,
     wait_before_test,
     wait_until_all_pods_are_ready,
@@ -143,11 +143,8 @@ class TestTransportServerTlsPassthrough:
         test_namespace,
     ):
         """
-        Test TransportServer TLS passthrough on https port with proxy
-        protocol enabled.
+        Test TransportServer TLS passthrough on https port with proxy protocol enabled.
         """
-        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
-        config_path = "/etc/nginx/nginx.conf"
         replace_configmap_from_yaml(
             kube_apis.v1,
             ingress_controller_prerequisites.config_map["metadata"]["name"],
@@ -155,7 +152,7 @@ class TestTransportServerTlsPassthrough:
             f"{TEST_DATA}/transport-server-tls-passthrough/nginx-config.yaml",
         )
         wait_before_test(1)
-        config = get_file_contents(kube_apis.v1, config_path, ic_pod_name, ingress_controller_prerequisites.namespace)
+        config = get_nginx_template_conf(kube_apis.v1, ingress_controller_prerequisites.namespace)
         assert "listen 443 proxy_protocol;" in config
         assert "listen [::]:443 proxy_protocol;" in config
         std_cm_src = f"{DEPLOYMENTS}/common/nginx-config.yaml"

--- a/tests/suite/test_ts_tls_passthrough.py
+++ b/tests/suite/test_ts_tls_passthrough.py
@@ -1,9 +1,8 @@
-import ssl
 from pprint import pprint
 
 import pytest
-import requests
-from settings import TEST_DATA
+
+from settings import TEST_DATA, DEPLOYMENTS
 from suite.custom_resources_utils import create_ts_from_yaml, delete_ts, read_ts
 from suite.fixtures import PublicEndpoint
 from suite.resources_utils import (
@@ -12,8 +11,10 @@ from suite.resources_utils import (
     get_first_pod_name,
     wait_before_test,
     wait_until_all_pods_are_ready,
+    replace_configmap_from_yaml,
+    get_file_contents,
 )
-from suite.ssl_utils import create_sni_session, get_server_certificate_subject
+from suite.ssl_utils import create_sni_session
 from suite.vs_vsr_resources_utils import create_virtual_server_from_yaml, delete_virtual_server, read_vs
 from suite.yaml_utils import get_first_host_from_yaml
 
@@ -133,6 +134,41 @@ class TestTransportServerTlsPassthrough:
         )
         assert resp.status_code == 200
         assert f"hello from pod {get_first_pod_name(kube_apis.v1, test_namespace)}" in resp.text
+
+    def test_tls_passthrough_proxy_protocol_config(
+        self,
+        kube_apis,
+        ingress_controller_prerequisites,
+        crd_ingress_controller,
+        transport_server_tls_passthrough_setup,
+        test_namespace,
+    ):
+        """
+        Test TransportServer TLS passthrough on https port with proxy
+        protocol enabled.
+        """
+        ic_pod_name = get_first_pod_name(kube_apis.v1, ingress_controller_prerequisites.namespace)
+        config_path = "/etc/nginx/nginx.conf"
+        replace_configmap_from_yaml(
+            kube_apis.v1,
+            ingress_controller_prerequisites.config_map["metadata"]["name"],
+            ingress_controller_prerequisites.namespace,
+            f"{TEST_DATA}/transport-server-tls-passthrough/nginx-config.yaml",
+        )
+        wait_before_test(1)
+        config = get_file_contents(kube_apis.v1,
+                                   config_path,
+                                   ic_pod_name,
+                                   ingress_controller_prerequisites.namespace)
+        assert "listen 443 proxy_protocol;" in config
+        assert "listen [::]:443 proxy_protocol;" in config
+        std_cm_src = f"{DEPLOYMENTS}/common/nginx-config.yaml"
+        replace_configmap_from_yaml(
+            kube_apis.v1,
+            ingress_controller_prerequisites.config_map["metadata"]["name"],
+            ingress_controller_prerequisites.namespace,
+            std_cm_src,
+        )
 
     def test_tls_passthrough_host_collision_ts(
         self,

--- a/tests/suite/test_ts_tls_passthrough.py
+++ b/tests/suite/test_ts_tls_passthrough.py
@@ -1,18 +1,17 @@
 from pprint import pprint
 
 import pytest
-
-from settings import TEST_DATA, DEPLOYMENTS
+from settings import DEPLOYMENTS, TEST_DATA
 from suite.custom_resources_utils import create_ts_from_yaml, delete_ts, read_ts
 from suite.fixtures import PublicEndpoint
 from suite.resources_utils import (
     create_items_from_yaml,
     delete_items_from_yaml,
+    get_file_contents,
     get_first_pod_name,
+    replace_configmap_from_yaml,
     wait_before_test,
     wait_until_all_pods_are_ready,
-    replace_configmap_from_yaml,
-    get_file_contents,
 )
 from suite.ssl_utils import create_sni_session
 from suite.vs_vsr_resources_utils import create_virtual_server_from_yaml, delete_virtual_server, read_vs


### PR DESCRIPTION
### Proposed changes
Accept requests with proxy protocol header at port 443 when TLS Passthrough is enabled to retrieve client IP.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
