### PR TITLE
Add bot-defense caseSensitiveHttpHeaders setting to APPolicy CRD

### DIFF
--- a/deployments/common/crds/appprotect.f5.com_appolicies.yaml
+++ b/deployments/common/crds/appprotect.f5.com_appolicies.yaml
@@ -336,6 +336,8 @@ spec:
                           properties:
                             isEnabled:
                               type: boolean
+                            caseSensitiveHttpHeaders:
+                              type: boolean
                           type: object
                       type: object
                     browser-definitions:

--- a/deployments/common/crds/appprotect.f5.com_appolicies.yaml
+++ b/deployments/common/crds/appprotect.f5.com_appolicies.yaml
@@ -334,9 +334,9 @@ spec:
                           type: object
                         settings:
                           properties:
-                            isEnabled:
-                              type: boolean
                             caseSensitiveHttpHeaders:
+                              type: boolean
+                            isEnabled:
                               type: boolean
                           type: object
                       type: object

--- a/deployments/helm-chart/crds/appprotect.f5.com_appolicies.yaml
+++ b/deployments/helm-chart/crds/appprotect.f5.com_appolicies.yaml
@@ -334,6 +334,8 @@ spec:
                           type: object
                         settings:
                           properties:
+                            caseSensitiveHttpHeaders:
+                              type: boolean
                             isEnabled:
                               type: boolean
                           type: object


### PR DESCRIPTION
### Proposed changes
Add the missing bot-defense `caseSensitiveHttpHeaders` setting to APPolicy CRD. Resolves #3111 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
