### PR TITLE
Add context to http calls

### DIFF
--- a/internal/nginx/verify.go
+++ b/internal/nginx/verify.go
@@ -37,7 +37,15 @@ func newVerifyClient(timeout time.Duration) *verifyClient {
 // GetConfigVersion get version number that we put in the nginx config to verify that we're using
 // the correct config.
 func (c *verifyClient) GetConfigVersion() (int, error) {
-	resp, err := c.client.Get("http://config-version/configVersion")
+	ctx := context.Background()
+	reqContext, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqContext, "GET", "http://config-version/configVersion", nil)
+	if err != nil {
+		return 0, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("error getting client: %w", err)
 	}


### PR DESCRIPTION
Adds context to http calls that check config version. 
This fixes a couple of linter errors:
```
internal/nginx/verify.go:40:27: (*net/http.Client).Get must not be called (noctx)
internal/nginx/manager.go:436:29: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
```

