### PR TITLE
Remove ineffective break

### DIFF
--- a/internal/k8s/spiffe.go
+++ b/internal/k8s/spiffe.go
@@ -77,7 +77,6 @@ func (sc *SpiffeCertFetcher) Start(ctx context.Context, onStart func()) error {
 		case <-stopCh:
 			return sc.client.Close()
 		default:
-			break
 		}
 		time.Sleep(duration)
 	}


### PR DESCRIPTION
The break is not needed.
Fixes:
```
internal/k8s/spiffe.go:80:4: SA4011: ineffective break statement. Did you mean to break out of the outer loop? (staticcheck)
```
