### PR TITLE
Don't use blocking status check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,10 +2,12 @@ coverage:
   status:
     project:
       default:
+        informational: true
         target: auto
         threshold: 0%
     patch:
       default:
+        informational: true
         target: auto
         threshold: 0%
     changes: false


### PR DESCRIPTION
This should prevent Codecov from failing while we update the config.
