### PR TITLE
Use Debian 11 with NAP WAF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ debian-image-plus: build ## Create Docker image for Ingress Controller (Debian w
 
 .PHONY: debian-image-nap-plus
 debian-image-nap-plus: build ## Create Docker image for Ingress Controller (Debian with NGINX Plus and App Protect WAF)
-	$(DOCKER_CMD) $(PLUS_ARGS) --build-arg BUILD_OS=debian-plus-nap --build-arg DEBIAN_VERSION=buster-slim --build-arg NAP_MODULES=waf
+	$(DOCKER_CMD) $(PLUS_ARGS) --build-arg BUILD_OS=debian-plus-nap --build-arg NAP_MODULES=waf
 
 .PHONY: debian-image-dos-plus
 debian-image-dos-plus: build ## Create Docker image for Ingress Controller (Debian with NGINX Plus and App Protect DoS)
@@ -123,7 +123,7 @@ debian-image-dos-plus: build ## Create Docker image for Ingress Controller (Debi
 
 .PHONY: debian-image-nap-dos-plus
 debian-image-nap-dos-plus: build ## Create Docker image for Ingress Controller (Debian with NGINX Plus, App Protect WAF and DoS)
-	$(DOCKER_CMD) $(PLUS_ARGS) --build-arg BUILD_OS=debian-plus-nap --build-arg DEBIAN_VERSION=buster-slim --build-arg NAP_MODULES=waf,dos
+	$(DOCKER_CMD) $(PLUS_ARGS) --build-arg BUILD_OS=debian-plus-nap --build-arg NAP_MODULES=waf,dos
 
 .PHONY: ubi-image
 ubi-image: build ## Create Docker image for Ingress Controller (UBI)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,6 @@
 ARG BUILD_OS=debian
 ARG NGINX_PLUS_VERSION=R27
 ARG DOWNLOAD_TAG=edge
-ARG DEBIAN_VERSION=bullseye-slim
 
 
 ############################################# Base images containing libs for Opentracing #############################################
@@ -47,7 +46,7 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/apk/cert.pem,mode=0644 \
 
 
 ############################################# Base image for Debian with NGINX Plus #############################################
-FROM debian:${DEBIAN_VERSION} AS debian-plus
+FROM debian:11-slim AS debian-plus
 ARG IC_VERSION
 ARG NGINX_PLUS_VERSION
 ARG BUILD_OS

--- a/docs/content/technical-specifications.md
+++ b/docs/content/technical-specifications.md
@@ -47,7 +47,7 @@ All images include NGINX 1.23.2.
 |Name | Base image | Third-party modules | DockerHub image | Architectures |
 | ---| ---| ---| --- | --- |
 |Alpine-based image | ``nginx:1.23.2-alpine``, which is based on ``alpine:3.16`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:2.4.1-alpine`` | arm/v7, arm64, amd64, ppc64le, s390x |
-|Debian-based image | ``nginx:1.23.2``, which is based on ``debian:bullseye-slim`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:2.4.1`` | arm/v7, arm64, amd64, ppc64le, s390x |
+|Debian-based image | ``nginx:1.23.2``, which is based on ``debian:11-slim`` | NGINX OpenTracing module, OpenTracing library, OpenTracing tracers for Jaeger, Zipkin and Datadog | ``nginx/nginx-ingress:2.4.1`` | arm/v7, arm64, amd64, ppc64le, s390x |
 |Ubi-based image | ``nginxcontrib/nginx:1.23.2-ubi``, which is based on ``redhat/ubi9-minimal`` |  | ``nginx/nginx-ingress:2.4.1-ubi`` | arm64, amd64, ppc64le, s390x |
 {{% /table %}}
 
@@ -61,10 +61,10 @@ NGINX Plus images are available through the F5 Container registry `private-regis
 |Name | Base image | Third-party modules | F5 Container Registry Image | Architectures |
 | ---| ---| --- | --- | --- |
 |Alpine-based image | ``alpine:3.16`` | NGINX Plus JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | `nginx-ic/nginx-plus-ingress:2.4.1-alpine` | arm64, amd64 |
-|Debian-based image | ``debian:bullseye-slim`` | NGINX Plus JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | `nginx-ic/nginx-plus-ingress:2.4.1` | arm64, amd64 |
-|Debian-based image with App Protect WAF | ``debian:buster-slim`` | NGINX Plus App Protect WAF, JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | `nginx-ic-nap/nginx-plus-ingress:2.4.1` | amd64 |
-|Debian-based image with App Protect DoS | ``debian:bullseye-slim`` | NGINX Plus App Protect DoS, JavaScript module and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | `nginx-ic-dos/nginx-plus-ingress:2.4.1` | amd64 |
-|Debian-based image with App Protect WAF and DoS | ``debian:buster-slim`` | NGINX Plus App Protect WAF, DoS, JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | `nginx-ic-nap-dos/nginx-plus-ingress:2.4.1` | amd64 |
+|Debian-based image | ``debian:11-slim`` | NGINX Plus JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | `nginx-ic/nginx-plus-ingress:2.4.1` | arm64, amd64 |
+|Debian-based image with App Protect WAF | ``debian:11-slim`` | NGINX Plus App Protect WAF, JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | `nginx-ic-nap/nginx-plus-ingress:2.4.1` | amd64 |
+|Debian-based image with App Protect DoS | ``debian:11-slim`` | NGINX Plus App Protect DoS, JavaScript module and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | `nginx-ic-dos/nginx-plus-ingress:2.4.1` | amd64 |
+|Debian-based image with App Protect WAF and DoS | ``debian:11-slim`` | NGINX Plus App Protect WAF, DoS, JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | `nginx-ic-nap-dos/nginx-plus-ingress:2.4.1` | amd64 |
 |Ubi-based image | ``redhat/ubi8`` | NGINX Plus JavaScript module | `nginx-ic/nginx-plus-ingress:2.4.1-ubi` | arm64, amd64, s390x |
 |Ubi-based image with App Protect WAF | ``redhat/ubi8`` | NGINX Plus App Protect WAF and JavaScript modules | `nginx-ic-nap/nginx-plus-ingress:2.4.1-ubi` | amd64 |
 |Ubi-based image with App Protect DoS | ``redhat/ubi8`` | NGINX Plus App Protect DoS and JavaScript modules | `nginx-ic-dos/nginx-plus-ingress:2.4.1-ubi` | amd64 |
@@ -76,8 +76,8 @@ We also provide NGINX Plus images through the AWS Marketplace. Please see [Using
 {{% table %}}
 |Name | Base image | Third-party modules | AWS Marketplace Link |
 | ---| ---| --- | --- |
-|Debian-based image | ``debian:bullseye-slim`` | NGINX Plus JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | [NGINX Ingress Controller](https://aws.amazon.com/marketplace/pp/prodview-fx3faxl7zqeau) |
-|Debian-based image with App Protect | ``debian:buster-slim`` | NGINX Plus App Protect, JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | [NGINX Ingress Controller with NGINX App Protect](https://aws.amazon.com/marketplace/pp/prodview-vnrnxbf6u3nra) |
+|Debian-based image | ``debian:11-slim`` | NGINX Plus JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | [NGINX Ingress Controller](https://aws.amazon.com/marketplace/pp/prodview-fx3faxl7zqeau) |
+|Debian-based image with App Protect | ``debian:11-slim`` | NGINX Plus App Protect, JavaScript and OpenTracing modules, OpenTracing tracers for Jaeger, Zipkin and Datadog | [NGINX Ingress Controller with NGINX App Protect](https://aws.amazon.com/marketplace/pp/prodview-vnrnxbf6u3nra) |
 {{% /table %}}
 
 ### Custom Images


### PR DESCRIPTION
Updates the `Dockerfile` and `Makefile` to use Debian 11 with NAP WAF. 

The builds will fail until R28 comes out.
