### PR TITLE
Bump Go to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginxinc/kubernetes-ingress
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.10


### PR DESCRIPTION
Bumps the version of `go` to `1.20`
