### PR TITLE
Fix conditions for Docker build and cache name

### DIFF
--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           path: ${{ github.workspace }}/dist
-          key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
+          key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}-multi
 
   test:
     name: Run tests
@@ -137,7 +137,7 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           path: ${{ github.workspace }}/dist
-          key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}
+          key: nginx-ingress-${{ github.run_id }}-${{ github.run_number }}-multi
         if: ${{ matrix.needs-updating == 'true' }}
       - name: Run Smoke Tests
         id: smoke-tests
@@ -164,7 +164,7 @@ jobs:
       tag: ${{ needs.variables.outputs.kic-tag }}
       sha_long: ${{ needs.variables.outputs.sha_long }}
     secrets: inherit
-    if: ${{ needs.check.outputs.needs-updating-debian }}
+    if: ${{ needs.check.outputs.needs-updating-debian == 'true' }}
 
   release-docker-alpine:
     name: Release Alpine Image
@@ -176,7 +176,7 @@ jobs:
       tag: ${{ needs.variables.outputs.kic-tag }}
       sha_long: ${{ needs.variables.outputs.sha_long }}
     secrets: inherit
-    if: ${{ needs.check.outputs.needs-updating-alpine }}
+    if: ${{ needs.check.outputs.needs-updating-alpine == 'true' }}
 
   release-docker-ubi:
     name: Release UBI Image
@@ -188,4 +188,4 @@ jobs:
       tag: ${{ needs.variables.outputs.kic-tag }}
       sha_long: ${{ needs.variables.outputs.sha_long }}
     secrets: inherit
-    if: ${{ needs.check.outputs.needs-updating-ubi }}
+    if: ${{ needs.check.outputs.needs-updating-ubi == 'true' }}


### PR DESCRIPTION
The variables like `needs.check.outputs.needs-updating-debian` are strings and can't be used as conditions unless they are compared with the strings `true` or `false`.

The reusable workflow `.github/workflows/build-oss.yml` uses `nginx-ingress-${{ github.run_id }}-${{ github.run_number }}-multi` as a key to restore the cache, so we need to use the same key when creating the binaries so they can be restored in the subsequent steps.
