### PR TITLE
Add feature: Overwrite default proxy_http_version

### DIFF
--- a/internal/configs/oidc/oidc.conf
+++ b/internal/configs/oidc/oidc.conf
@@ -14,6 +14,7 @@
         proxy_ssl_server_name on;                     # For SNI to the IdP
         proxy_method GET;                             # In case client request was non-GET
         proxy_set_header Content-Length "";           # ''
+        proxy_http_version    1.1;
         proxy_pass $oidc_jwt_keyfile;                 # Expecting to find a URI here
         proxy_ignore_headers Cache-Control Expires Set-Cookie; # Does not influence caching
     }
@@ -41,6 +42,7 @@
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=authorization_code&client_id=$oidc_client&$args&redirect_uri=$redirect_base$redir_location";
         proxy_method          POST;
+        proxy_http_version    1.1;
         proxy_pass            $oidc_token_endpoint;
    }
 
@@ -53,6 +55,7 @@
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=refresh_token&refresh_token=$arg_token&client_id=$oidc_client&client_secret=$oidc_client_secret";
         proxy_method          POST;
+        proxy_http_version    1.1;
         proxy_pass            $oidc_token_endpoint;
     }
 


### PR DESCRIPTION
Overwrite the default proxy_http_version to v1.1

### Proposed changes
If an OIDC Provider forces you to use HTTP 1.1 nginx will receive a http response 426 which is at the moment not handled. To make this compatiblty I suggest to increase it by default. If there is the need to still have 1.0 I'm happy to configure it as configuration parameter

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] I have checked that all unit tests pass after adding my changes
- [ x] I have updated necessary documentation
- [ x] I have rebased my branch onto main
- [ x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
