### PR TITLE
Fix dependabot for test deps and run checks weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,31 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
       interval: daily
-    reviewers:
-      - "nginxinc/kic"
-  - package-ecosystem: "gomod"
-    directory: "/"
+
+  - package-ecosystem: gomod
+    directory: /
     schedule:
       interval: daily
-    reviewers:
-      - "nginxinc/kic"
-  - package-ecosystem: "docker"
-    directory: "/build"
+
+  - package-ecosystem: docker
+    directory: /build
     schedule:
       interval: daily
-    reviewers:
-      - "nginxinc/kic"
-  - package-ecosystem: "docker"
-    directory: "/tests/docker"
+
+  - package-ecosystem: docker
+    directory: /tests/docker
     schedule:
       interval: daily
-    reviewers:
-      - "nginxinc/kic"
-  - package-ecosystem: "pip"
-    directory: "/tests"
+
+  - package-ecosystem: pip-compile
+    directory: /tests
     schedule:
-      interval: daily
-    reviewers:
-      - "nginxinc/kic"
-  - package-ecosystem: "pip"
-    directory: "/perf-tests"
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /perf-tests
     schedule:
-      interval: daily
-    reviewers:
-      - "nginxinc/kic"
+      interval: weekly


### PR DESCRIPTION
The python dependencies in `/tests` now use `pip-compile`. This PR fixes dependabot to use the right package ecosystem.
It also reduces the interval to weekly for python dependencies to decrease the number of PRs.