### PR TITLE
fix: Pin ubi8 image to unblock nap ubi builds

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -124,7 +124,7 @@ RUN microdnf --nodocs upgrade -y freetype lua-libs zlib
 
 
 ############################################# Base image for UBI with NGINX Plus #############################################
-FROM redhat/ubi8 AS ubi-plus
+FROM redhat/ubi8:8.6-990 AS ubi-plus
 ARG NGINX_PLUS_VERSION
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
### Proposed changes
NAP builds are failing with:

`subscription-manager is disabled when running inside a container. Please refer to your host system for subscription management.`

Looks a change has occurred in the latest version of RH that requires the host system building the container be a RHEL image when trying to use subscription manager. This has already been the case for ubi9 (although there is a workaround), but now the latest version of ubi8 has the same behaviour (but the workaround doesn't work). This happens both in the pipeline and locally. This commit pins the ubi image version for now while we come up with a better long-term solution.

See https://serverfault.com/questions/1106847/rhel-9-in-docker-container-on-macos-subscription-manager-is-disabled-when-runni

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
