### PR TITLE
docs: Correct Security link to Installation page

### DIFF
--- a/docs/content/configuration/security.md
+++ b/docs/content/configuration/security.md
@@ -51,7 +51,7 @@ Snippets are disabled by default. To use snippets, set the [`enable-snippets`](/
 
 The F5 Nginx Ingress Controller (NIC) has various protections against attacks, such as running the service as non-root to avoid changes to files. An additional industry best practice is having root filesystems set as read-only so that the attack surface is further reduced by limiting changes to binaries and libraries.
 
-Currently we do not set read-only root filesystem as default. Instead, this is an opt-in feature available on the [helm-chart](/nginx-ingress-controller/installation-with-helm/#configuration) via `controller.readOnlyRootFilesystem`.
+Currently we do not set read-only root filesystem as default. Instead, this is an opt-in feature available on the [helm-chart](/nginx-ingress-controller/installation/installation-with-helm/#configuration) via `controller.readOnlyRootFilesystem`.
 When using manifests instead of Helm, uncomment the following sections of the deployment:
  * `readOnlyRootFilesystem: true`,
  * The entire `volumeMounts` section,


### PR DESCRIPTION
### Proposed changes

The resource being referenced is actually available at https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/#configuration but the current link does not include `installation/` subdirectory. This commit remedies that so that people can look up the reference page quicker.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
