### PR TITLE
Only get the subject of the commit message for notifications

### DIFF
--- a/.github/workflows/updates-notification.yml
+++ b/.github/workflows/updates-notification.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Get variables for Slack
         id: slack
         run: |
-          echo "message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
+          echo "message=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
           echo "date=$(date +%s)" >> $GITHUB_OUTPUT
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Send Notification


### PR DESCRIPTION
When commit messages are not properly cleaned up during a squash and merge they could have characters that make the workflow brake.

With this change we're only retrieving the subject of the commit message (instead of the whole body) reducing the probability of breaking the workflow.

