### PR TITLE
Always print build info, add flags used

### DIFF
--- a/cmd/nginx-ingress/flags.go
+++ b/cmd/nginx-ingress/flags.go
@@ -15,15 +15,6 @@ import (
 )
 
 var (
-
-	// Injected during build
-	version string
-
-	// Info read from the binary
-	commitHash = "unknown"
-	commitTime = "unknown"
-	dirtyBuild = true
-
 	healthStatus = flag.Bool("health-status", false,
 		`Add a location based on the value of health-status-uri to the default server. The location responds with the 200 status code for any request.
 	Useful for external health-checking of the Ingress Controller`)
@@ -187,17 +178,14 @@ var (
 )
 
 //gocyclo:ignore
-func parseFlags(versionInfo string, binaryInfo string) {
+func parseFlags() {
 	flag.Parse()
 
-	initialChecks()
-
 	if *versionFlag {
-		printVersionInfo(versionInfo, binaryInfo)
+		os.Exit(0)
 	}
 
-	glog.Infof("Starting NGINX Ingress Controller %v PlusFlag=%v", versionInfo, *nginxPlus)
-	glog.Info(binaryInfo)
+	initialChecks()
 
 	watchNamespaces = strings.Split(*watchNamespace, ",")
 
@@ -284,17 +272,12 @@ func initialChecks() {
 		}
 	}
 
+	glog.Infof("Starting with flags: %+q", os.Args[1:])
+
 	unparsed := flag.Args()
 	if len(unparsed) > 0 {
 		glog.Warningf("Ignoring unhandled arguments: %+q", unparsed)
 	}
-}
-
-// printVersionInfo prints the the version and binary info before exiting if the flag is set
-func printVersionInfo(versionInfo string, binaryInfo string) {
-	fmt.Println(versionInfo)
-	fmt.Println(binaryInfo)
-	os.Exit(0)
 }
 
 // validationChecks checks the values for various flags

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -37,9 +38,14 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// Injected during build
+var version string
+
 func main() {
-	binaryInfo, versionInfo := getBuildInfo()
-	parseFlags(binaryInfo, versionInfo)
+	commitHash, commitTime, dirtyBuild := getBuildInfo()
+	fmt.Printf("NGINX Ingress Controller Version=%v Commit=%v Date=%v DirtyState=%v Arch=%v/%v Go=%v\n", version, commitHash, commitTime, dirtyBuild, runtime.GOOS, runtime.GOARCH, runtime.Version())
+
+	parseFlags()
 
 	config, kubeClient := createConfigAndKubeClient()
 

--- a/cmd/nginx-ingress/utils.go
+++ b/cmd/nginx-ingress/utils.go
@@ -1,15 +1,17 @@
 package main
 
 import (
-	"fmt"
-	"runtime"
 	"runtime/debug"
 )
 
-func getBuildInfo() (string, string) {
+func getBuildInfo() (commitHash string, commitTime string, dirtyBuild string) {
+	commitHash = "unknown"
+	commitTime = "unknown"
+	dirtyBuild = "unknown"
+
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		return "", ""
+		return
 	}
 	for _, kv := range info.Settings {
 		switch kv.Key {
@@ -18,11 +20,8 @@ func getBuildInfo() (string, string) {
 		case "vcs.time":
 			commitTime = kv.Value
 		case "vcs.modified":
-			dirtyBuild = kv.Value == "true"
+			dirtyBuild = kv.Value
 		}
 	}
-	binaryInfo := fmt.Sprintf("Commit=%v Date=%v DirtyState=%v Arch=%v/%v Go=%v", commitHash, commitTime, dirtyBuild, runtime.GOOS, runtime.GOARCH, runtime.Version())
-	versionInfo := fmt.Sprintf("Version=%v", version)
-
-	return versionInfo, binaryInfo
+	return commitHash, commitTime, dirtyBuild
 }


### PR DESCRIPTION
- Moves the build info output to the beginning of `main.go`, so it will always print the info even if there are errors with the flags or somewhere else
- Adds output of all the flags passed to the binary
