### PR TITLE
Update keyCache path for JWKs to avoid conflict with OIDC

### DIFF
--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -58,7 +58,7 @@ match {{ $m.Name }} {
 
 {{ $s := .Server }}
 {{ with $s.JWTAuth }}
-{{ if .KeyCache }}proxy_cache_path /var/cache/nginx/jwk levels=1 keys_zone=jwk:1m max_size=10m; {{ end }}
+{{ if .KeyCache }}proxy_cache_path /var/cache/nginx/jwks_uri levels=1 keys_zone=jwks_uri:1m max_size=10m; {{ end }}
 {{ end }}
 
 {{ range $l := $s.Locations }}


### PR DESCRIPTION
### Proposed changes
This update resolves an issue that causes the `keyCache` directive from OIDC to collide with the `keyCache` directive used by JWKs.

Resolves this reported error
```
nginx: [emerg] the same path name "/var/cache/nginx/jwk" used in /etc/nginx/oidc/oidc_common.conf:17 and in /etc/nginx/conf.d/vs_default_webapp.conf:33
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
