### PR TITLE
Remove duplicate print for k8s version, use right check for args

### DIFF
--- a/cmd/nginx-ingress/flags.go
+++ b/cmd/nginx-ingress/flags.go
@@ -282,8 +282,8 @@ func initialChecks() {
 	}
 
 	unparsed := flag.Args()
-	if unparsed != nil {
-		glog.Warningf("Ignoring unhandled arguments: %v", unparsed)
+	if len(unparsed) > 0 {
+		glog.Warningf("Ignoring unhandled arguments: %+q", unparsed)
 	}
 }
 

--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 
@@ -164,7 +163,5 @@ func GetK8sVersion(client kubernetes.Interface) (v *version.Version, err error) 
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error parsing running Kubernetes version: %w", err)
 	}
-	glog.V(3).Infof("Kubernetes version: %v", runningVersion)
-
 	return runningVersion, nil
 }


### PR DESCRIPTION
We are already printing the version of kubernetes, so we don't need the additional V(3).

flag.Args is never `nil`, we need to check if there are values in the array.

