### PR TITLE
Update Helm Chart apiVersion to v2

### DIFF
--- a/deployments/helm-chart/Chart.yaml
+++ b/deployments/helm-chart/Chart.yaml
@@ -1,8 +1,9 @@
+apiVersion: v2
 name: nginx-ingress
 version: 0.14.1
 appVersion: 2.3.1
-apiVersion: v1
 kubeVersion: ">= 1.19.0-0"
+type: application
 description: NGINX Ingress Controller
 icon: https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/v2.3.1/deployments/helm-chart/chart-icon.png
 home: https://github.com/nginxinc/kubernetes-ingress


### PR DESCRIPTION
We only support helm 3 so it's safe to update to v2.
