### PR TITLE
Add RBAC for coordination.k8s.io/leases

### DIFF
--- a/deployments/helm-chart/templates/rbac.yaml
+++ b/deployments/helm-chart/templates/rbac.yaml
@@ -75,6 +75,16 @@ rules:
   - patch
   - list
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingresses


### PR DESCRIPTION
### Proposed changes
In #2839 the RBAC was changed to add the coordination.k8s.io/leases for the deployments/rbac but not for deployments/helm-chart/templates/rbac. Without this change the helm chart deployment is broken on main.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
