### PR TITLE
Fix git command to retrieve commit matching the tag

### DIFF
--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -4,16 +4,17 @@ git_commit=$1
 git_tag=$2
 docker_tag=edge
 
-commit_tag=$(git tag --contains ${git_commit})
+commit_tag=$(git describe --exact-match ${git_commit} 2>/dev/null)
 
-if [[ ${commit_tag} == *${git_tag}* ]]; then
-    # we're on the tag, use the docker image for the tag
+if [[ ${commit_tag} == ${git_tag} ]]; then
+    # we're on the exact commit of the tag, use the docker image for the tag
     docker_tag=${git_tag//v/}
     echo ${docker_tag}
     exit 0
 
 else
-    # we're on main or a branch, try to download the latest edge and see if sha matches
+    # we're on a random commit, pull the 'edge' docker image to compare commits
+    # if it's the latest commit from 'main' the SHA will match the 'revision' of the 'edge' docker image
     docker pull nginx/nginx-ingress:${docker_tag} >/dev/null 2>&1
     DOCKER_SHA=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' nginx/nginx-ingress:${docker_tag})
     if [[ ${DOCKER_SHA} == ${git_commit} ]]; then


### PR DESCRIPTION
To find the correct binary to use for the build when a ueser checks out a tag, we need to match the exact commit for the tag. `git tag --contains` would list all the tags containg the commit, but we need to verify that the commit we're on matches the current tag.

