### PR TITLE
fix: Requeue DNSEndpoint request when create fails with already exists error

### DIFF
--- a/tests/suite/test_virtual_server_externaldns.py
+++ b/tests/suite/test_virtual_server_externaldns.py
@@ -1,7 +1,7 @@
 import pytest
 from settings import TEST_DATA
-from suite.utils.custom_assertions import assert_event
-from suite.utils.custom_resources_utils import is_dnsendpoint_present
+from suite.utils.custom_assertions import assert_event, assert_event_not_present
+from suite.utils.custom_resources_utils import is_dnsendpoint_present, read_custom_resource
 from suite.utils.resources_utils import get_events, patch_namespace_with_label, wait_before_test
 from suite.utils.vs_vsr_resources_utils import patch_virtual_server_from_yaml
 from suite.utils.yaml_utils import get_name_from_yaml, get_namespace_from_yaml
@@ -48,6 +48,21 @@ class TestExternalDNSVirtualServer:
             wait_before_test(1)
             print(f"External DNS not updated, retrying... #{retry}")
         assert wanted_string in log_contents
+        print("\nStep 3: Verify VS status is Valid and no bad config events occurred")
+        events = get_events(kube_apis.v1, virtual_server_setup.namespace)
+        vs_bad_config_event = "Error creating DNSEndpoint for VirtualServer resource"
+        assert_event_not_present(vs_bad_config_event, events)
+        response = read_custom_resource(
+            kube_apis.custom_objects,
+            virtual_server_setup.namespace,
+            "virtualservers",
+            virtual_server_setup.vs_name,
+        )
+        assert (
+            response["status"]
+            and response["status"]["reason"] == "AddedOrUpdated"
+            and response["status"]["state"] == "Valid"
+        )
 
     def test_update_to_ed_in_vs(
         self, kube_apis, crd_ingress_controller_with_ed, create_externaldns, virtual_server_setup
@@ -65,6 +80,18 @@ class TestExternalDNSVirtualServer:
         wait_before_test(5)
         events = get_events(kube_apis.v1, virtual_server_setup.namespace)
         assert_event(vs_event_update_text, events)
+        print("\nStep 3: Verify VS status is Valid")
+        response = read_custom_resource(
+            kube_apis.custom_objects,
+            virtual_server_setup.namespace,
+            "virtualservers",
+            virtual_server_setup.vs_name,
+        )
+        assert (
+            response["status"]
+            and response["status"]["reason"] == "AddedOrUpdated"
+            and response["status"]["state"] == "Valid"
+        )
 
 
 @pytest.mark.vs
@@ -122,3 +149,18 @@ class TestExternalDNSVirtualServerWatchLabel:
             wait_before_test(1)
             print(f"External DNS not updated, retrying... #{retry}")
         assert wanted_string in log_contents
+        print("\nStep 3: Verify VS status is Valid and no bad config events occurred")
+        events = get_events(kube_apis.v1, virtual_server_setup.namespace)
+        vs_bad_config_event = "Error creating DNSEndpoint for VirtualServer resource"
+        assert_event_not_present(vs_bad_config_event, events)
+        response = read_custom_resource(
+            kube_apis.custom_objects,
+            virtual_server_setup.namespace,
+            "virtualservers",
+            virtual_server_setup.vs_name,
+        )
+        assert (
+            response["status"]
+            and response["status"]["reason"] == "AddedOrUpdated"
+            and response["status"]["state"] == "Valid"
+        )

--- a/tests/suite/utils/custom_assertions.py
+++ b/tests/suite/utils/custom_assertions.py
@@ -143,6 +143,19 @@ def assert_event(event_text, events_list) -> None:
     pytest.fail(f'Failed to find the event "{event_text}" in the list. Exiting...')
 
 
+def assert_event_not_present(event_text, events_list) -> None:
+    """
+    Search for the event in the list.
+
+    :param event_text: event text
+    :param events_list: list of events
+    :return:
+    """
+    for i in range(len(events_list) - 1, -1, -1):
+        if event_text in events_list[i].message:
+            pytest.fail(f'Event "{event_text}" exists in the list. Exiting...')
+
+
 def assert_event_starts_with_text_and_contains_errors(event_text, events_list, fields_list) -> None:
     """
     Search for the event starting with the expected text in the list and check its message.


### PR DESCRIPTION
### Proposed changes
There can be a race condition creating a new DNS endpoint when running multiple replicas of the Ingress Controller. This occurs when inbetween checking if the DNSEndpoint already exists and issuing the create request, another replica has already created the resource. The resource is created correctly, but the owning VirtualServer appears in an unhealthy state, and we see (an) event(s) like:

`Warning  BadConfig          14m                  nginx-ingress-controller  Error creating DNSEndpoint for VirtualServer resource dnsendpoints.externaldns.nginx.org "dev" already exists`

on the resource.

This PR resolves the issue by requeuing the resource when we get an already exists error back for a create request.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
