### PR TITLE
Remove version check in controller-service.yaml

### DIFF
--- a/deployments/helm-chart/templates/controller-service.yaml
+++ b/deployments/helm-chart/templates/controller-service.yaml
@@ -32,13 +32,11 @@ spec:
   {{- end }}
 {{- end }}
   type: {{ .Values.controller.service.type }}
-  {{- if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version }}
   {{- if .Values.controller.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.controller.service.ipFamilyPolicy }}
   {{- end }}
   {{- if .Values.controller.service.ipFamilies }}
   ipFamilies: {{ .Values.controller.service.ipFamilies }}
-  {{- end }}
   {{- end }}
   ports:
 {{- if .Values.controller.service.customPorts }}


### PR DESCRIPTION
The check is no longer needed since we bumped the minimum version to 1.21
