### PR TITLE
Run golangci-lint in pre-commit only for changed files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,10 +38,3 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           only-new-issues: true
-
-  lint-python:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: isort/isort-action@v1.1.0
-      - uses: psf/black@stable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,10 +29,19 @@ repos:
       - id: no-commit-to-branch
       - id: requirements-txt-fixer
       - id: fix-byte-order-marker
+  - repo: local
+    hooks:
+      - id: golang-diff
+        name: create-go-diff
+        entry: bash -c 'git diff -p origin/main > /tmp/diff.patch'
+        language: system
+        types: [go]
+        pass_filenames: false
   - repo: https://github.com/golangci/golangci-lint
     rev: v1.50.1
     hooks:
       - id: golangci-lint
+        args: [--new-from-patch=/tmp/diff.patch]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.2.0
     hooks:
@@ -53,3 +62,5 @@ repos:
         files: deployments/helm-chart/values.yaml
         types: [yaml]
         args: ['--schemafile', 'deployments/helm-chart/values.schema.json']
+ci:
+  skip: [golang-diff, golangci-lint, check-jsonschema]


### PR DESCRIPTION
This will also disables golangci-lint in pre-commit.ci (we'll still use the action) and removes `lint-python` as it's part of pre-commit