### PR TITLE
Fix docs label name, remove test for unit tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,13 +11,12 @@ tests:
 - branch: ['tests/**', 'test/**']
 - tests/**/*
 - perf-tests/**/*
-- '**/*_test.go'
 
-docs:
+documentation:
 - branch: ['docs/**', 'doc/**']
 - '**/*.md'
 
 dependencies:
-- branch: ['deps/**', 'dep/**']
+- branch: ['deps/**', 'dep/**', 'dependabot/**']
 - go.mod
 - go.sum


### PR DESCRIPTION
The right label for docs is `documentation`.
Removes `tests` label for unit tests as it will add a lot of noise to the changelog.
