### PR TITLE
Fix dependabot for test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     schedule:
       interval: daily
 
-  - package-ecosystem: pip-compile
+  - package-ecosystem: pip
     directory: /tests
     schedule:
       interval: weekly


### PR DESCRIPTION
Turns out I misread the docs and `pip-compile` it's not actually an accepted value.