### PR TITLE
Update package for CVE-2022-44617

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -26,6 +26,8 @@ FROM nginx:1.23.3-alpine AS alpine
 
 RUN --mount=type=bind,from=alpine-opentracing-lib,target=/tmp/ot/ \
 	apk add --no-cache libcap libstdc++ \
+	# temp fix for CVE-2022-44617
+	&& apk upgrade --no-cache libxpm \
 	&& cp -av /tmp/ot/usr/local/lib/libopentracing.so* /tmp/ot/usr/local/lib/libjaegertracing*so* /tmp/ot/usr/local/lib/libzipkin*so* /tmp/ot/usr/local/lib/libdd*so* /tmp/ot/usr/local/lib/libyaml*so* /usr/local/lib/ \
 	&& cp -av /tmp/ot/usr/lib/nginx/modules/ngx_http_opentracing_module.so /usr/lib/nginx/modules/ \
 	&& ldconfig /usr/local/lib/


### PR DESCRIPTION
Fixes:
- https://github.com/nginxinc/kubernetes-ingress/security/code-scanning/9976
