### PR TITLE
Drop support for k8s < 1.21

### DIFF
--- a/.github/actions/smoke-tests/action.yaml
+++ b/.github/actions/smoke-tests/action.yaml
@@ -81,8 +81,6 @@ runs:
     - name: Deploy Kubernetes
       id: k8s
       run: |
-        # no support for dual stack in < 1.20, we need to use ipv4 only
-        printf '%s\n' "1.20.0" "${{ inputs.k8s-version }}" | sort --version-sort --check=quiet || echo "Using ipv4" && sed -i 's/dual/ipv4/g' ${{ github.workspace }}/tests/ci-files/ci-kind-config.yaml
         kind create cluster --name ${{ github.run_id }} --image=kindest/node:v${{ inputs.k8s-version }} --config ${{ github.workspace }}/tests/ci-files/ci-kind-config.yaml --kubeconfig kube-${{ github.run_id }} --wait ${{ inputs.k8s-timeout }}
         kind load docker-image docker.io/nginx/${{ steps.ingress-type.outputs.name }}:${{ steps.ingress-type.outputs.tag }} --name ${{ github.run_id }}
         marker="${{ inputs.marker }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,8 +220,8 @@ jobs:
                                                 {\"image\": \"debian-plus-nap\", \"marker\": \"dos\"}], \
                                               \"k8s\": [\"${{ needs.checks.outputs.k8s_latest }}\"]}"
           else
-            echo "::set-output name=matrix::{\"k8s\": [\"1.19.16\", \"1.20.15\", \"1.21.14\", \"1.22.13\", \"1.23.10\", \"1.24.4\", \"${{ needs.checks.outputs.k8s_latest }}\"], \
-                                             \"images\": [{\"image\": \"debian\"}, {\"image\": \"debian-plus\"}]}"
+            echo "matrix={\"k8s\": [\"1.21.14\", \"1.22.15\", \"1.23.13\", \"1.24.7\", \"${{ needs.checks.outputs.k8s_latest }}\"], \
+                                             \"images\": [{\"image\": \"debian\"}, {\"image\": \"debian-plus\"}]}" >> $GITHUB_OUTPUT
           fi
 
   smoke-tests:

--- a/deployments/helm-chart-dos-arbitrator/Chart.yaml
+++ b/deployments/helm-chart-dos-arbitrator/Chart.yaml
@@ -2,7 +2,7 @@ name: nginx-appprotect-dos-arbitrator
 version: 0.1.0
 appVersion: 1.1.0
 apiVersion: v1
-kubeVersion: ">= 1.19.0-0"
+kubeVersion: ">= 1.21.0-0"
 description: NGINX App Protect Dos arbitrator
 icon: https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/v2.4.1/deployments/helm-chart-dos-arbitrator/chart-icon.png
 home: https://github.com/nginxinc/kubernetes-ingress

--- a/deployments/helm-chart/Chart.yaml
+++ b/deployments/helm-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx-ingress
 version: 0.15.1
 appVersion: 2.4.1
-kubeVersion: ">= 1.19.0-0"
+kubeVersion: ">= 1.21.0-0"
 type: application
 description: NGINX Ingress Controller
 icon: https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/v2.4.1/deployments/helm-chart/chart-icon.png


### PR DESCRIPTION
- Removes k8s versions < 1.21 from tests
- Removes logic in tests that is no longer needed 
- Updates minimum version in helm charts