### PR TITLE
Remove deprecated kubernetes.io/ingress.class from examples

### DIFF
--- a/docs/content/configuration/handling-host-and-listener-collisions.md
+++ b/docs/content/configuration/handling-host-and-listener-collisions.md
@@ -31,9 +31,8 @@ Consider the following two resources:
     kind: Ingress
     metadata:
       name: cafe-ingress
-      annotations:
-        kubernetes.io/ingress.class: "nginx"
     spec:
+      ingressClassName: nginx
       rules:
       - host: cafe.example.com
         . . .

--- a/docs/content/configuration/ingress-resources/advanced-configuration-with-annotations.md
+++ b/docs/content/configuration/ingress-resources/advanced-configuration-with-annotations.md
@@ -91,14 +91,6 @@ The table below summarizes the available annotations.
 
 **Note**: The annotations that start with `nginx.com` are only supported with NGINX Plus.
 
-### Ingress Controller (Not Related to NGINX Configuration)
-
-{{% table %}}
-|Annotation | ConfigMap Key | Description | Default | Example |
-| ---| ---| ---| ---| --- |
-|``kubernetes.io/ingress.class`` | N/A | Specifies which Ingress Controller must handle the Ingress resource. Set to ``nginx`` to make NGINX Ingress Controller handle it. | N/A | [Multiple Ingress Controllers](/nginx-ingress-controller/installation/running-multiple-ingress-controllers). |
-{{% /table %}}
-
 ### General Customization
 
 {{% table %}}

--- a/examples/ingress-resources/app-protect-waf/cafe-ingress.yaml
+++ b/examples/ingress-resources/app-protect-waf/cafe-ingress.yaml
@@ -3,13 +3,13 @@ kind: Ingress
 metadata:
   name: cafe-ingress
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     appprotect.f5.com/app-protect-policy: "default/dataguard-alarm"
     appprotect.f5.com/app-protect-enable: "True"
     appprotect.f5.com/app-protect-security-log-enable: "True"
     appprotect.f5.com/app-protect-security-log: "default/logconf"
     appprotect.f5.com/app-protect-security-log-destination: "syslog:server=syslog-svc.default:514"
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - cafe.example.com

--- a/examples/ingress-resources/basic-auth/README.md
+++ b/examples/ingress-resources/basic-auth/README.md
@@ -78,9 +78,9 @@ In the following example we enable Basic Auth validation for the [mergeable Ingr
   metadata:
     name: cafe-ingress-master
     annotations:
-      kubernetes.io/ingress.class: "nginx"
       nginx.org/mergeable-ingress-type: "master"
   spec:
+    ingressClassName: nginx
     tls:
     - hosts:
       - cafe.example.com

--- a/examples/ingress-resources/custom-annotations/README.md
+++ b/examples/ingress-resources/custom-annotations/README.md
@@ -86,11 +86,11 @@ Customize the template for Ingress resources to include the logic to handle and 
     metadata:
       name: cafe-ingress
       annotations:
-        kubernetes.io/ingress.class: "nginx"
         custom.nginx.org/rate-limiting: "on"
         custom.nginx.org/rate-limiting-rate: "5r/s"
         custom.nginx.org/rate-limiting-burst: "1"
     spec:
+      ingressClassName: nginx
       rules:
       - host: "cafe.example.com"
         http:

--- a/examples/ingress-resources/externalname-services/README.md
+++ b/examples/ingress-resources/externalname-services/README.md
@@ -44,9 +44,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
 spec:
+  ingressClassName: nginx
   rules:
   - host: example.com
     http:

--- a/examples/ingress-resources/grpc-services/README.md
+++ b/examples/ingress-resources/grpc-services/README.md
@@ -24,8 +24,8 @@ metadata:
   name: grpc-ingress
   annotations:
     nginx.org/grpc-services: "grpc-svc"
-    kubernetes.io/ingress.class: "nginx"
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - grpc.example.com

--- a/examples/ingress-resources/health-checks/README.md
+++ b/examples/ingress-resources/health-checks/README.md
@@ -20,9 +20,9 @@ kind: Ingress
 metadata:
   name: cafe-ingress
   annotations:
-     kubernetes.io/ingress.class: "nginx"
      nginx.com/health-checks: "true"
 spec:
+  ingressClassName: nginx
   rules:
   - host: "cafe.example.com"
     http:

--- a/examples/ingress-resources/jwt/README.md
+++ b/examples/ingress-resources/jwt/README.md
@@ -56,9 +56,9 @@ In the following example we enable JWT validation for the [mergeable Ingresses](
   metadata:
     name: cafe-ingress-master
     annotations:
-      kubernetes.io/ingress.class: "nginx"
       nginx.org/mergeable-ingress-type: "master"
   spec:
+    ingressClassName: nginx
     tls:
     - hosts:
       - cafe.example.com
@@ -74,13 +74,13 @@ In the following example we enable JWT validation for the [mergeable Ingresses](
   metadata:
     name: cafe-ingress-tea-minion
     annotations:
-      kubernetes.io/ingress.class: "nginx"
       nginx.org/mergeable-ingress-type: "minion"
       nginx.com/jwt-key: "tea-jwk"
       nginx.com/jwt-realm: "Tea"
       nginx.com/jwt-token: "$cookie_auth_token"
       nginx.com/jwt-login-url: "https://login-tea.cafe.example.com"
   spec:
+    ingressClassName: nginx
     rules:
     - host: cafe.example.com
       http:
@@ -101,13 +101,13 @@ In the following example we enable JWT validation for the [mergeable Ingresses](
   metadata:
     name: cafe-ingress-coffee-minion
     annotations:
-      kubernetes.io/ingress.class: "nginx"
       nginx.org/mergeable-ingress-type: "minion"
       nginx.com/jwt-key: "coffee-jwk"
       nginx.com/jwt-realm: "Coffee"
       nginx.com/jwt-token: "$cookie_auth_token"
       nginx.com/jwt-login-url: "https://login-coffee.cafe.example.com"
   spec:
+    ingressClassName: nginx
     rules:
     - host: cafe.example.com
       http:

--- a/examples/ingress-resources/mergeable-ingress-types/cafe-master.yaml
+++ b/examples/ingress-resources/mergeable-ingress-types/cafe-master.yaml
@@ -3,9 +3,9 @@ kind: Ingress
 metadata:
   name: cafe-ingress-master
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.org/mergeable-ingress-type: "master"
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - cafe.example.com

--- a/examples/ingress-resources/mergeable-ingress-types/coffee-minion.yaml
+++ b/examples/ingress-resources/mergeable-ingress-types/coffee-minion.yaml
@@ -3,9 +3,9 @@ kind: Ingress
 metadata:
   name: cafe-ingress-coffee-minion
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.org/mergeable-ingress-type: "minion"
 spec:
+  ingressClassName: nginx
   rules:
   - host: cafe.example.com
     http:

--- a/examples/ingress-resources/mergeable-ingress-types/tea-minion.yaml
+++ b/examples/ingress-resources/mergeable-ingress-types/tea-minion.yaml
@@ -3,9 +3,9 @@ kind: Ingress
 metadata:
   name: cafe-ingress-tea-minion
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.org/mergeable-ingress-type: "minion"
 spec:
+  ingressClassName: nginx
   rules:
   - host: cafe.example.com
     http:

--- a/examples/shared-examples/wildcard-tls-certificate/README.md
+++ b/examples/shared-examples/wildcard-tls-certificate/README.md
@@ -26,9 +26,8 @@ kind: Ingress
 metadata:
   name: foo
   namespace: foo
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - foo.example.com
@@ -56,9 +55,9 @@ metadata:
 spec:
   host: bar.example.com
   tls:
-    secret: "" 
+    secret: ""
   upstreams:
-  - name: bar 
+  - name: bar
     service: bar-service
     port: 80
   routes:


### PR DESCRIPTION
Replaces `kubernetes.io/ingress.class` with  `ingressClassName`.

Opening it as a draft as I'm not sure if we need to add something to the examples to call out the need to deploy the ingressClass. It's already called out in the https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-manifests/ and we deploy it automatically with `helm`
