### PR TITLE
Fix typo in anchor link

### DIFF
--- a/docs/content/configuration/virtualserver-and-virtualserverroute-resources.md
+++ b/docs/content/configuration/virtualserver-and-virtualserverroute-resources.md
@@ -57,7 +57,7 @@ spec:
 |``dos`` | A reference to a DosProtectedResource, setting this enables DOS protection of the VirtualServer. | ``string`` | No |
 |``policies`` | A list of policies. | [[]policy](#virtualserverpolicy) | No |
 |``upstreams`` | A list of upstreams. | [[]upstream](#upstream) | No |
-|``routes`` | A list of routes. | [[]route](#virtualserver-route) | No |
+|``routes`` | A list of routes. | [[]route](#virtualserverroute) | No |
 |``ingressClassName`` | Specifies which Ingress Controller must handle the VirtualServer resource. | ``string`` | No |
 |``http-snippets`` | Sets a custom snippet in the http context. | ``string`` | No |
 |``server-snippets`` | Sets a custom snippet in server context. Overrides the ``server-snippets`` ConfigMap key. | ``string`` | No |


### PR DESCRIPTION
### Proposed changes
This is a docs fix for bug [KIC-995](https://nginxsoftware.atlassian.net/browse/KIC-995), correcting a typo in an anchor link.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
