### PR TITLE
set Content-Length "" for jwks uri and enable test

### DIFF
--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -182,6 +182,7 @@ server {
     location = /_jwks_uri_server {
         internal;
         proxy_method GET;
+        proxy_set_header Content-Length "";
         {{ if .KeyCache }}
         proxy_cache jwks_uri;
         proxy_cache_valid 200 12h;
@@ -382,6 +383,7 @@ server {
         location = {{ $l.Path }}_jwks_uri {
             internal;
             proxy_method GET;
+            proxy_set_header Content-Length "";
             {{ if .KeyCache }}
             proxy_cache {{ $l.Path }}_jwks_uri;
             proxy_cache_valid 200 12h;

--- a/tests/suite/test_jwt_policies_jwksuri.py
+++ b/tests/suite/test_jwt_policies_jwksuri.py
@@ -62,8 +62,6 @@ def get_token(request):
 )
 class TestJWTPoliciesVsJwksuri:
     @pytest.mark.parametrize("jwt_virtual_server", [jwt_vs_spec_src, jwt_vs_route_src])
-    @pytest.mark.flaky(max_runs=3)
-    @pytest.mark.skip(reason="under review for causing pipeline delays")
     def test_jwt_policy_jwksuri(
         self,
         request,
@@ -110,6 +108,7 @@ class TestJWTPoliciesVsJwksuri:
         resp2 = requests.get(
             virtual_server_setup.backend_1_url,
             headers={"host": virtual_server_setup.vs_host, "token": token},
+            timeout=5,
         )
 
         delete_policy(kube_apis.custom_objects, pol_name, test_namespace)


### PR DESCRIPTION
### Proposed changes
- sets `proxy_set_header Content-Length "";` under server and location context for jwks-uri,
- enables jwks-uri test, which was earlier disabled due to pipeline delays.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
