### PR TITLE
Use the "runtime default" seccomp profile

### DIFF
--- a/deployments/daemon-set/nginx-ingress.yaml
+++ b/deployments/daemon-set/nginx-ingress.yaml
@@ -20,6 +20,8 @@ spec:
       serviceAccountName: nginx-ingress
       automountServiceAccountToken: true
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         sysctls:
           - name: "net.ipv4.ip_unprivileged_port_start"
             value: "0"

--- a/deployments/daemon-set/nginx-plus-ingress.yaml
+++ b/deployments/daemon-set/nginx-plus-ingress.yaml
@@ -20,6 +20,8 @@ spec:
       serviceAccountName: nginx-ingress
       automountServiceAccountToken: true
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         sysctls:
           - name: "net.ipv4.ip_unprivileged_port_start"
             value: "0"

--- a/deployments/deployment/nginx-ingress.yaml
+++ b/deployments/deployment/nginx-ingress.yaml
@@ -21,6 +21,8 @@ spec:
       serviceAccountName: nginx-ingress
       automountServiceAccountToken: true
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         sysctls:
           - name: "net.ipv4.ip_unprivileged_port_start"
             value: "0"

--- a/deployments/deployment/nginx-plus-ingress.yaml
+++ b/deployments/deployment/nginx-plus-ingress.yaml
@@ -21,6 +21,8 @@ spec:
       serviceAccountName: nginx-ingress
       automountServiceAccountToken: true
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         sysctls:
           - name: "net.ipv4.ip_unprivileged_port_start"
             value: "0"

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -44,6 +44,8 @@ spec:
       serviceAccountName: {{ include "nginx-ingress.serviceAccountName" . }}
       automountServiceAccountToken: true
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         sysctls:
           - name: "net.ipv4.ip_unprivileged_port_start"
             value: "0"

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -77,6 +77,8 @@ spec:
       serviceAccountName: {{ include "nginx-ingress.serviceAccountName" . }}
       automountServiceAccountToken: true
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         sysctls:
           - name: "net.ipv4.ip_unprivileged_port_start"
             value: "0"


### PR DESCRIPTION
### Proposed changes

[seccomp profiles](https://kubernetes.io/docs/tutorials/security/seccomp/) allow sandboxing processes, in particular to restrict allowed syscalls from applications to the kernel. Kubernetes default in current release is Unconfined seccomp profile, which is essentially privileged. It is preferred for security purposes to restrict this.

[KEP-2413](https://github.com/kubernetes/enhancements/tree/642733833dbfa33e13d3627963cb0f310355bc82/keps/sig-node/2413-seccomp-by-default) proposes that RuntimeDefault will become the new default for Kubernetes. With Kubernetes v1.25, this is in Beta, and [available with `SeccompDefault` feature gate and `--seccomp-default` CLI flag](https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads).

`nginx-ingress` should switch to this new default, in order to ensure compatibility down the line, as well as enable enhanced security on older Kubernetes versions.

This improves on #3544 as reported by @blurpy.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
