### PR TITLE
Fix typo in command line arguments

### DIFF
--- a/docs/content/configuration/global-configuration/command-line-arguments.md
+++ b/docs/content/configuration/global-configuration/command-line-arguments.md
@@ -73,7 +73,7 @@ Default `false`.
 &nbsp;
 <a name="cmdoption-enable-leader-election"></a>
 
-### -inlcude-year
+### -include-year
 Adds year to log headers.
 
 Default `false`.


### PR DESCRIPTION
Fixes `inlcude`.
