### PR TITLE
feat: initial podman support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ coverage.out
 node_modules
 package-lock.json
 package.json
+
+# Dockerfile generated from template
+build/Dockerfile

--- a/Makefile.containers
+++ b/Makefile.containers
@@ -1,0 +1,39 @@
+#!/usr/bin/make -f
+
+ifndef CONTAINER_CLITOOL
+ifeq ($(shell docker -v >/dev/null 2>&1 || echo FAIL),)
+CONTAINER_CLITOOL = docker
+else ifeq ($(shell podman -v >/dev/null 2>&1 || echo FAIL),)
+CONTAINER_CLITOOL = podman
+endif
+endif
+
+ifeq ($(CONTAINER_CLITOOL), docker)
+CONTAINER_BUILDENV ?= DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain
+# https://github.com/containers/buildah/issues/4325
+CONTAINER_COPY_FLAGS ?= --link
+ifeq ($(shell docker-compose -v >/dev/null 2>&1 || echo FAIL),)
+CONTAINER_COMPOSE = docker-compose
+endif
+else ifeq ($(CONTAINER_CLITOOL), podman)
+# https://github.com/containers/podman/issues/17032
+CONTAINER_MOUNT_FLAGS ?= ,shared,z
+ifeq ($(shell podman-compose -v >/dev/null 2>&1 || echo FAIL),)
+CONTAINER_COMPOSE = podman-compose --podman-rm-args=--depend
+endif
+else ifdef CONTAINER_CLITOOL
+CONTAINER_COMPOSE = $(error Invalid CONTAINER_CLITOOL: $(CONTAINER_CLITOOL) (supported values: docker, podman))
+endif
+
+ifdef CONTAINER_COMPOSE
+CONTAINER_COMPOSETOOL = $(CONTAINER_COMPOSE)
+ifeq ($(OS), linux)
+CONTAINER_VOLUME_FLAGS = :z
+else
+CONTAINER_VOLUME_FLAGS =
+endif
+else
+CONTAINER_COMPOSETOOL = $(error Neither docker-compose nor podman-compose found)
+endif
+
+CONTAINER_VARS = CONTAINER_CLITOOL CONTAINER_COMPOSE CONTAINER_BUILDENV

--- a/build/Dockerfile.in
+++ b/build/Dockerfile.in
@@ -5,12 +5,12 @@ ARG DOWNLOAD_TAG=edge
 
 
 ############################################# Base images containing libs for Opentracing #############################################
-FROM opentracing/nginx-opentracing:nginx-1.23.3 as opentracing-lib
-FROM opentracing/nginx-opentracing:nginx-1.23.3-alpine as alpine-opentracing-lib
+FROM docker.io/opentracing/nginx-opentracing:nginx-1.23.3 as opentracing-lib
+FROM docker.io/opentracing/nginx-opentracing:nginx-1.23.3-alpine as alpine-opentracing-lib
 
 
 ############################################# Base image for Debian #############################################
-FROM nginx:1.23.3 AS debian
+FROM docker.io/nginx:1.23.3 AS debian
 
 RUN --mount=type=bind,from=opentracing-lib,target=/tmp/ot/ \
 	cp -av /tmp/ot/usr/local/lib/libopentracing.so* /tmp/ot/usr/local/lib/libjaegertracing*so* /tmp/ot/usr/local/lib/libzipkin*so* /tmp/ot/usr/local/lib/libdd*so* /tmp/ot/usr/local/lib/libyaml*so* /usr/local/lib/ \
@@ -19,7 +19,7 @@ RUN --mount=type=bind,from=opentracing-lib,target=/tmp/ot/ \
 
 
 ############################################# Base image for Alpine #############################################
-FROM nginx:1.23.3-alpine AS alpine
+FROM docker.io/nginx:1.23.3-alpine AS alpine
 
 RUN --mount=type=bind,from=alpine-opentracing-lib,target=/tmp/ot/ \
 	apk add --no-cache libstdc++ \
@@ -31,7 +31,7 @@ RUN --mount=type=bind,from=alpine-opentracing-lib,target=/tmp/ot/ \
 
 
 ############################################# Base image for Alpine with NGINX Plus #############################################
-FROM alpine:3.17 as alpine-plus
+FROM docker.io/alpine:3.17 as alpine-plus
 ARG NGINX_PLUS_VERSION
 
 RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/apk/cert.pem,mode=0644 \
@@ -45,7 +45,7 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/apk/cert.pem,mode=0644 \
 
 
 ############################################# Base image for Debian with NGINX Plus #############################################
-FROM debian:11-slim AS debian-plus
+FROM docker.io/debian:11-slim AS debian-plus
 ARG IC_VERSION
 ARG NGINX_PLUS_VERSION
 ARG BUILD_OS
@@ -103,7 +103,7 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 
 
 ############################################# Base image for UBI #############################################
-FROM nginxcontrib/nginx:1.23.3-ubi AS ubi
+FROM docker.io/nginxcontrib/nginx:1.23.3-ubi AS ubi
 ARG IC_VERSION
 
 LABEL name="NGINX Ingress Controller" \
@@ -116,14 +116,14 @@ LABEL name="NGINX Ingress Controller" \
 	io.k8s.description="The NGINX Ingress Controller is an application that runs in a cluster and configures an HTTP load balancer according to Ingress resources." \
 	io.openshift.tags="nginx,ingress-controller,ingress,controller,kubernetes,openshift"
 
-COPY --link --chown=101:0 LICENSE /licenses/
+COPY %% COPY_FLAGS %% --chown=101:0 LICENSE /licenses/
 
 # temp fix for CVE-2023-0361 and CVE-2021-46822
 RUN microdnf --nodocs upgrade -y gnutls libjpeg-turbo
 
 
 ############################################# Base image for UBI with NGINX Plus #############################################
-FROM redhat/ubi9-minimal AS ubi-plus
+FROM docker.io/redhat/ubi9-minimal AS ubi-plus
 ARG NGINX_PLUS_VERSION
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -195,10 +195,10 @@ ARG TARGETPLATFORM
 ARG NAP_MODULES=none
 
 # copy oidc files on plus build
-RUN --mount=type=bind,target=/tmp [ -n "${BUILD_OS##*plus*}" ] && exit 0; mkdir -p /etc/nginx/oidc/ && cp -a /tmp/internal/configs/oidc/* /etc/nginx/oidc/
+RUN --mount=type=bind,source=internal,target=/tmp%% MOUNT_FLAGS %% [ -n "${BUILD_OS##*plus*}" ] && exit 0; mkdir -p /etc/nginx/oidc/ && cp -a /tmp/configs/oidc/* /etc/nginx/oidc/
 
 # run only on nap waf build
-RUN --mount=type=bind,target=/tmp [ -n "${NAP_MODULES##*waf*}" ] && exit 0; mkdir -p /etc/nginx/waf/nac-policies /etc/nginx/waf/nac-logconfs /etc/nginx/waf/nac-usersigs /var/log/app_protect /opt/app_protect \
+RUN --mount=type=bind,target=/tmp%% MOUNT_FLAGS %% [ -n "${NAP_MODULES##*waf*}" ] && exit 0; mkdir -p /etc/nginx/waf/nac-policies /etc/nginx/waf/nac-logconfs /etc/nginx/waf/nac-usersigs /var/log/app_protect /opt/app_protect \
 	&& chown -R 101:0 /etc/app_protect /usr/share/ts /var/log/app_protect/ /opt/app_protect/ /var/log/nginx/ \
 	&& touch /etc/nginx/waf/nac-usersigs/index.conf \
 	&& cp -a /tmp/build/log-default.json /etc/nginx
@@ -207,9 +207,9 @@ RUN --mount=type=bind,target=/tmp [ -n "${NAP_MODULES##*waf*}" ] && exit 0; mkdi
 RUN [ -n "${NAP_MODULES##*dos*}" ] && exit 0; mkdir -p /root/app_protect_dos /etc/nginx/dos/policies /etc/nginx/dos/logconfs /shared/cores /var/log/adm /var/run/adm \
 	&& chmod 777 /shared/cores /var/log/adm /var/run/adm /etc/app_protect_dos
 
-RUN --mount=type=bind,target=/tmp mkdir -p /var/lib/nginx /etc/nginx/secrets /etc/nginx/stream-conf.d \
-	&& [ -z "${BUILD_OS##*plus*}" ] && PLUS=-plus; cp -a /tmp/internal/configs/version1/nginx$PLUS.ingress.tmpl /tmp/internal/configs/version1/nginx$PLUS.tmpl \
-	/tmp/internal/configs/version2/nginx$PLUS.virtualserver.tmpl /tmp/internal/configs/version2/nginx$PLUS.transportserver.tmpl / \
+RUN --mount=type=bind,source=internal,target=/tmp%% MOUNT_FLAGS %% mkdir -p /var/lib/nginx /etc/nginx/secrets /etc/nginx/stream-conf.d \
+	&& [ -z "${BUILD_OS##*plus*}" ] && PLUS=-plus; cp -a /tmp/configs/version1/nginx$PLUS.ingress.tmpl /tmp/configs/version1/nginx$PLUS.tmpl \
+	/tmp/configs/version2/nginx$PLUS.virtualserver.tmpl /tmp/configs/version2/nginx$PLUS.transportserver.tmpl / \
 	&& chown -R 101:0 /etc/nginx /var/cache/nginx /var/lib/nginx /*.tmpl \
 	&& rm -f /etc/nginx/conf.d/* /etc/apt/apt.conf.d/90pkgs-nginx /etc/apt/sources.list.d/nginx-plus.list
 
@@ -232,15 +232,15 @@ LABEL org.nginx.kic.image.build.nginx.version="${NGINX_PLUS_VERSION}${NGINX_VERS
 
 
 ############################################# Build nginx-ingress in golang container #############################################
-FROM golang:1.20-alpine AS builder
+FROM docker.io/golang:1.20-alpine AS builder
 ARG IC_VERSION
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/nginxinc/kubernetes-ingress/
 RUN apk add --no-cache git
-RUN --mount=type=bind,target=/go/src/github.com/nginxinc/kubernetes-ingress/ --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=bind,target=/go/src/github.com/nginxinc/kubernetes-ingress/%% MOUNT_FLAGS %% --mount=type=cache,target=/root/.cache/go-build \
 	go mod download
-RUN --mount=type=bind,target=/go/src/github.com/nginxinc/kubernetes-ingress/ --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=bind,target=/go/src/github.com/nginxinc/kubernetes-ingress/%% MOUNT_FLAGS %% --mount=type=cache,target=/root/.cache/go-build \
 	CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath -ldflags "-s -w -X main.version=${IC_VERSION}" -o /nginx-ingress github.com/nginxinc/kubernetes-ingress/cmd/nginx-ingress
 
 
@@ -249,7 +249,7 @@ FROM common AS container
 
 LABEL org.nginx.kic.image.build.version="container"
 
-COPY --link --from=builder --chown=101:0 /nginx-ingress /
+COPY %% COPY_FLAGS %% --from=builder --chown=101:0 /nginx-ingress /
 
 
 ############################################# Create image with nginx-ingress built locally #############################################
@@ -257,7 +257,7 @@ FROM common AS local
 
 LABEL org.nginx.kic.image.build.version="local"
 
-COPY --link --chown=101:0 nginx-ingress /
+COPY %% COPY_FLAGS %% --chown=101:0 nginx-ingress /
 
 
 ############################################# Create image with nginx-ingress built by GoReleaser #############################################
@@ -266,7 +266,7 @@ ARG TARGETARCH
 
 LABEL org.nginx.kic.image.build.version="goreleaser"
 
-COPY --link --chown=101:0 dist/kubernetes-ingress_linux_${TARGETARCH}*/nginx-ingress /
+COPY %% COPY_FLAGS %% --chown=101:0 dist/kubernetes-ingress_linux_${TARGETARCH}*/nginx-ingress /
 
 
 ############################################# Create image with nginx-ingress built by GoReleaser for AWS Marketplace #############################################
@@ -276,7 +276,7 @@ ARG NAP_MODULES_AWS
 
 LABEL org.nginx.kic.image.build.version="aws"
 
-COPY --link --chown=101:0 dist/aws*${NAP_MODULES_AWS}_linux_${TARGETARCH}*/nginx-ingress /
+COPY %% COPY_FLAGS %% --chown=101:0 dist/aws*${NAP_MODULES_AWS}_linux_${TARGETARCH}*/nginx-ingress /
 
 
 ############################################# Create image with nginx-ingress extracted from image on Docker Hub #############################################
@@ -286,4 +286,4 @@ FROM common as download
 
 LABEL org.nginx.kic.image.build.version="binaries"
 
-COPY --link --from=kic --chown=101:0 /nginx-ingress /
+COPY %% COPY_FLAGS %% --from=kic --chown=101:0 /nginx-ingress /


### PR DESCRIPTION
### Proposed changes

This change introduces an ability to use [podman](https://podman.io) container management tool in addition to docker, which remains the default. Podman provides daemonless architecture and allows to run containers in unprivileged mode natively on Linux.

On systems with both docker and podman installed, the `CONTAINER_CLITOOL` environment variable can be used to choose a desired option.

Closes #2924.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Manual tests performed

Test environments:

1. MacOS host (M1) with Docker Desktop 4.15.0:
```
% docker version
Client:
 Cloud integration: v1.0.29
 Version:           20.10.21
 API version:       1.41
 Go version:        go1.18.7
 Git commit:        baeda1f
 Built:             Tue Oct 25 18:01:18 2022
 OS/Arch:           darwin/arm64
 Context:           default
 Experimental:      true

Server: Docker Desktop 4.15.0 (93002)
 Engine:
  Version:          20.10.21
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.18.7
  Git commit:       3056208
  Built:            Tue Oct 25 17:59:41 2022
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.6.10
  GitCommit:        770bd0108c32f3fb5c73ae1264f7e503fe7b2661
 runc:
  Version:          1.1.4
  GitCommit:        v1.1.4-0-g5fd4c4d
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

2. MacOS host (M1) with podman 4.3.1:
```
% podman version
Client:       Podman Engine
Version:      4.3.1
API Version:  4.3.1
Go Version:   go1.18.8
Built:        Thu Nov 10 00:43:58 2022
OS/Arch:      darwin/arm64

Server:       Podman Engine
Version:      4.3.1
API Version:  4.3.1
Go Version:   go1.19.2
Built:        Fri Nov 11 19:00:31 2022
OS/Arch:      linux/arm64

% podman machine ssh
Connecting to vm podman-machine-default. To close connection, use `~.` or `exit`
Fedora CoreOS 37.20221225.2.2
Tracker: https://github.com/coreos/fedora-coreos-tracker
Discuss: https://discussion.fedoraproject.org/tag/coreos

Last login: Wed Jan 11 02:57:40 2023 from 192.168.127.1
[core@localhost ~]$ podman version
Client:       Podman Engine
Version:      4.3.1
API Version:  4.3.1
Go Version:   go1.19.2
Built:        Fri Nov 11 19:00:31 2022
OS/Arch:      linux/arm64
```

3. Fedora 37 host (amd64) with docker-ce :
```
$ docker version
Client: Docker Engine - Community
 Version:           20.10.22
 API version:       1.41
 Go version:        go1.18.9
 Git commit:        3a2c30b
 Built:             Thu Dec 15 22:28:45 2022
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          20.10.22
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.18.9
  Git commit:       42c8b31
  Built:            Thu Dec 15 22:26:25 2022
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.15
  GitCommit:        5b842e528e99d4d4c1686467debf2bd4b88ecd86
 runc:
  Version:          1.1.4
  GitCommit:        v1.1.4-0-g5fd4c4d
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

4. Fedora 37 host (amd64) with podman 4.3.1:
```
$ podman version
Client:       Podman Engine
Version:      4.3.1
API Version:  4.3.1
Go Version:   go1.19.2
Built:        Fri Nov 11 15:01:27 2022
OS/Arch:      linux/amd64
```

The following targets confirmed to work under all 4 test environments (with `ARCH=arm64` where appropriate):
 - `make debian-image`
 - `make debian-image-plus`
 - `make alpine-image`
 - `make ubi-image`
 - `make ubi-image-plus`