### PR TITLE
Run CI for docs changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,20 +5,12 @@ on:
     branches:
       - main
       - release-*
-    paths-ignore:
-      - 'docs/**'
-      - 'examples/**'
-      - '**.md'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main
       - release-*
-    paths-ignore:
-      - 'docs/**'
-      - 'examples/**'
-      - '**.md'
     types:
       - opened
       - reopened


### PR DESCRIPTION
We have a couple of required checks that need to pass for a PR to be merged. When there are only docs changes, the CI pipeline doesn't run, making it impossible to merge the PR. With this change, we will always run the CI unconditionally.
