### PR TITLE
Update GitLab branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
 include:
   - project: "f5/nginx/kic/kic-pipelines"
     file: "/include/ingress-controller.yml"
-    ref: "master"
+    ref: "release-2.4"


### PR DESCRIPTION
Uses corresponding release branch from GitLab instead of `master`
