### PR TITLE
Ensure non-ready endpoints are not added to upstreams

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -3567,6 +3567,9 @@ func getEndpointsFromEndpointSlicesForSubselectedPods(targetPort int32, pods []*
 					continue
 				}
 				for _, endpoint := range endpointSlice.Endpoints {
+					if !*endpoint.Conditions.Ready {
+						continue
+					}
 					for _, address := range endpoint.Addresses {
 						if pod.Status.PodIP == address {
 							addr := ipv6SafeAddrPort(pod.Status.PodIP, targetPort)
@@ -3718,6 +3721,9 @@ func (lbc *LoadBalancerController) getEndpointsForPortFromEndpointSlices(endpoin
 		for _, endpointSlicePort := range endpointSlice.Ports {
 			if *endpointSlicePort.Port == targetPort {
 				for _, endpoint := range endpointSlice.Endpoints {
+					if !*endpoint.Conditions.Ready {
+						continue
+					}
 					for _, endpointAddress := range endpoint.Addresses {
 						address := ipv6SafeAddrPort(endpointAddress, *endpointSlicePort.Port)
 						podEndpoint := podEndpoint{

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -484,7 +484,7 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsInOneEndpointSlice(t *
 		Name:   "foo",
 	}
 
-	podReady := true
+	endpointReady := true
 
 	tests := []struct {
 		desc              string
@@ -529,7 +529,7 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsInOneEndpointSlice(t *
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 						{
@@ -537,7 +537,7 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsInOneEndpointSlice(t *
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},
@@ -571,7 +571,7 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsInOnEndpointSlice(t
 		Number: 8080,
 		Name:   "foo",
 	}
-	podReady := true
+	endpointReady := true
 
 	tests := []struct {
 		desc              string
@@ -619,7 +619,7 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsInOnEndpointSlice(t
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 						{
@@ -627,7 +627,7 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsInOnEndpointSlice(t
 								"5.6.7.8",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},
@@ -662,7 +662,7 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsAcrossTwoEndpointSlice
 		Name:   "foo",
 	}
 
-	podReady := true
+	endpointReady := true
 
 	tests := []struct {
 		desc              string
@@ -713,7 +713,7 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsAcrossTwoEndpointSlice
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 						{
@@ -721,7 +721,7 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsAcrossTwoEndpointSlice
 								"5.6.7.8",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},
@@ -738,7 +738,7 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsAcrossTwoEndpointSlice
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 						{
@@ -746,7 +746,7 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsAcrossTwoEndpointSlice
 								"10.0.0.1",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},
@@ -780,8 +780,8 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsInOnEndpointSliceOn
 		Number: 8080,
 		Name:   "foo",
 	}
-	podReadyTrue := true
-	podReadyFalse := false
+	endpointReadyTrue := true
+	endpointReadyFalse := false
 
 	tests := []struct {
 		desc              string
@@ -826,7 +826,7 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsInOnEndpointSliceOn
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReadyTrue,
+								Ready: &endpointReadyTrue,
 							},
 						},
 						{
@@ -834,7 +834,7 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsInOnEndpointSliceOn
 								"5.6.7.8",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReadyFalse,
+								Ready: &endpointReadyFalse,
 							},
 						},
 					},
@@ -869,8 +869,8 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsAcrossTwoEndpointSl
 		Name:   "foo",
 	}
 
-	podReadyTrue := true
-	podReadyFalse := false
+	endpointReadyTrue := true
+	endpointReadyFalse := false
 
 	tests := []struct {
 		desc              string
@@ -915,7 +915,7 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsAcrossTwoEndpointSl
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReadyTrue,
+								Ready: &endpointReadyTrue,
 							},
 						},
 					},
@@ -932,7 +932,7 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsAcrossTwoEndpointSl
 								"10.0.0.1",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReadyFalse,
+								Ready: &endpointReadyFalse,
 							},
 						},
 					},
@@ -1077,7 +1077,7 @@ func TestGetEndpointsFromEndpointSlices_ErrorsOnNoEndpointSlicesFound(t *testing
 
 func TestGetEndpointSlicesBySubselectedPods_FindOnePodInOneEndpointSlice(t *testing.T) {
 	endpointPort := int32(8080)
-	podReady := true
+	endpointReady := true
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -1127,7 +1127,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodInOneEndpointSlice(t *test
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},
@@ -1149,7 +1149,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodInOneEndpointSlice(t *test
 
 func TestGetEndpointSlicesBySubselectedPods_FindOnePodInTwoEndpointSlicesWithDuplicateEndpoints(t *testing.T) {
 	endpointPort := int32(8080)
-	podReady := true
+	endpointReady := true
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -1199,7 +1199,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodInTwoEndpointSlicesWithDup
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},
@@ -1216,7 +1216,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodInTwoEndpointSlicesWithDup
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},
@@ -1238,7 +1238,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodInTwoEndpointSlicesWithDup
 
 func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInOneEndpointSlice(t *testing.T) {
 	endpointPort := int32(8080)
-	podReady := true
+	endpointReady := true
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -1309,7 +1309,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInOneEndpointSlice(t *tes
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 						{
@@ -1317,7 +1317,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInOneEndpointSlice(t *tes
 								"5.6.7.8",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},
@@ -1339,7 +1339,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInOneEndpointSlice(t *tes
 
 func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInTwoEndpointSlices(t *testing.T) {
 	endpointPort := int32(8080)
-	podReady := true
+	endpointReady := true
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -1410,7 +1410,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInTwoEndpointSlices(t *te
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},
@@ -1427,7 +1427,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInTwoEndpointSlices(t *te
 								"5.6.7.8",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},
@@ -1449,8 +1449,8 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInTwoEndpointSlices(t *te
 
 func TestGetEndpointSlicesBySubselectedPods_FindOnePodEndpointInOneEndpointSliceWithOneEndpointNotReady(t *testing.T) {
 	endpointPort := int32(8080)
-	podReadyTrue := true
-	podReadyFalse := false
+	endpointReadyTrue := true
+	endpointReadyFalse := false
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -1514,7 +1514,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodEndpointInOneEndpointSlice
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReadyTrue,
+								Ready: &endpointReadyTrue,
 							},
 						},
 						{
@@ -1522,7 +1522,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodEndpointInOneEndpointSlice
 								"5.6.7.8",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReadyFalse,
+								Ready: &endpointReadyFalse,
 							},
 						},
 					},
@@ -1544,8 +1544,8 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodEndpointInOneEndpointSlice
 
 func TestGetEndpointSlicesBySubselectedPods_FindOnePodEndpointInTwoEndpointSlicesWithOneEndpointNotReady(t *testing.T) {
 	endpointPort := int32(8080)
-	podReadyTrue := true
-	podReadyFalse := false
+	endpointReadyTrue := true
+	endpointReadyFalse := false
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -1609,7 +1609,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodEndpointInTwoEndpointSlice
 								"1.2.3.4",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReadyTrue,
+								Ready: &endpointReadyTrue,
 							},
 						},
 					},
@@ -1626,7 +1626,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodEndpointInTwoEndpointSlice
 								"5.6.7.8",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReadyFalse,
+								Ready: &endpointReadyFalse,
 							},
 						},
 					},
@@ -1648,7 +1648,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodEndpointInTwoEndpointSlice
 
 func TestGetEndpointSlicesBySubselectedPods_FindNoPods(t *testing.T) {
 	endpointPort := int32(8080)
-	podReady := true
+	endpointReady := true
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -1690,7 +1690,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindNoPods(t *testing.T) {
 								"5.4.3.2",
 							},
 							Conditions: discovery_v1.EndpointConditions{
-								Ready: &podReady,
+								Ready: &endpointReady,
 							},
 						},
 					},

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -484,6 +484,8 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsInOneEndpointSlice(t *
 		Name:   "foo",
 	}
 
+	podReady := true
+
 	tests := []struct {
 		desc              string
 		svc               api_v1.Service
@@ -526,10 +528,16 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsInOneEndpointSlice(t *
 							Addresses: []string{
 								"1.2.3.4",
 							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
+							},
 						},
 						{
 							Addresses: []string{
 								"1.2.3.4",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
 							},
 						},
 					},
@@ -563,6 +571,7 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsInOnEndpointSlice(t
 		Number: 8080,
 		Name:   "foo",
 	}
+	podReady := true
 
 	tests := []struct {
 		desc              string
@@ -609,10 +618,16 @@ func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsInOnEndpointSlice(t
 							Addresses: []string{
 								"1.2.3.4",
 							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
+							},
 						},
 						{
 							Addresses: []string{
 								"5.6.7.8",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
 							},
 						},
 					},
@@ -646,6 +661,8 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsAcrossTwoEndpointSlice
 		Number: 8080,
 		Name:   "foo",
 	}
+
+	podReady := true
 
 	tests := []struct {
 		desc              string
@@ -695,10 +712,16 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsAcrossTwoEndpointSlice
 							Addresses: []string{
 								"1.2.3.4",
 							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
+							},
 						},
 						{
 							Addresses: []string{
 								"5.6.7.8",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
 							},
 						},
 					},
@@ -714,10 +737,202 @@ func TestGetEndpointsFromEndpointSlices_DuplicateEndpointsAcrossTwoEndpointSlice
 							Addresses: []string{
 								"1.2.3.4",
 							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
+							},
 						},
 						{
 							Addresses: []string{
 								"10.0.0.1",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotEndpoints, err := lbc.getEndpointsForPortFromEndpointSlices(test.svcEndpointSlices, backendServicePort, &test.svc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result := unorderedEqual(gotEndpoints, test.expectedEndpoints); !result {
+				t.Errorf("lbc.getEndpointsForPortFromEndpointSlices() got %v, want %v",
+					gotEndpoints, test.expectedEndpoints)
+			}
+		})
+	}
+}
+
+func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsInOnEndpointSliceOneEndpointNotReady(t *testing.T) {
+	endpointPort := int32(8080)
+
+	lbc := LoadBalancerController{
+		isNginxPlus: true,
+	}
+
+	backendServicePort := networking.ServiceBackendPort{
+		Number: 8080,
+		Name:   "foo",
+	}
+	podReadyTrue := true
+	podReadyFalse := false
+
+	tests := []struct {
+		desc              string
+		svc               api_v1.Service
+		svcEndpointSlices []discovery_v1.EndpointSlice
+		expectedEndpoints []podEndpoint
+	}{
+		{
+			desc: "two different endpoints in one endpoint slice",
+			svc: api_v1.Service{
+				TypeMeta: meta_v1.TypeMeta{},
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "coffee-svc",
+					Namespace: "default",
+				},
+				Spec: api_v1.ServiceSpec{
+					Ports: []api_v1.ServicePort{
+						{
+							Name:       "foo",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						},
+					},
+				},
+				Status: api_v1.ServiceStatus{},
+			},
+			expectedEndpoints: []podEndpoint{
+				{
+					Address: "1.2.3.4:8080",
+				},
+			},
+			svcEndpointSlices: []discovery_v1.EndpointSlice{
+				{
+					Ports: []discovery_v1.EndpointPort{
+						{
+							Port: &endpointPort,
+						},
+					},
+					Endpoints: []discovery_v1.Endpoint{
+						{
+							Addresses: []string{
+								"1.2.3.4",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReadyTrue,
+							},
+						},
+						{
+							Addresses: []string{
+								"5.6.7.8",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReadyFalse,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotEndpoints, err := lbc.getEndpointsForPortFromEndpointSlices(test.svcEndpointSlices, backendServicePort, &test.svc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result := unorderedEqual(gotEndpoints, test.expectedEndpoints); !result {
+				t.Errorf("lbc.getEndpointsForPortFromEndpointSlices() got %v, want %v",
+					gotEndpoints, test.expectedEndpoints)
+			}
+		})
+	}
+}
+
+func TestGetEndpointsFromEndpointSlices_TwoDifferentEndpointsAcrossTwoEndpointSlicesOneEndpointNotReady(t *testing.T) {
+	endpointPort := int32(8080)
+
+	lbc := LoadBalancerController{
+		isNginxPlus: true,
+	}
+
+	backendServicePort := networking.ServiceBackendPort{
+		Number: 8080,
+		Name:   "foo",
+	}
+
+	podReadyTrue := true
+	podReadyFalse := false
+
+	tests := []struct {
+		desc              string
+		svc               api_v1.Service
+		svcEndpointSlices []discovery_v1.EndpointSlice
+		expectedEndpoints []podEndpoint
+	}{
+		{
+			desc: "duplicate endpoints across two endpointslices",
+			svc: api_v1.Service{
+				TypeMeta: meta_v1.TypeMeta{},
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "coffee-svc",
+					Namespace: "default",
+				},
+				Spec: api_v1.ServiceSpec{
+					Ports: []api_v1.ServicePort{
+						{
+							Name:       "foo",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						},
+					},
+				},
+				Status: api_v1.ServiceStatus{},
+			},
+			expectedEndpoints: []podEndpoint{
+				{
+					Address: "1.2.3.4:8080",
+				},
+			},
+			svcEndpointSlices: []discovery_v1.EndpointSlice{
+				{
+					Ports: []discovery_v1.EndpointPort{
+						{
+							Port: &endpointPort,
+						},
+					},
+					Endpoints: []discovery_v1.Endpoint{
+						{
+							Addresses: []string{
+								"1.2.3.4",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReadyTrue,
+							},
+						},
+					},
+				},
+				{
+					Ports: []discovery_v1.EndpointPort{
+						{
+							Port: &endpointPort,
+						},
+					},
+					Endpoints: []discovery_v1.Endpoint{
+						{
+							Addresses: []string{
+								"10.0.0.1",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReadyFalse,
 							},
 						},
 					},
@@ -862,7 +1077,7 @@ func TestGetEndpointsFromEndpointSlices_ErrorsOnNoEndpointSlicesFound(t *testing
 
 func TestGetEndpointSlicesBySubselectedPods_FindOnePodInOneEndpointSlice(t *testing.T) {
 	endpointPort := int32(8080)
-
+	podReady := true
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -911,6 +1126,9 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodInOneEndpointSlice(t *test
 							Addresses: []string{
 								"1.2.3.4",
 							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
+							},
 						},
 					},
 				},
@@ -931,7 +1149,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodInOneEndpointSlice(t *test
 
 func TestGetEndpointSlicesBySubselectedPods_FindOnePodInTwoEndpointSlicesWithDuplicateEndpoints(t *testing.T) {
 	endpointPort := int32(8080)
-
+	podReady := true
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -980,6 +1198,9 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodInTwoEndpointSlicesWithDup
 							Addresses: []string{
 								"1.2.3.4",
 							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
+							},
 						},
 					},
 				},
@@ -993,6 +1214,9 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodInTwoEndpointSlicesWithDup
 						{
 							Addresses: []string{
 								"1.2.3.4",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
 							},
 						},
 					},
@@ -1014,7 +1238,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindOnePodInTwoEndpointSlicesWithDup
 
 func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInOneEndpointSlice(t *testing.T) {
 	endpointPort := int32(8080)
-
+	podReady := true
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -1084,10 +1308,16 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInOneEndpointSlice(t *tes
 							Addresses: []string{
 								"1.2.3.4",
 							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
+							},
 						},
 						{
 							Addresses: []string{
 								"5.6.7.8",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
 							},
 						},
 					},
@@ -1109,7 +1339,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInOneEndpointSlice(t *tes
 
 func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInTwoEndpointSlices(t *testing.T) {
 	endpointPort := int32(8080)
-
+	podReady := true
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -1179,6 +1409,9 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInTwoEndpointSlices(t *te
 							Addresses: []string{
 								"1.2.3.4",
 							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
+							},
 						},
 					},
 				},
@@ -1192,6 +1425,208 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInTwoEndpointSlices(t *te
 						{
 							Addresses: []string{
 								"5.6.7.8",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotEndpoints := getEndpointsFromEndpointSlicesForSubselectedPods(test.targetPort, test.pods, test.svcEndpointSlices)
+
+			if result := unorderedEqual(gotEndpoints, test.expectedEndpoints); !result {
+				t.Errorf("getEndpointsFromEndpointSlicesForSubselectedPods() = got %v, want %v", gotEndpoints, test.expectedEndpoints)
+			}
+		})
+	}
+}
+
+func TestGetEndpointSlicesBySubselectedPods_FindOnePodEndpointInOneEndpointSliceWithOneEndpointNotReady(t *testing.T) {
+	endpointPort := int32(8080)
+	podReadyTrue := true
+	podReadyFalse := false
+	boolPointer := func(b bool) *bool { return &b }
+	tests := []struct {
+		desc              string
+		targetPort        int32
+		svcEndpointSlices []discovery_v1.EndpointSlice
+		pods              []*api_v1.Pod
+		expectedEndpoints []podEndpoint
+	}{
+		{
+			desc:       "find two pods in one endpointslice",
+			targetPort: 8080,
+			expectedEndpoints: []podEndpoint{
+				{
+					Address: "1.2.3.4:8080",
+					MeshPodOwner: configs.MeshPodOwner{
+						OwnerType: "deployment",
+						OwnerName: "deploy-1",
+					},
+				},
+			},
+			pods: []*api_v1.Pod{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						OwnerReferences: []meta_v1.OwnerReference{
+							{
+								Kind:       "Deployment",
+								Name:       "deploy-1",
+								Controller: boolPointer(true),
+							},
+						},
+					},
+					Status: api_v1.PodStatus{
+						PodIP: "1.2.3.4",
+					},
+				},
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						OwnerReferences: []meta_v1.OwnerReference{
+							{
+								Kind:       "Deployment",
+								Name:       "deploy-1",
+								Controller: boolPointer(true),
+							},
+						},
+					},
+					Status: api_v1.PodStatus{
+						PodIP: "5.6.7.8",
+					},
+				},
+			},
+			svcEndpointSlices: []discovery_v1.EndpointSlice{
+				{
+					Ports: []discovery_v1.EndpointPort{
+						{
+							Port: &endpointPort,
+						},
+					},
+					Endpoints: []discovery_v1.Endpoint{
+						{
+							Addresses: []string{
+								"1.2.3.4",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReadyTrue,
+							},
+						},
+						{
+							Addresses: []string{
+								"5.6.7.8",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReadyFalse,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotEndpoints := getEndpointsFromEndpointSlicesForSubselectedPods(test.targetPort, test.pods, test.svcEndpointSlices)
+
+			if result := unorderedEqual(gotEndpoints, test.expectedEndpoints); !result {
+				t.Errorf("getEndpointsFromEndpointSlicesForSubselectedPods() = got %v, want %v", gotEndpoints, test.expectedEndpoints)
+			}
+		})
+	}
+}
+
+func TestGetEndpointSlicesBySubselectedPods_FindOnePodEndpointInTwoEndpointSlicesWithOneEndpointNotReady(t *testing.T) {
+	endpointPort := int32(8080)
+	podReadyTrue := true
+	podReadyFalse := false
+	boolPointer := func(b bool) *bool { return &b }
+	tests := []struct {
+		desc              string
+		targetPort        int32
+		svcEndpointSlices []discovery_v1.EndpointSlice
+		pods              []*api_v1.Pod
+		expectedEndpoints []podEndpoint
+	}{
+		{
+			desc:       "find two pods in two endpointslices",
+			targetPort: 8080,
+			expectedEndpoints: []podEndpoint{
+				{
+					Address: "1.2.3.4:8080",
+					MeshPodOwner: configs.MeshPodOwner{
+						OwnerType: "deployment",
+						OwnerName: "deploy-1",
+					},
+				},
+			},
+			pods: []*api_v1.Pod{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						OwnerReferences: []meta_v1.OwnerReference{
+							{
+								Kind:       "Deployment",
+								Name:       "deploy-1",
+								Controller: boolPointer(true),
+							},
+						},
+					},
+					Status: api_v1.PodStatus{
+						PodIP: "1.2.3.4",
+					},
+				},
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						OwnerReferences: []meta_v1.OwnerReference{
+							{
+								Kind:       "Deployment",
+								Name:       "deploy-1",
+								Controller: boolPointer(true),
+							},
+						},
+					},
+					Status: api_v1.PodStatus{
+						PodIP: "5.6.7.8",
+					},
+				},
+			},
+			svcEndpointSlices: []discovery_v1.EndpointSlice{
+				{
+					Ports: []discovery_v1.EndpointPort{
+						{
+							Port: &endpointPort,
+						},
+					},
+					Endpoints: []discovery_v1.Endpoint{
+						{
+							Addresses: []string{
+								"1.2.3.4",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReadyTrue,
+							},
+						},
+					},
+				},
+				{
+					Ports: []discovery_v1.EndpointPort{
+						{
+							Port: &endpointPort,
+						},
+					},
+					Endpoints: []discovery_v1.Endpoint{
+						{
+							Addresses: []string{
+								"5.6.7.8",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReadyFalse,
 							},
 						},
 					},
@@ -1213,7 +1648,7 @@ func TestGetEndpointSlicesBySubselectedPods_FindTwoPodsInTwoEndpointSlices(t *te
 
 func TestGetEndpointSlicesBySubselectedPods_FindNoPods(t *testing.T) {
 	endpointPort := int32(8080)
-
+	podReady := true
 	boolPointer := func(b bool) *bool { return &b }
 	tests := []struct {
 		desc              string
@@ -1253,6 +1688,9 @@ func TestGetEndpointSlicesBySubselectedPods_FindNoPods(t *testing.T) {
 						{
 							Addresses: []string{
 								"5.4.3.2",
+							},
+							Conditions: discovery_v1.EndpointConditions{
+								Ready: &podReady,
 							},
 						},
 					},


### PR DESCRIPTION
### Proposed changes
This change adds a check to ensure non-ready endpoints are not added to our upstreams.

Resolves https://github.com/nginxinc/kubernetes-ingress/issues/3534

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
