### PR TITLE
Apply UID/GID defaults from image

### DIFF
--- a/charts/nginx-ingress/templates/controller-daemonset.yaml
+++ b/charts/nginx-ingress/templates/controller-daemonset.yaml
@@ -100,7 +100,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: {{ .Values.controller.readOnlyRootFilesystem }}
-          runAsUser: 101 #nginx
           runAsNonRoot: true
           capabilities:
             drop:
@@ -153,7 +152,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsUser: 101 #nginx
           runAsNonRoot: true
           capabilities:
             drop:

--- a/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -109,7 +109,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: {{ .Values.controller.readOnlyRootFilesystem }}
-          runAsUser: 101 #nginx
           runAsNonRoot: true
           capabilities:
             drop:
@@ -160,7 +159,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsUser: 101 #nginx
           runAsNonRoot: true
           capabilities:
             drop:

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -176,7 +176,6 @@ controller:
   securityContext: {} # Remove curly brackets before adding values
     # allowPrivilegeEscalation: true
     # readOnlyRootFilesystem: true
-    # runAsUser: 101 #nginx
     # runAsNonRoot: true
     # capabilities:
     #   drop:

--- a/deployments/daemon-set/nginx-ingress.yaml
+++ b/deployments/daemon-set/nginx-ingress.yaml
@@ -61,7 +61,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
 #          readOnlyRootFilesystem: true
-          runAsUser: 101 #nginx
           runAsNonRoot: true
           capabilities:
             drop:
@@ -103,7 +102,6 @@ spec:
 #        securityContext:
 #          allowPrivilegeEscalation: false
 #          readOnlyRootFilesystem: true
-#          runAsUser: 101 #nginx
 #          runAsNonRoot: true
 #          capabilities:
 #            drop:

--- a/deployments/daemon-set/nginx-plus-ingress.yaml
+++ b/deployments/daemon-set/nginx-plus-ingress.yaml
@@ -61,7 +61,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
 #          readOnlyRootFilesystem: true
-          runAsUser: 101 #nginx
           runAsNonRoot: true
           capabilities:
             drop:
@@ -106,7 +105,6 @@ spec:
 #        securityContext:
 #          allowPrivilegeEscalation: false
 #          readOnlyRootFilesystem: true
-#          runAsUser: 101 #nginx
 #          runAsNonRoot: true
 #          capabilities:
 #            drop:

--- a/deployments/deployment/nginx-ingress.yaml
+++ b/deployments/deployment/nginx-ingress.yaml
@@ -60,7 +60,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
 #          readOnlyRootFilesystem: true
-          runAsUser: 101 #nginx
           runAsNonRoot: true
           capabilities:
             drop:
@@ -104,7 +103,6 @@ spec:
 #        securityContext:
 #          allowPrivilegeEscalation: false
 #          readOnlyRootFilesystem: true
-#          runAsUser: 101 #nginx
 #          runAsNonRoot: true
 #          capabilities:
 #            drop:

--- a/deployments/deployment/nginx-plus-ingress.yaml
+++ b/deployments/deployment/nginx-plus-ingress.yaml
@@ -62,7 +62,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
 #          readOnlyRootFilesystem: true
-          runAsUser: 101 #nginx
           runAsNonRoot: true
           capabilities:
             drop:
@@ -110,7 +109,6 @@ spec:
 #        securityContext:
 #          allowPrivilegeEscalation: false
 #          readOnlyRootFilesystem: true
-#          runAsUser: 101 #nginx
 #          runAsNonRoot: true
 #          capabilities:
 #            drop:


### PR DESCRIPTION
### Proposed changes

[`build/Dockerfile` specifies `USER 101` for `common` target](https://github.com/nginxinc/kubernetes-ingress/blob/v3.2.1/build/Dockerfile#L247-L248), which is re-applied into the final images. Helm Chart/Manifests do not need to specify UID explicitly, and can instead use the image's UID. (PodSecurityContext v1 core specifies `runAsUser` defaults to user specified in image metadata if unspecified.)

The existing `runAsNonRoot: true` flag (already in place) will ensure during runtime that the image is configured with a custom user ID.

This is notably helpful for users running OpenShift, because OpenShift attempts to enforce custom UID/GID ranges for individual namespaces as part of `restricted-v2` Security Context Constraint. When removing hard-coded values from manifests, OpenShift will be able to assign its own UID/GID.

In practice, this means a different model of configuring file system permissions. OpenShift assigns the container process GID 0 as supplemental to assist with that. Locations that are expected to be written to must be owned by GID 0, with group write permissions. Previous changes to `main` have ensured that is the case.

Init container copying files is not a concern, as we will have the same UID as owner there as the main NIC container.

Reference: [A Guide to OpenShift and UIDs](https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids)

Closes #5422.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
