### PR TITLE
Support empty path for ImplementationSpecific pathType

### DIFF
--- a/docs/content/configuration/ingress-resources/basic-configuration.md
+++ b/docs/content/configuration/ingress-resources/basic-configuration.md
@@ -60,7 +60,7 @@ Here is a breakdown of what this Ingress resource definition means:
 Starting from Kubernetes 1.18, you can use the following new features:
 
 * The host field supports wildcard domain names, such as `*.example.com`.
-* The path supports different matching rules with the new field `PathType`, which takes the following values: `Prefix` for prefix-based matching, `Exact` for exact matching and `ImplementationSpecific`, which is the default type and is the same as `Prefix`. For example:
+* The path supports different matching rules with the new field `pathType`, which takes the following values: `Prefix` for prefix-based matching, `Exact` for exact matching and `ImplementationSpecific`, which is the default type and is the same as `Prefix`. For example:
   ```yaml
     - path: /tea
       pathType: Prefix
@@ -105,7 +105,8 @@ Starting from Kubernetes 1.18, you can use the following new features:
 The NGINX Ingress Controller imposes the following restrictions on Ingress resources:
 * When defining an Ingress resource, the `host` field is required.
 * The `host` value needs to be unique among all Ingress and VirtualServer resources unless the Ingress resource is a [mergeable minion](/nginx-ingress-controller/configuration/ingress-resources/cross-namespace-configuration/). See also [Handling Host and Listener Collisions](/nginx-ingress-controller/configuration/handling-host-and-listener-collisions).
-* The `path` field in `spec.rules[].http.paths[]` is required.
+* The `path` field in `spec.rules[].http.paths[]` is required for `Exact` and `Prefix` `pathTypes`.
+* The ImplementationSpecific `pathType` is treated as equivilent to `Prefix` `pathType`, with the exception that when this `pathType` is configured, the `path` field in `spec.rules[].http.paths[]` is not mandatory. `path` defaults to `/` if not set but the `pathType` is set to ImplementationSpecific.
 
 ## Advanced Configuration
 

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -3420,8 +3420,10 @@ func TestValidatePath(t *testing.T) {
 		"/abc}{abc",
 	}
 
+	pathType := networking.PathTypeExact
+
 	for _, path := range validPaths {
-		allErrs := validatePath(path, field.NewPath("path"))
+		allErrs := validatePath(path, &pathType, field.NewPath("path"))
 		if len(allErrs) > 0 {
 			t.Errorf("validatePath(%q) returned errors %v for valid input", path, allErrs)
 		}
@@ -3440,10 +3442,17 @@ func TestValidatePath(t *testing.T) {
 	}
 
 	for _, path := range invalidPaths {
-		allErrs := validatePath(path, field.NewPath("path"))
+		allErrs := validatePath(path, &pathType, field.NewPath("path"))
 		if len(allErrs) == 0 {
 			t.Errorf("validatePath(%q) returned no errors for invalid input", path)
 		}
+	}
+
+	pathType = networking.PathTypeImplementationSpecific
+
+	allErrs := validatePath("", &pathType, field.NewPath("path"))
+	if len(allErrs) > 0 {
+		t.Errorf("validatePath with empty path and type ImplementationSpecific returned errors %v for valid input", allErrs)
 	}
 }
 

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -2503,9 +2503,9 @@ func TestValidateUpstreamHealthCheck(t *testing.T) {
 				Value: "my.service",
 			},
 		},
-		StatusMatch: "! 500",
-		Mandatory:   true,
-		Persistent:  true,
+		StatusMatch:   "! 500",
+		Mandatory:     true,
+		Persistent:    true,
 		KeepaliveTime: "120s",
 	}
 

--- a/tests/data/smoke/implementation-specific-pathtype/smoke-ingress.yaml
+++ b/tests/data/smoke/implementation-specific-pathtype/smoke-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+  name: smoke-ingress
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - smoke.example.com
+    secretName: smoke-secret
+  rules:
+  - host: smoke.example.com
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: backend1-svc
+            port:
+              number: 80

--- a/tests/suite/test_smoke.py
+++ b/tests/suite/test_smoke.py
@@ -44,7 +44,7 @@ class SmokeSetup:
         self.ingress_host = ingress_host
 
 
-@pytest.fixture(scope="class", params=["standard", "mergeable"])
+@pytest.fixture(scope="class", params=["standard", "mergeable", "implementation-specific-pathtype"])
 def smoke_setup(request, kube_apis, ingress_controller_endpoint, ingress_controller, test_namespace) -> SmokeSetup:
     print("------------------------- Deploy Smoke Example -----------------------------------")
     secret_name = create_secret_from_yaml(kube_apis.v1, test_namespace, f"{TEST_DATA}/smoke/smoke-secret.yaml")


### PR DESCRIPTION
### Proposed changes
Path is required for Exact and Prefix PathTypes, but should not be required for ImplementationSpecific PathTypes according to the [Kubernetes specs](https://pkg.go.dev/k8s.io/api@v0.26.1/networking/v1#HTTPIngressPath)

Our validation rules require a path be set for all PathTypes. This commit closes this gap - If an Ingress is configured with an ImplementationSpecific PathType and an empty Path, this will be allowed, and the Path will default to `/`. Otherwise ImplementationSpecific PathType is treated identically to the Prefix PathType.

Closes https://github.com/nginxinc/kubernetes-ingress/issues/3498

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
