### PR TITLE
Don't use `latest` tag for AWS images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,7 +531,9 @@ jobs:
             name=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic${{ contains(matrix.image, 'nap') && '-dos' || '' }}/nginx-plus-ingress,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             name=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/staging/nginx-ic${{ contains(matrix.image, 'nap') && '-dos' || '' }}/nginx-plus-ingress,enable=${{ startsWith(github.ref, 'refs/heads/release') }}
             name=709825985650.dkr.ecr.us-east-1.amazonaws.com/nginx/nginx-plus-ingress,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(matrix.target, 'aws') }}
-          flavor: suffix=${{ contains(matrix.image, 'ubi') && '-ubi' || '' }}${{ contains(matrix.image, 'alpine') && '-alpine' || '' }}${{ contains(matrix.target, 'aws') && '-mktpl' || '' }},onlatest=true
+          flavor: |
+            suffix=${{ contains(matrix.image, 'ubi') && '-ubi' || '' }}${{ contains(matrix.image, 'alpine') && '-alpine' || '' }}${{ contains(matrix.target, 'aws') && '-mktpl' || '' }},onlatest=true
+            latest=${{ contains(matrix.target, 'aws') && 'false' || 'auto' }}
           tags: |
             type=edge
             type=ref,event=branch,enable=${{ startsWith(github.ref, 'refs/heads/release') }}


### PR DESCRIPTION
AWS doesn't accept the tag `latest` and causes the pipeline to throw an error.
