### PR TITLE
Add missing OSS internal routes

### DIFF
--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -10,6 +10,12 @@ upstream {{$upstream.Name}} {
 
 {{range $server := .Servers}}
 server {
+	{{if $server.SpiffeCerts}}
+	listen 443 ssl;
+	{{if not $server.DisableIPV6}}listen [::]:443 ssl;{{end}}
+	ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
+	ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
+	{{else}}
 	{{if not $server.GRPCOnly}}
 	{{range $port := $server.Ports}}
 	listen {{$port}}{{if $server.ProxyProtocol}} proxy_protocol{{end}};
@@ -33,6 +39,7 @@ server {
 	{{else}}
 	ssl_certificate {{$server.SSLCertificate}};
 	ssl_certificate_key {{$server.SSLCertificateKey}};
+	{{end}}
 	{{end}}
 	{{end}}
 
@@ -142,6 +149,15 @@ server {
 		{{- if $location.ProxyBufferSize}}
 		grpc_buffer_size {{$location.ProxyBufferSize}};
 		{{- end}}
+		{{if $.SpiffeClientCerts}}
+		grpc_ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
+		grpc_ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
+		grpc_ssl_trusted_certificate /etc/nginx/secrets/spiffe_rootca.pem;
+		grpc_ssl_server_name on;
+		grpc_ssl_verify on;
+		grpc_ssl_verify_depth 25;
+		grpc_ssl_name {{$location.ProxySSLName}};
+		{{end}}
 		{{if $location.SSL}}
 		grpc_pass grpcs://{{$location.Upstream.Name}}{{$location.Rewrite}};
 		{{else}}
@@ -187,6 +203,15 @@ server {
 		{{- if $location.ProxyMaxTempFileSize}}
 		proxy_max_temp_file_size {{$location.ProxyMaxTempFileSize}};
 		{{- end}}
+		{{if $.SpiffeClientCerts}}
+		proxy_ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
+		proxy_ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
+		proxy_ssl_trusted_certificate /etc/nginx/secrets/spiffe_rootca.pem;
+		proxy_ssl_server_name on;
+		proxy_ssl_verify on;
+		proxy_ssl_verify_depth 25;
+		proxy_ssl_name {{$location.ProxySSLName}};
+		{{end}}
 		{{if $location.SSL}}
 		proxy_pass https://{{$location.Upstream.Name}}{{$location.Rewrite}};
 		{{else}}

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -210,6 +210,17 @@ http {
 
         return 418;
     }
+    {{if .InternalRouteServer}}
+    server {
+        listen 443 ssl;
+        server_name {{.InternalRouteServerName}};
+        ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
+        ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
+        ssl_client_certificate /etc/nginx/secrets/spiffe_rootca.pem;
+        ssl_verify_client on;
+        ssl_verify_depth 25;
+    }
+    {{end}}
 }
 
 stream {

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -213,6 +213,7 @@ http {
     {{if .InternalRouteServer}}
     server {
         listen 443 ssl;
+        {{if not .DisableIPV6}}listen [::]:443 ssl;{{end}}
         server_name {{.InternalRouteServerName}};
         ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
         ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -358,13 +358,13 @@ server {
         add_header {{ $h.Name }} "{{ $h.Value }}" {{ if $h.Always }}always{{ end }};
             {{ end }}
             {{ if $.SpiffeCerts }}
-        proxy_ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
-        proxy_ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
-        proxy_ssl_trusted_certificate /etc/nginx/secrets/spiffe_rootca.pem;
-        proxy_ssl_server_name on;
-        proxy_ssl_verify on;
-        proxy_ssl_verify_depth 25;
-        proxy_ssl_name {{ $l.ProxySSLName }};
+        {{ $proxyOrGRPC }}_ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
+        {{ $proxyOrGRPC }}_ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
+        {{ $proxyOrGRPC }}_ssl_trusted_certificate /etc/nginx/secrets/spiffe_rootca.pem;
+        {{ $proxyOrGRPC }}_ssl_server_name on;
+        {{ $proxyOrGRPC }}_ssl_verify on;
+        {{ $proxyOrGRPC }}_ssl_verify_depth 25;
+        {{ $proxyOrGRPC }}_ssl_name {{ $l.ProxySSLName }};
             {{ end }}
             {{if $l.GRPCPass}}
         grpc_pass {{ $l.GRPCPass }};

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -357,6 +357,15 @@ server {
             {{ range $h := $l.AddHeaders }}
         add_header {{ $h.Name }} "{{ $h.Value }}" {{ if $h.Always }}always{{ end }};
             {{ end }}
+            {{ if $.SpiffeCerts }}
+        proxy_ssl_certificate /etc/nginx/secrets/spiffe_cert.pem;
+        proxy_ssl_certificate_key /etc/nginx/secrets/spiffe_key.pem;
+        proxy_ssl_trusted_certificate /etc/nginx/secrets/spiffe_rootca.pem;
+        proxy_ssl_server_name on;
+        proxy_ssl_verify on;
+        proxy_ssl_verify_depth 25;
+        proxy_ssl_name {{ $l.ProxySSLName }};
+            {{ end }}
             {{if $l.GRPCPass}}
         grpc_pass {{ $l.GRPCPass }};
             {{ else }}


### PR DESCRIPTION
### Proposed changes
While enabling the OSS version of Kubernetes Ingress to integrate with NSM, the additional templates for internal routes were forgotten. This allows the OSS ingress templating to configure ingress/egress for NSM.

- Sync N+ and OSS templates to have same functionality for NSM traffic

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
