### PR TITLE
Add notifications for Build workflows

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -10,6 +10,8 @@ on:
       - "Lint"
       - "Update Docker Images"
       - "OpenSSF Scorecards"
+      - "Build OSS"
+      - "Build Plus"
     types:
       - completed
 


### PR DESCRIPTION
The Build process was moved to two separate workflows: `Build OSS` and `Build Plus`. 
This PR adds these two workflows to the list of workflows to watch for failures and send Slack notifications.
