### PR TITLE
Push NAP DoS image to AWS Marketplace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
           GOPATH: ${{ needs.checks.outputs.go_path }}
           AWS_PRODUCT_CODE: ${{ secrets.AWS_PRODUCT_CODE }}
           AWS_PUB_KEY: ${{ secrets.AWS_PUB_KEY }}
+          AWS_NAP_DOS_PRODUCT_CODE: ${{ secrets.AWS_NAP_DOS_PRODUCT_CODE }}
+          AWS_NAP_DOS_PUB_KEY: ${{ secrets.AWS_NAP_DOS_PUB_KEY }}
       - name: Store Artifacts in Cache
         uses: actions/cache@v3
         with:
@@ -327,6 +329,8 @@ jobs:
           GOPATH: ${{ needs.checks.outputs.go_path }}
           AWS_PRODUCT_CODE: ${{ secrets.AWS_PRODUCT_CODE }}
           AWS_PUB_KEY: ${{ secrets.AWS_PUB_KEY }}
+          AWS_NAP_DOS_PRODUCT_CODE: ${{ secrets.AWS_NAP_DOS_PRODUCT_CODE }}
+          AWS_NAP_DOS_PUB_KEY: ${{ secrets.AWS_NAP_DOS_PUB_KEY }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_COMMUNITY }}
           AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
           AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
@@ -493,6 +497,9 @@ jobs:
             - image: debian-plus-nap
               platforms: "linux/amd64"
               target: goreleaser
+            - image: debian-plus-nap
+              platforms: "linux/amd64"
+              target: aws
 
     steps:
       - name: Checkout Repository
@@ -531,10 +538,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            name=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic${{ contains(matrix.image, 'nap') && '-dos' || '' }}/nginx-plus-ingress
             name=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release/nginx-ic${{ contains(matrix.image, 'nap') && '-dos' || '' }}/nginx-plus-ingress,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             name=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/staging/nginx-ic${{ contains(matrix.image, 'nap') && '-dos' || '' }}/nginx-plus-ingress,enable=${{ startsWith(github.ref, 'refs/heads/release') }}
-            name=709825985650.dkr.ecr.us-east-1.amazonaws.com/nginx/nginx-plus-ingress,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(matrix.target, 'aws') }}
+            name=709825985650.dkr.ecr.us-east-1.amazonaws.com/nginx/nginx-plus-ingress${{ contains(matrix.image, 'nap') && '-dos' || '' }},enable=${{ startsWith(github.ref, 'refs/tags/') && contains(matrix.target, 'aws') }}
           flavor: |
             suffix=${{ contains(matrix.image, 'ubi') && '-ubi' || '' }}${{ contains(matrix.image, 'alpine') && '-alpine' || '' }}${{ contains(matrix.target, 'aws') && '-mktpl' || '' }},onlatest=true
             latest=${{ contains(matrix.target, 'aws') && 'false' || 'auto' }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,23 @@ builds:
     binary: nginx-ingress
     tags:
       - aws
+  - id: aws-nap-dos
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -trimpath
+    gcflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    asmflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.productCode={{.Env.AWS_NAP_DOS_PRODUCT_CODE}} -X main.pubKeyString={{.Env.AWS_NAP_DOS_PUB_KEY}}
+    main: ./cmd/nginx-ingress/
+    binary: nginx-ingress
+    tags:
+      - aws
 
 archives:
   - id: kubernetes-ingress

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -273,16 +273,17 @@ ARG TARGETARCH
 
 LABEL org.nginx.kic.image.build.version="goreleaser"
 
-COPY --link --chown=101:0 dist/kubernetes-ingress_linux_$TARGETARCH*/nginx-ingress /
+COPY --link --chown=101:0 dist/kubernetes-ingress_linux_${TARGETARCH}*/nginx-ingress /
 
 
 ############################################# Create image with nginx-ingress built by GoReleaser for AWS Marketplace #############################################
 FROM common AS aws
 ARG TARGETARCH
+ARG NAP_MODULES=
 
 LABEL org.nginx.kic.image.build.version="aws"
 
-COPY --link --chown=101:0 dist/aws_linux_$TARGETARCH*/nginx-ingress /
+COPY --link --chown=101:0 dist/aws*${NAP_MODULES}_linux_${TARGETARCH}*/nginx-ingress /
 
 
 ############################################# Create image with nginx-ingress extracted from image on Docker Hub #############################################


### PR DESCRIPTION
Adds support for building and pushing NAP DoS images to the AWS Marketplace.
