### PR TITLE
Fix OpenAPI version in NAP WAF docs

### DIFF
--- a/docs/content/app-protect-waf/configuration.md
+++ b/docs/content/app-protect-waf/configuration.md
@@ -333,7 +333,7 @@ apiVersion: appprotect.f5.com/v1beta1
 Content of the referenced file `myapi.yaml`:
 
 ~~~yaml
-openapi: 3.1.0
+openapi: 3.0.1
 info:
   title: 'Primitive data types'
   description: 'Primitive data types.'


### PR DESCRIPTION
The version of OpenAPI is not related to the Ingress Controller. Reverting this to the original value.
