### PR TITLE
Update workflow for UBI image

### DIFF
--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           nginx=library/$(grep -m1 "FROM nginx:" < build/Dockerfile | awk -F" " '{print $2}')
           nginx_alpine=library/nginx:$(grep -m1 "FROM.*nginx:.*alpine" < build/Dockerfile | awk -F"[ :]" '{print $3}')
-          nginx_ubi=$(grep "FROM redhat" < build/Dockerfile | awk -F" " '{print $2}')
+          nginx_ubi=$(grep -m1 "FROM nginxcontrib/nginx:" < build/Dockerfile | awk -F" " '{print $2}')
           echo "matrix=[{\"version\": \"${nginx}\", \"distro\": \"debian\"}, {\"version\": \"${nginx_alpine}\", \"distro\": \"alpine\"}, {\"version\": \"${nginx_ubi}\", \"distro\": \"ubi\"}]" >> $GITHUB_OUTPUT
       - name: Set other variables
         id: vars
@@ -183,7 +183,7 @@ jobs:
     needs: [binary, check, variables]
     uses: ./.github/workflows/build-oss.yml
     with:
-      platforms: linux/arm64,linux/amd64,linux/s390x
+      platforms: linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
       image: ubi
       tag: ${{ needs.variables.outputs.kic-tag }}
       sha_long: ${{ needs.variables.outputs.sha_long }}


### PR DESCRIPTION
The base image for UBI changed in #2845 so the `update-docker-images.yml` workflow needs to be updated to reflect that. 