### PR TITLE
Sync only once a week

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
       - reopened
       - synchronize
   schedule:
-    - cron:  '0 4 * * *'
+    - cron: '0 4 * * *' # run every day at 04:00 UTC
 
 defaults:
   run:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ main ]
   schedule:
-    - cron: '36 6 * * 4'
+    - cron: '36 6 * * 4' # run every Thursday at 06:36 UTC
 
 concurrency:
   group: ${{ github.ref_name }}-codeql

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -3,7 +3,7 @@ on:
   # Only the default branch is supported.
   branch_protection_rule:
   schedule:
-    - cron: '43 20 * * 0'
+    - cron: '43 20 * * 0' # run every Sunday at 20:43 UTC
   push:
     branches: [ "main" ]
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '30 1 * * *' # run every day at 01:30 UTC
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,12 +1,9 @@
-name: Sync
+name: Sync labels
 
 on:
-  workflow_run:
-    branches: main
-    workflows:
-      - "CI"
-    types:
-      - completed
+  schedule:
+    - cron: '8 0 * * 1' # run every Monday at 00:08 UTC
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref_name }}-sync

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -2,7 +2,7 @@ name: Update Docker Images
 
 on:
   schedule:
-    - cron:  '0 1 * * *'
+    - cron: '0 1 * * *' # run every day at 01:00 UTC
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
We don't need to sync the labels on every commit, we can run the workflow once a week.
