### PR TITLE
feat: F5-hugo theme September bump (cherrypick)

### DIFF
--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/coveo.css
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/coveo.css
@@ -236,9 +236,6 @@
   width: 15px
 }
 
-.coveo-facet-value[data-value="No Product"] {
-  display: none
-}
 .coveo-modal-backdrop{
 z-index: 1072
 }

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/f5-hugo.css
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/css/f5-hugo.css
@@ -502,7 +502,7 @@ blockquote {
 
 }
 
-.warning {
+.warning, .important {
     border-left: 4px solid #c20025;
 }
 

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/js/coveo.js
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/assets/js/coveo.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', function () {
-  Coveo.SearchEndpoint.configureCloudV2Endpoint("", 'xx79df1e1f-11e4-4da5-8ea8-2ed7e24cca6a');
+  Coveo.SearchEndpoint.configureCloudV2Endpoint("", 'xx79df1e1f-11e4-4da5-8ea8-2ed7e24cca6a');  // Prod API key
+  // Coveo.SearchEndpoint.configureCloudV2Endpoint("", 'xxe1e9046f-585c-4518-a14a-6b986a5efffd'); // test API key
   const root = document.getElementById("search");
   const searchBoxRoot = document.getElementById("searchbox");
   Coveo.initSearchbox(searchBoxRoot, "/search.html");
@@ -23,6 +24,16 @@ document.addEventListener('DOMContentLoaded', function () {
       Coveo.$('.CoveoResultLink').removeAttr('title');         
     }
   });
-  Coveo.init(root);
+  Coveo.init(root, {
+    f5_product_module: {
+      dependsOn: "@f5_product",
+      dependsOnCondition: (parentFacet) => {
+        const id = parentFacet.options.id;
+        const value = "NGINX Management Suite";
+        const selected = parentFacet.queryStateModel.get(`f:${id}`)
+        return selected.includes(value);
+      }
+    }
+  });
 })
 

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/_default/sitemap.xml
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/_default/sitemap.xml
@@ -2,22 +2,24 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
-  <url>
-    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
-    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
-    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
-    <xhtml:link
-                rel="alternate"
-                hreflang="{{ .Lang }}"
-                href="{{ .Permalink }}"
-                />{{ end }}
-    <xhtml:link
-                rel="alternate"
-                hreflang="{{ .Lang }}"
-                href="{{ .Permalink }}"
-                />{{ end }}
-  </url>
+    {{ if not (in .Site.Params.taxonomiesExcludedFromSitemap .Data.Plural) }}
+    <url>
+      <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+      <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+      <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+      <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+      <xhtml:link
+                  rel="alternate"
+                  hreflang="{{ .Lang }}"
+                  href="{{ .Permalink }}"
+                  />{{ end }}
+      <xhtml:link
+                  rel="alternate"
+                  hreflang="{{ .Lang }}"
+                  href="{{ .Permalink }}"
+                  />{{ end }}
+    </url>
+    {{ end }}
   {{ end }}
 </urlset>
 

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/meta.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/meta.html
@@ -66,3 +66,8 @@
 <meta property="environment" type="{{ hugo.Environment }}" />
 <meta property="buildtype" type="{{ .Site.Params.buildtype }}" />
 <meta property="isServer" type="{{ .Site.IsServer }}" />
+
+<!-- Coveo metadata-->
+<meta name="product" content="{{ .Site.Title }}">
+<meta name="version" content="{{ .Site.Params.currentVersion }}"> 
+<meta name="doc_type" content="Manual">

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/styles.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/partials/styles.html
@@ -1,9 +1,9 @@
 {{ $css1 := resources.Get "css/docs-nginx-com/nginx-site-header.css" }}
 {{ $css2 := resources.Get "css/docs-nginx-com/style.css" }}
 {{ $css3 := resources.Get "css/bootstrap-docs.css" }}
-{{ $css5 := resources.Get "css/coveo.css" }}
 {{ $css4 := resources.Get "css/f5-hugo.css" }}
 {{ $css5 := resources.Get "css/highlight.css" }}
+{{ $css6 := resources.Get "css/coveo.css" }}
 
 {{ if in .Site.Params.buildtype "package" }}
 
@@ -38,7 +38,7 @@
 <link href="{{ $bootstrapDocs.RelPermalink }}" rel="stylesheet" type="text/css">
 
 {{ if ( not ( in .Site.Params.buildtype "package" ) ) }}
-{{ $cssCoveo := $css5 | minify | fingerprint "sha512"}}
+{{ $cssCoveo := $css6 | minify | fingerprint "sha512"}}
 <link href="{{ $cssCoveo.RelPermalink }}" rel="stylesheet" type="text/css">
 {{ end }}
 

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/search/single.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/search/single.html
@@ -14,6 +14,7 @@
         <div class="coveo-facet-column">
           <div class="CoveoFacet" data-title="Show by product" data-field="@f5_product" data-tab="All"
             data-number-of-values="15"></div>
+          <div class="CoveoFacet" id="f5_product_module" data-title="Module" data-field="@f5_product_module" data-enable-settings="true" data-is-multi-value-field="true" data-number-of-values="10"></div>
           <button id="reset_btn"><img src="{{ .Site.BaseURL }}/images/svg/refresh.svg">Reset</button>
         </div>
         <div class="coveo-results-column">

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/shortcodes/important.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/shortcodes/important.html
@@ -1,3 +1,3 @@
-<blockquote class="note">
+<blockquote class="important">
   <div><strong>Important:</strong><br/> {{ .Inner | markdownify }}</div>
 </blockquote>

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/shortcodes/shortversions.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/shortcodes/shortversions.html
@@ -1,66 +1,69 @@
 {{/* Use this shortcode to display the versions that the document applies to 
-Parameters: "first version"  "last version" "product"
-First version can be a version number, e.g. "3.18", or "first" to use as the 1st version to show
-Last version can be a version number, e.g. "3.21", to show as the 2nd version to show, or it can be "latest" to show 'and later'
-Product can be "ctrlvers" "apimvers" "adcvers" "nimvers" */}}
-{{ $start := string (.Get 0)  }}
-{{ $end := string (.Get 1)  }}
-{{ $product := string (.Get 2)  }}
-{{ $temp := slice }}
-{{ $result := ""}}
-{{ $ver := slice }}
-{{ $prodname := ""}}
-{{ $istart := 0}}
-{{ $iend := 100}}
-{{ $islatest := 0}}
-{{if eq $product "apimvers"  }}
-  {{ $ver = $.Site.Params.apimvers }}
-  {{ $prodname = "NGINX Controller API Management module" }}
-{{else if eq $product "adcvers" }}
-  {{ $ver = $.Site.Params.adcvers }}
-  {{ $prodname = "NGINX Controller App Delivery module" }}
-{{else if eq $product "nimvers" }}
-  {{ $ver = $.Site.Params.nimvers }}
-  {{ $prodname = "NGINX Instance Manager" }}
-{{else}}
-  {{ $ver = $.Site.Params.ctrlvers }}
-  {{ $prodname = "NGINX Controller" }}
-{{end}} 
-{{if eq $start "first"}}
-  {{$start = first 1 $ver}}
-{{end}}
-{{if eq $end "latest"}}
-  {{$islatest = true}}
-  {{$end = last 1 $ver}}
-{{end}}
-{{ $.Scratch.Set "counter" 0 }}
-{{ range $ver }}
-    {{ $index := $.Scratch.Get "counter"}}
-    {{ $current := index $ver $index}}
-    {{if eq $current $start }}
-        {{$istart = $index}}
-    {{end}}
-    {{if eq $current $end}}
-        {{$iend = $index}}
-    {{end}}
-    {{ $.Scratch.Set "counter" (add ($.Scratch.Get "counter") 1) }}
-{{ end }}
-{{ $temp = after $istart $ver }}
-{{ $iend = add (sub $iend $istart) 1 }}
-{{ $temp = first $iend $temp }}
-{{ $result = delimit $temp ", " " and " }}
-{{ if $islatest}}
-  <hr> 
-  <div id="versions-list">
-      <p>This documentation applies to {{$prodname}} {{$start}} and later.</p>
-  </div>
-  {{ if eq $product "nimvers" }}
-    <hr>    
+  Parameters: "first version"  "last version" "product"
+  First version can be a version number, e.g. "3.18", or "first" to use as the 1st version to show
+  Last version can be a version number, e.g. "3.21", to show as the 2nd version to show, or it can be "latest" to show 'and later'
+  Product can be "ctrlvers" "apimvers" "adcvers" "nimvers" "acmvers" */}}
+  {{ $start := string (.Get 0)  }}
+  {{ $end := string (.Get 1)  }}
+  {{ $product := string (.Get 2)  }}
+  {{ $temp := slice }}
+  {{ $result := ""}}
+  {{ $ver := slice }}
+  {{ $prodname := ""}}
+  {{ $istart := 0}}
+  {{ $iend := 100}}
+  {{ $islatest := 0}}
+  {{if eq $product "apimvers"  }}
+    {{ $ver = $.Site.Params.apimvers }}
+    {{ $prodname = "NGINX Controller API Management module" }}
+  {{else if eq $product "adcvers" }}
+    {{ $ver = $.Site.Params.adcvers }}
+    {{ $prodname = "NGINX Controller App Delivery module" }}
+  {{else if eq $product "nimvers" }}
+    {{ $ver = $.Site.Params.nimvers }}
+    {{ $prodname = "NGINX Management Suite Instance Manager" }}
+  {{else if eq $product "acmvers" }}
+    {{ $ver = $.Site.Params.acmvers }}
+    {{ $prodname = "NGINX Management Suite API Connectivity Manager" }}
+  {{else}}
+    {{ $ver = $.Site.Params.ctrlvers }}
+    {{ $prodname = "NGINX Controller" }}
+  {{end}} 
+  {{if eq $start "first"}}
+    {{$start = first 1 $ver}}
   {{end}}
-{{else}}
-  <hr> 
-  <div id="versions-list">
-      <p>This documentation applies to {{$prodname}} {{$start}} - {{$end}}.</p>
-  </div>
-    <hr>    
-{{end}}
+  {{if eq $end "latest"}}
+    {{$islatest = true}}
+    {{$end = last 1 $ver}}
+  {{end}}
+  {{ $.Scratch.Set "counter" 0 }}
+  {{ range $ver }}
+      {{ $index := $.Scratch.Get "counter"}}
+      {{ $current := index $ver $index}}
+      {{if eq $current $start }}
+          {{$istart = $index}}
+      {{end}}
+      {{if eq $current $end}}
+          {{$iend = $index}}
+      {{end}}
+      {{ $.Scratch.Set "counter" (add ($.Scratch.Get "counter") 1) }}
+  {{ end }}
+  {{ $temp = after $istart $ver }}
+  {{ $iend = add (sub $iend $istart) 1 }}
+  {{ $temp = first $iend $temp }}
+  {{ $result = delimit $temp ", " " and " }}
+  {{ if $islatest}}
+    <hr> 
+    <div id="versions-list">
+        <p>This documentation applies to {{$prodname}} {{$start}} and later.</p>
+    </div>
+    {{ if eq $product "nimvers" }}
+      <hr>    
+    {{end}}
+  {{else}}
+    <hr> 
+    <div id="versions-list">
+        <p>This documentation applies to {{$prodname}} {{$start}} - {{$end}}.</p>
+    </div>
+      <hr>    
+  {{end}}

--- a/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/shortcodes/versions.html
+++ b/docs/_vendor/gitlab.com/f5/nginx/controller/poc/f5-hugo/layouts/shortcodes/versions.html
@@ -2,7 +2,7 @@
   Parameters: "first version"  "last version" "product"
   First version can be a version number, e.g. "3.18", or "first" to use the lowest value in the array 
   Last version can be a version number, e.g. "3.21", or "latest" to use the highest value in the array
-  Product can be "ctrlvers" "apimvers" "adcvers" "nimvers" */}}
+  Product can be "ctrlvers" "apimvers" "adcvers" "nimvers" "acmvers" */}}
   {{ $start := string (.Get 0)  }}
   {{ $end := string (.Get 1)  }}
   {{ $product := string (.Get 2)  }}
@@ -20,7 +20,10 @@
     {{ $prodname = "NGINX Controller App Delivery module" }}
   {{else if eq $product "nimvers" }}
     {{ $ver = $.Site.Params.nimvers }}
-    {{ $prodname = "Instance Manager" }}
+    {{ $prodname = "NGINX Management Suite Instance Manager" }}
+  {{else if eq $product "acmvers" }}
+    {{ $ver = $.Site.Params.acmvers }}
+    {{ $prodname = "NGINX Management Suite API Connectivity Manager" }}
   {{else}}
     {{ $ver = $.Site.Params.ctrlvers }}
     {{ $prodname = "NGINX Controller" }}

--- a/docs/_vendor/modules.txt
+++ b/docs/_vendor/modules.txt
@@ -1,1 +1,1 @@
-# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.2
+# gitlab.com/f5/nginx/controller/poc/f5-hugo v0.23.3

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/nginxinc/kubernetes-ingress/docs
 
 go 1.15
 
-require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.2 // indirect
+require gitlab.com/f5/nginx/controller/poc/f5-hugo v0.23.3 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -26,3 +26,5 @@ gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.1 h1:SKPsQzWo5xBDmXoIi3ti8TAZtd
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.1/go.mod h1:Y9Ez7EKgsbFXNsflK0tGLe6FWqlPToWFGZyrkduYdM4=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.2 h1:NTQmkbyS8/SA4p8c2J6idx/KQhky36PYNsTJHxH9Vig=
 gitlab.com/f5/nginx/controller/poc/f5-hugo v0.22.2/go.mod h1:Y9Ez7EKgsbFXNsflK0tGLe6FWqlPToWFGZyrkduYdM4=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.23.3 h1:PwuNzUQWW4G3FUYa+vmh/FK+sKsdg7oKgAQDKF2QkT4=
+gitlab.com/f5/nginx/controller/poc/f5-hugo v0.23.3/go.mod h1:Y9Ez7EKgsbFXNsflK0tGLe6FWqlPToWFGZyrkduYdM4=


### PR DESCRIPTION
**Cherrypick of the theme bump to the release branch**

This request updates the f5-hugo theme files to v. 0.23.3

- Coveo search updates and fixes
- Sitemap changes
- "Important" callout improvements
- Shortcodes updates

and more.