### PR TITLE
Update Helm docs

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -46,51 +46,22 @@ $ kubectl delete -f crds/
 > This command will delete all the corresponding custom resources in your cluster across all namespaces. Please ensure there are no custom resources that you want to keep and there are no other Ingress Controller releases running in the cluster.
 
 
-## Managing the Chart via OCI Registry (edge version)
-
-> **Warning**
->
-> The `edge` version is not intended for production use. It is intended for testing and development purposes only.
-
+## Managing the Chart via OCI Registry
 ### Installing the Chart
 
 To install the chart with the release name my-release (my-release is the name that you choose):
 
 For NGINX:
 ```console
-$ helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.0.0-edge
+$ helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.17.0
 ```
 
 For NGINX Plus: (assuming you have pushed the Ingress Controller image `nginx-plus-ingress` to your private registry `myregistry.example.com`)
 ```console
-$ helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.0.0-edge --set controller.image.repository=myregistry.example.com/nginx-plus-ingress --set controller.nginxplus=true
+$ helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.17.0 --set controller.image.repository=myregistry.example.com/nginx-plus-ingress --set controller.nginxplus=true
 ```
 
 This will install the latest `edge` version of the Ingress Controller from GitHub Container Registry. If you prefer to use Docker Hub, you can replace `ghcr.io/nginxinc/charts/nginx-ingress` with `registry-1.docker.io/nginxcharts/nginx-ingress`.
-
-
-## Managing the Chart via Helm Repository
-
-### Adding the helm repository
-
-```console
-$ helm repo add nginx-stable https://helm.nginx.com/stable
-$ helm repo update
-```
-
-### Installing the Chart
-
-To install the chart with the release name my-release (my-release is the name that you choose):
-
-For NGINX:
-```console
-$ helm install my-release nginx-stable/nginx-ingress
-```
-
-For NGINX Plus: (assuming you have pushed the Ingress Controller image `nginx-plus-ingress` to your private registry `myregistry.example.com`)
-```console
-$ helm install my-release nginx-stable/nginx-ingress --set controller.image.repository=myregistry.example.com/nginx-plus-ingress --set controller.nginxplus=true
-```
 
 ### Upgrading the Chart
 
@@ -99,7 +70,7 @@ Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a re
 To upgrade the release `my-release`:
 
 ```console
-$ helm upgrade my-release nginx-stable/nginx-ingress
+$ helm upgrade my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.17.0
 ```
 
 ### Uninstalling the Chart
@@ -113,6 +84,19 @@ The command removes all the Kubernetes components associated with the release an
 
 Uninstalling the release does not remove the CRDs. To remove the CRDs, see [Uninstalling the CRDs](#uninstalling-the-crds).
 
+### Edge Version
+
+To test the latest changes in the Ingress Controller before a new release, you can install the `edge` version. This version is built from the `main` branch of the Ingress Controller repository.
+You can install the `edge` version by specifying the `--version` flag with the value `0.0.0-edge`:
+
+```console
+$ helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.0.0-edge
+```
+
+> **Warning**
+>
+> The `edge` version is not intended for production use. It is intended for testing and development purposes only.
+
 
 ## Managing the Chart via Sources
 
@@ -122,14 +106,15 @@ This step is required if you're installing the chart using its sources. Addition
 
 1. Pull the chart sources:
     ```console
-    $ helm pull nginx-stable/nginx-ingress --untar --version 0.16.1
+    $ helm pull oci://ghcr.io/nginxinc/charts/nginx-ingress --untar --version 0.17.0
     ```
 
 2. Change your working directory to nginx-ingress:
     ```console
     $ cd nginx-ingress
     ```
-### Installing
+
+### Installing the Chart
 
 To install the chart with the release name my-release (my-release is the name that you choose):
 
@@ -145,14 +130,27 @@ $ helm install my-release -f values-plus.yaml .
 
 The command deploys the Ingress Controller in your Kubernetes cluster in the default configuration. The configuration section lists the parameters that can be configured during installation.
 
-When deploying the Ingress Controller, make sure to use your own TLS certificate and key for the default server rather than the default pre-generated ones. Read the [Configuration](#Configuration) section below to see how to configure a TLS certificate and key for the default server. Note that the default server returns the Not Found page with the 404 status code for all requests for domains for which there are no Ingress rules defined.
+### Upgrading the Chart
 
-### Upgrading
+Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a release, see [Upgrading the CRDs](#upgrading-the-crds).
+
+To upgrade the release `my-release`:
 
 ```console
 $ helm upgrade my-release .
 ```
 
+### Uninstalling the Chart
+
+To uninstall/delete the release `my-release`:
+
+```console
+$ helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the release and deletes the release.
+
+Uninstalling the release does not remove the CRDs. To remove the CRDs, see [Uninstalling the CRDs](#uninstalling-the-crds).
 
 ## Running Multiple Ingress Controllers
 
@@ -165,134 +163,134 @@ See [running multiple Ingress Controllers](https://docs.nginx.com/nginx-ingress-
 
 The following tables lists the configurable parameters of the NGINX Ingress Controller chart and their default values.
 
-Parameter | Description | Default
---- | --- | ---
-`controller.name` | The name of the Ingress Controller daemonset or deployment. | Autogenerated
-`controller.kind` | The kind of the Ingress Controller installation - deployment or daemonset. | deployment
-`controller.annotations` | Allows for setting of `annotations` for deployment or daemonset. | {}
-`controller.nginxplus` | Deploys the Ingress Controller for NGINX Plus. | false
-`controller.nginxReloadTimeout` | The timeout in milliseconds which the Ingress Controller will wait for a successful NGINX reload after a change or at the initial start. | 60000
-`controller.hostNetwork` | Enables the Ingress Controller pods to use the host's network namespace. | false
-`controller.dnsPolicy` | DNS policy for the Ingress Controller pods. | ClusterFirst
-`controller.nginxDebug` | Enables debugging for NGINX. Uses the `nginx-debug` binary. Requires `error-log-level: debug` in the ConfigMap via `controller.config.entries`. | false
-`controller.logLevel` | The log level of the Ingress Controller. | 1
-`controller.image.digest ` | The image digest of the Ingress Controller. | None
-`controller.image.repository` | The image repository of the Ingress Controller. | nginx/nginx-ingress
-`controller.image.tag` | The tag of the Ingress Controller image. | 3.1.0
-`controller.image.pullPolicy` | The pull policy for the Ingress Controller image. | IfNotPresent
-`controller.lifecycle` | The lifecycle of the Ingress Controller pods. | {}
-`controller.customConfigMap` | The name of the custom ConfigMap used by the Ingress Controller. If set, then the default config is ignored. | ""
-`controller.config.name` | The name of the ConfigMap used by the Ingress Controller. | Autogenerated
-`controller.config.annotations` | The annotations of the Ingress Controller configmap. | {}
-`controller.config.entries` | The entries of the ConfigMap for customizing NGINX configuration. See [ConfigMap resource docs](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource/) for the list of supported ConfigMap keys. | {}
-`controller.customPorts` | A list of custom ports to expose on the NGINX Ingress Controller pod. Follows the conventional Kubernetes yaml syntax for container ports. | []
-`controller.defaultTLS.cert` | The base64-encoded TLS certificate for the default HTTPS server. **Note:** By default, a pre-generated self-signed certificate is used. It is recommended that you specify your own certificate. Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. | A pre-generated self-signed certificate.
-`controller.defaultTLS.key` | The base64-encoded TLS key for the default HTTPS server. **Note:** By default, a pre-generated key is used. It is recommended that you specify your own key. Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. | A pre-generated key.
-`controller.defaultTLS.secret` | The secret with a TLS certificate and key for the default HTTPS server. The value must follow the following format: `<namespace>/<name>`. Used as an alternative to specifying a certificate and key using `controller.defaultTLS.cert` and `controller.defaultTLS.key` parameters. **Note:** Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. | None
-`controller.wildcardTLS.cert` | The base64-encoded TLS certificate for every Ingress/VirtualServer host that has TLS enabled but no secret specified. If the parameter is not set, for such Ingress/VirtualServer hosts NGINX will break any attempt to establish a TLS connection. | None
-`controller.wildcardTLS.key` | The base64-encoded TLS key for every Ingress/VirtualServer host that has TLS enabled but no secret specified. If the parameter is not set, for such Ingress/VirtualServer hosts NGINX will break any attempt to establish a TLS connection. | None
-`controller.wildcardTLS.secret` | The secret with a TLS certificate and key for every Ingress/VirtualServer host that has TLS enabled but no secret specified. The value must follow the following format: `<namespace>/<name>`. Used as an alternative to specifying a certificate and key using `controller.wildcardTLS.cert` and `controller.wildcardTLS.key` parameters. | None
-`controller.nodeSelector` | The node selector for pod assignment for the Ingress Controller pods. | {}
-`controller.terminationGracePeriodSeconds` | The termination grace period of the Ingress Controller pod. | 30
-`controller.tolerations` | The tolerations of the Ingress Controller pods. | []
-`controller.affinity` | The affinity of the Ingress Controller pods. | {}
-`controller.topologySpreadConstraints` | The topology spread constraints of the Ingress controller pods. | {}
-`controller.env` | The additional environment variables to be set on the Ingress Controller pods. | []
-`controller.volumes` | The volumes of the Ingress Controller pods. | []
-`controller.volumeMounts` | The volumeMounts of the Ingress Controller pods. | []
-`controller.initContainers` | InitContainers for the Ingress Controller pods. | []
-`controller.extraContainers` | Extra (eg. sidecar) containers for the Ingress Controller pods. | []
-`controller.resources` | The resources of the Ingress Controller pods. | requests: cpu=100m,memory=128Mi
-`controller.replicaCount` | The number of replicas of the Ingress Controller deployment. | 1
-`controller.ingressClass` | A class of the Ingress Controller. An IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start. The Ingress Controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class. The Ingress Controller processes all the VirtualServer/VirtualServerRoute/TransportServer resources that do not have the "ingressClassName" field for all versions of kubernetes. | nginx
-`controller.setAsDefaultIngress` | New Ingresses without an `"ingressClassName"` field specified will be assigned the class specified in `controller.ingressClass`. | false
-`controller.watchNamespace` | Comma separated list of namespaces the Ingress Controller should watch for resources. By default the Ingress Controller watches all namespaces. Mutually exclusive with `controller.watchNamespaceLabel`. Please note that if configuring multiple namespaces using the Helm cli `--set` option, the string needs to wrapped in double quotes and the commas escaped using a backslash - e.g. `--set controller.watchNamespace="default\,nginx-ingress"`. | ""
-`controller.watchNamespaceLabel` | Configures the Ingress Controller to watch only those namespaces with label foo=bar. By default the Ingress Controller watches all namespaces. Mutually exclusive with `controller.watchNamespace`. | ""
-`controller.watchSecretNamespace` | Comma separated list of namespaces the Ingress Controller should watch for resources of type Secret. If this arg is not configured, the Ingress Controller watches the same namespaces for all resources. See `controller.watchNamespace` and `controller.watchNamespaceLabel`. Please note that if configuring multiple namespaces using the Helm cli `--set` option, the string needs to wrapped in double quotes and the commas escaped using a backslash - e.g. `--set controller.watchSecretNamespace="default\,nginx-ingress"`. | ""
-`controller.enableCustomResources` | Enable the custom resources. | true
-`controller.enablePreviewPolicies` | Enable preview policies. This parameter is deprecated. To enable OIDC Policies please use `controller.enableOIDC` instead. | false
-`controller.enableOIDC` | Enable OIDC policies. | false
-`controller.enableTLSPassthrough` | Enable TLS Passthrough on port 443. Requires `controller.enableCustomResources`. | false
-`controller.enableCertManager` | Enable x509 automated certificate management for VirtualServer resources using cert-manager (cert-manager.io). Requires `controller.enableCustomResources`. | false
-`controller.enableExternalDNS` | Enable integration with ExternalDNS for configuring public DNS entries for VirtualServer resources using [ExternalDNS](https://github.com/kubernetes-sigs/external-dns). Requires `controller.enableCustomResources`. | false
-`controller.globalConfiguration.create` | Creates the GlobalConfiguration custom resource. Requires `controller.enableCustomResources`. | false
-`controller.globalConfiguration.spec` | The spec of the GlobalConfiguration for defining the global configuration parameters of the Ingress Controller. | {}
-`controller.enableSnippets` | Enable custom NGINX configuration snippets in Ingress, VirtualServer, VirtualServerRoute and TransportServer resources. | false
-`controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress Controller. | false
-`controller.healthStatusURI` | Sets the URI of health status location in the default server. Requires `controller.healthStatus`. | "/nginx-health"
-`controller.nginxStatus.enable` | Enable the NGINX stub_status, or the NGINX Plus API. | true
-`controller.nginxStatus.port` | Set the port where the NGINX stub_status or the NGINX Plus API is exposed. | 8080
-`controller.nginxStatus.allowCidrs` | Add IP/CIDR blocks to the allow list for NGINX stub_status or the NGINX Plus API. Separate multiple IP/CIDR by commas. | 127.0.0.1,::1
-`controller.priorityClassName` | The PriorityClass of the Ingress Controller pods. | None
-`controller.service.create` | Creates a service to expose the Ingress Controller pods. | true
-`controller.service.type` | The type of service to create for the Ingress Controller. | LoadBalancer
-`controller.service.externalTrafficPolicy` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | Local
-`controller.service.annotations` | The annotations of the Ingress Controller service. | {}
-`controller.service.extraLabels` | The extra labels of the service. | {}
-`controller.service.loadBalancerIP` | The static IP address for the load balancer. Requires `controller.service.type` set to `LoadBalancer`. The cloud provider must support this feature. | ""
-`controller.service.externalIPs` | The list of external IPs for the Ingress Controller service. | []
-`controller.service.loadBalancerSourceRanges` | The IP ranges (CIDR) that are allowed to access the load balancer. Requires `controller.service.type` set to `LoadBalancer`. The cloud provider must support this feature. | []
-`controller.service.name` | The name of the service. | Autogenerated
-`controller.service.customPorts` | A list of custom ports to expose through the Ingress Controller service. Follows the conventional Kubernetes yaml syntax for service ports. | []
-`controller.service.httpPort.enable` | Enables the HTTP port for the Ingress Controller service. | true
-`controller.service.httpPort.port` | The HTTP port of the Ingress Controller service. | 80
-`controller.service.httpPort.nodePort` | The custom NodePort for the HTTP port. Requires `controller.service.type` set to `NodePort`. | ""
-`controller.service.httpPort.targetPort` | The target port of the HTTP port of the Ingress Controller service. | 80
-`controller.service.httpsPort.enable` | Enables the HTTPS port for the Ingress Controller service. | true
-`controller.service.httpsPort.port` | The HTTPS port of the Ingress Controller service. | 443
-`controller.service.httpsPort.nodePort` | The custom NodePort for the HTTPS port. Requires `controller.service.type` set to `NodePort`. | ""
-`controller.service.httpsPort.targetPort` | The target port of the HTTPS port of the Ingress Controller service. | 443
-`controller.serviceAccount.annotations` | The annotations of the Ingress Controller service account. | {}
-`controller.serviceAccount.name` | The name of the service account of the Ingress Controller pods. Used for RBAC. | Autogenerated
-`controller.serviceAccount.imagePullSecretName` | The name of the secret containing docker registry credentials. Secret must exist in the same namespace as the helm release. | ""
-`controller.serviceMonitor.name` | The name of the serviceMonitor. | Autogenerated
-`controller.serviceMonitor.create` | Create a ServiceMonitor custom resource. | false
-`controller.serviceMonitor.labels` | Kubernetes object labels to attach to the serviceMonitor object. | ""
-`controller.serviceMonitor.selectorMatchLabels` | A set of labels to allow the selection of endpoints for the ServiceMonitor. | ""
-`controller.serviceMonitor.endpoints` | A list of endpoints allowed as part of this ServiceMonitor. | ""
-`controller.reportIngressStatus.enable` | Updates the address field in the status of Ingress resources with an external address of the Ingress Controller. You must also specify the source of the external address either through an external service via `controller.reportIngressStatus.externalService`, `controller.reportIngressStatus.ingressLink` or the `external-status-address` entry in the ConfigMap via `controller.config.entries`. **Note:** `controller.config.entries.external-status-address` takes precedence over the others. | true
-`controller.reportIngressStatus.externalService` | Specifies the name of the service with the type LoadBalancer through which the Ingress Controller is exposed externally. The external address of the service is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources. `controller.reportIngressStatus.enable` must be set to `true`. The default is autogenerated and enabled when `controller.service.create` is set to `true` and `controller.service.type` is set to `LoadBalancer`. | Autogenerated
-`controller.reportIngressStatus.ingressLink` | Specifies the name of the IngressLink resource, which exposes the Ingress Controller pods via a BIG-IP system. The IP of the BIG-IP system is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources. `controller.reportIngressStatus.enable` must be set to `true`. | ""
-`controller.reportIngressStatus.enableLeaderElection` | Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources. `controller.reportIngressStatus.enable` must be set to `true`. | true
-`controller.reportIngressStatus.leaderElectionLockName` | Specifies the name of the ConfigMap, within the same namespace as the controller, used as the lock for leader election. controller.reportIngressStatus.enableLeaderElection must be set to true. | Autogenerated
-`controller.reportIngressStatus.annotations` | The annotations of the leader election configmap. | {}
-`controller.pod.annotations` | The annotations of the Ingress Controller pod. | {}
-`controller.pod.extraLabels` | The additional extra labels of the Ingress Controller pod. | {}
-`controller.appprotect.enable` | Enables the App Protect WAF module in the Ingress Controller. | false
-`controller.appprotectdos.enable` | Enables the App Protect DoS module in the Ingress Controller. | false
-`controller.appprotectdos.debug` | Enable debugging for App Protect DoS. | false
-`controller.appprotectdos.maxDaemons` | Max number of ADMD instances. | 1
-`controller.appprotectdos.maxWorkers` | Max number of nginx processes to support. | Number of CPU cores in the machine
-`controller.appprotectdos.memory` | RAM memory size to consume in MB. | 50% of free RAM in the container or 80MB, the smaller
-`controller.readyStatus.enable` | Enables the readiness endpoint `"/nginx-ready"`. The endpoint returns a success code when NGINX has loaded all the config after the startup. This also configures a readiness probe for the Ingress Controller pods that uses the readiness endpoint. | true
-`controller.readyStatus.port` | The HTTP port for the readiness endpoint. | 8081
-`controller.readyStatus.initialDelaySeconds` | The number of seconds after the Ingress Controller pod has started before readiness probes are initiated. | 0
-`controller.enableLatencyMetrics` | Enable collection of latency metrics for upstreams. Requires `prometheus.create`. | false
-`controller.minReadySeconds` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0
-`controller.autoscaling.enabled` | Enables HorizontalPodAutoscaling. | false
-`controller.autoscaling.annotations` | The annotations of the Ingress Controller HorizontalPodAutoscaler. | {}
-`controller.autoscaling.minReplicas` | Minimum number of replicas for the HPA. | 1
-`controller.autoscaling.maxReplicas` | Maximum number of replicas for the HPA. | 3
-`controller.autoscaling.targetCPUUtilizationPercentage` | The target CPU utilization percentage. | 50
-`controller.autoscaling.targetMemoryUtilizationPercentage` | The target memory utilization percentage. | 50
-`controller.podDisruptionBudget.enabled` | Enables PodDisruptionBudget. | false
-`controller.podDisruptionBudget.annotations` | The annotations of the Ingress Controller pod disruption budget | {}
-`controller.podDisruptionBudget.minAvailable` | The number of Ingress Controller pods that should be available. This is a mutually exclusive setting with "maxUnavailable". | 0
-`controller.podDisruptionBudget.maxUnavailable` | The number of Ingress Controller pods that can be unavailable. This is a mutually exclusive setting with "minAvailable". | 0
-`controller.strategy` | Specifies the strategy used to replace old Pods with new ones. Docs for [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) and [Daemonset update strategy](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy) | {}
-`controller.disableIPV6` | Disable IPV6 listeners explicitly for nodes that do not support the IPV6 stack. | false
-`controller.readOnlyRootFilesystem` | Configure root filesystem as read-only and add volumes for temporary data. | false
-`rbac.create` | Configures RBAC. | true
-`prometheus.create` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | true
-`prometheus.port` | Configures the port to scrape the metrics. | 9113
-`prometheus.scheme` | Configures the HTTP scheme to use for connections to the Prometheus endpoint. | http
-`prometheus.secret` | The namespace / name of a Kubernetes TLS Secret. If specified, this secret is used to secure the Prometheus endpoint with TLS connections. | ""
-`serviceInsight.create` | Expose NGINX Plus Service Insight endpoint. | false
-`serviceInsight.port` | Configures the port to expose endpoints. | 9114
-`serviceInsight.scheme` | Configures the HTTP scheme to use for connections to the Service Insight endpoint. | http
-`serviceInsight.secret` | The namespace / name of a Kubernetes TLS Secret. If specified, this secret is used to secure the Service Insight endpoint with TLS connections. | ""
-`nginxServiceMesh.enable` | Enable integration with NGINX Service Mesh. See the NGINX Service Mesh [docs](https://docs.nginx.com/nginx-service-mesh/tutorials/kic/deploy-with-kic/) for more details. Requires `controller.nginxplus`. | false
-`nginxServiceMesh.enableEgress` | Enable NGINX Service Mesh workloads to route egress traffic through the Ingress Controller. See the NGINX Service Mesh [docs](https://docs.nginx.com/nginx-service-mesh/tutorials/kic/deploy-with-kic/#enabling-egress) for more details. Requires `nginxServiceMesh.enable`. | false
+|Parameter | Description | Default |
+| --- | --- | --- |
+|`controller.name` | The name of the Ingress Controller daemonset or deployment. | Autogenerated |
+|`controller.kind` | The kind of the Ingress Controller installation - deployment or daemonset. | deployment |
+|`controller.annotations` | Allows for setting of `annotations` for deployment or daemonset. | {} |
+|`controller.nginxplus` | Deploys the Ingress Controller for NGINX Plus. | false |
+|`controller.nginxReloadTimeout` | The timeout in milliseconds which the Ingress Controller will wait for a successful NGINX reload after a change or at the initial start. | 60000 |
+|`controller.hostNetwork` | Enables the Ingress Controller pods to use the host's network namespace. | false |
+|`controller.dnsPolicy` | DNS policy for the Ingress Controller pods. | ClusterFirst |
+|`controller.nginxDebug` | Enables debugging for NGINX. Uses the `nginx-debug` binary. Requires `error-log-level: debug` in the ConfigMap via `controller.config.entries`. | false |
+|`controller.logLevel` | The log level of the Ingress Controller. | 1 |
+|`controller.image.digest ` | The image digest of the Ingress Controller. | None |
+|`controller.image.repository` | The image repository of the Ingress Controller. | nginx/nginx-ingress |
+|`controller.image.tag` | The tag of the Ingress Controller image. | 3.1.0 |
+|`controller.image.pullPolicy` | The pull policy for the Ingress Controller image. | IfNotPresent |
+|`controller.lifecycle` | The lifecycle of the Ingress Controller pods. | {} |
+|`controller.customConfigMap` | The name of the custom ConfigMap used by the Ingress Controller. If set, then the default config is ignored. | "" |
+|`controller.config.name` | The name of the ConfigMap used by the Ingress Controller. | Autogenerated |
+|`controller.config.annotations` | The annotations of the Ingress Controller configmap. | {} |
+|`controller.config.entries` | The entries of the ConfigMap for customizing NGINX configuration. See [ConfigMap resource docs](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource/) for the list of supported ConfigMap keys. | {} |
+|`controller.customPorts` | A list of custom ports to expose on the NGINX Ingress Controller pod. Follows the conventional Kubernetes yaml syntax for container ports. | [] |
+|`controller.defaultTLS.cert` | The base64-encoded TLS certificate for the default HTTPS server. **Note:** By default, a pre-generated self-signed certificate is used. It is recommended that you specify your own certificate. Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. | A pre-generated self-signed certificate. |
+|`controller.defaultTLS.key` | The base64-encoded TLS key for the default HTTPS server. **Note:** By default, a pre-generated key is used. It is recommended that you specify your own key. Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. | A pre-generated key. |
+|`controller.defaultTLS.secret` | The secret with a TLS certificate and key for the default HTTPS server. The value must follow the following format: `<namespace>/<name>`. Used as an alternative to specifying a certificate and key using `controller.defaultTLS.cert` and `controller.defaultTLS.key` parameters. **Note:** Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. | None |
+|`controller.wildcardTLS.cert` | The base64-encoded TLS certificate for every Ingress/VirtualServer host that has TLS enabled but no secret specified. If the parameter is not set, for such Ingress/VirtualServer hosts NGINX will break any attempt to establish a TLS connection. | None |
+|`controller.wildcardTLS.key` | The base64-encoded TLS key for every Ingress/VirtualServer host that has TLS enabled but no secret specified. If the parameter is not set, for such Ingress/VirtualServer hosts NGINX will break any attempt to establish a TLS connection. | None |
+|`controller.wildcardTLS.secret` | The secret with a TLS certificate and key for every Ingress/VirtualServer host that has TLS enabled but no secret specified. The value must follow the following format: `<namespace>/<name>`. Used as an alternative to specifying a certificate and key using `controller.wildcardTLS.cert` and `controller.wildcardTLS.key` parameters. | None |
+|`controller.nodeSelector` | The node selector for pod assignment for the Ingress Controller pods. | {} |
+|`controller.terminationGracePeriodSeconds` | The termination grace period of the Ingress Controller pod. | 30 |
+|`controller.tolerations` | The tolerations of the Ingress Controller pods. | [] |
+|`controller.affinity` | The affinity of the Ingress Controller pods. | {} |
+|`controller.topologySpreadConstraints` | The topology spread constraints of the Ingress controller pods. | {} |
+|`controller.env` | The additional environment variables to be set on the Ingress Controller pods. | [] |
+|`controller.volumes` | The volumes of the Ingress Controller pods. | [] |
+|`controller.volumeMounts` | The volumeMounts of the Ingress Controller pods. | [] |
+|`controller.initContainers` | InitContainers for the Ingress Controller pods. | [] |
+|`controller.extraContainers` | Extra (eg. sidecar) containers for the Ingress Controller pods. | [] |
+|`controller.resources` | The resources of the Ingress Controller pods. | requests: cpu=100m,memory=128Mi |
+|`controller.replicaCount` | The number of replicas of the Ingress Controller deployment. | 1 |
+|`controller.ingressClass` | A class of the Ingress Controller. An IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start. The Ingress Controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class. The Ingress Controller processes all the VirtualServer/VirtualServerRoute/TransportServer resources that do not have the "ingressClassName" field for all versions of kubernetes. | nginx |
+|`controller.setAsDefaultIngress` | New Ingresses without an `"ingressClassName"` field specified will be assigned the class specified in `controller.ingressClass`. | false |
+|`controller.watchNamespace` | Comma separated list of namespaces the Ingress Controller should watch for resources. By default the Ingress Controller watches all namespaces. Mutually exclusive with `controller.watchNamespaceLabel`. Please note that if configuring multiple namespaces using the Helm cli `--set` option, the string needs to wrapped in double quotes and the commas escaped using a backslash - e.g. `--set controller.watchNamespace="default\,nginx-ingress"`. | "" |
+|`controller.watchNamespaceLabel` | Configures the Ingress Controller to watch only those namespaces with label foo=bar. By default the Ingress Controller watches all namespaces. Mutually exclusive with `controller.watchNamespace`. | "" |
+|`controller.watchSecretNamespace` | Comma separated list of namespaces the Ingress Controller should watch for resources of type Secret. If this arg is not configured, the Ingress Controller watches the same namespaces for all resources. See `controller.watchNamespace` and `controller.watchNamespaceLabel`. Please note that if configuring multiple namespaces using the Helm cli `--set` option, the string needs to wrapped in double quotes and the commas escaped using a backslash - e.g. `--set controller.watchSecretNamespace="default\,nginx-ingress"`. | "" |
+|`controller.enableCustomResources` | Enable the custom resources. | true |
+|`controller.enablePreviewPolicies` | Enable preview policies. This parameter is deprecated. To enable OIDC Policies please use `controller.enableOIDC` instead. | false |
+|`controller.enableOIDC` | Enable OIDC policies. | false |
+|`controller.enableTLSPassthrough` | Enable TLS Passthrough on port 443. Requires `controller.enableCustomResources`. | false |
+|`controller.enableCertManager` | Enable x509 automated certificate management for VirtualServer resources using cert-manager (cert-manager.io). Requires `controller.enableCustomResources`. | false |
+|`controller.enableExternalDNS` | Enable integration with ExternalDNS for configuring public DNS entries for VirtualServer resources using [ExternalDNS](https://github.com/kubernetes-sigs/external-dns). Requires `controller.enableCustomResources`. | false |
+|`controller.globalConfiguration.create` | Creates the GlobalConfiguration custom resource. Requires `controller.enableCustomResources`. | false |
+|`controller.globalConfiguration.spec` | The spec of the GlobalConfiguration for defining the global configuration parameters of the Ingress Controller. | {} |
+|`controller.enableSnippets` | Enable custom NGINX configuration snippets in Ingress, VirtualServer, VirtualServerRoute and TransportServer resources. | false |
+|`controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress Controller. | false |
+|`controller.healthStatusURI` | Sets the URI of health status location in the default server. Requires `controller.healthStatus`. | "/nginx-health" |
+|`controller.nginxStatus.enable` | Enable the NGINX stub_status, or the NGINX Plus API. | true |
+|`controller.nginxStatus.port` | Set the port where the NGINX stub_status or the NGINX Plus API is exposed. | 8080 |
+|`controller.nginxStatus.allowCidrs` | Add IP/CIDR blocks to the allow list for NGINX stub_status or the NGINX Plus API. Separate multiple IP/CIDR by commas. | 127.0.0.1,::1 |
+|`controller.priorityClassName` | The PriorityClass of the Ingress Controller pods. | None |
+|`controller.service.create` | Creates a service to expose the Ingress Controller pods. | true |
+|`controller.service.type` | The type of service to create for the Ingress Controller. | LoadBalancer |
+|`controller.service.externalTrafficPolicy` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | Local |
+|`controller.service.annotations` | The annotations of the Ingress Controller service. | {} |
+|`controller.service.extraLabels` | The extra labels of the service. | {} |
+|`controller.service.loadBalancerIP` | The static IP address for the load balancer. Requires `controller.service.type` set to `LoadBalancer`. The cloud provider must support this feature. | "" |
+|`controller.service.externalIPs` | The list of external IPs for the Ingress Controller service. | [] |
+|`controller.service.loadBalancerSourceRanges` | The IP ranges (CIDR) that are allowed to access the load balancer. Requires `controller.service.type` set to `LoadBalancer`. The cloud provider must support this feature. | [] |
+|`controller.service.name` | The name of the service. | Autogenerated |
+|`controller.service.customPorts` | A list of custom ports to expose through the Ingress Controller service. Follows the conventional Kubernetes yaml syntax for service ports. | [] |
+|`controller.service.httpPort.enable` | Enables the HTTP port for the Ingress Controller service. | true |
+|`controller.service.httpPort.port` | The HTTP port of the Ingress Controller service. | 80 |
+|`controller.service.httpPort.nodePort` | The custom NodePort for the HTTP port. Requires `controller.service.type` set to `NodePort`. | "" |
+|`controller.service.httpPort.targetPort` | The target port of the HTTP port of the Ingress Controller service. | 80 |
+|`controller.service.httpsPort.enable` | Enables the HTTPS port for the Ingress Controller service. | true |
+|`controller.service.httpsPort.port` | The HTTPS port of the Ingress Controller service. | 443 |
+|`controller.service.httpsPort.nodePort` | The custom NodePort for the HTTPS port. Requires `controller.service.type` set to `NodePort`. | "" |
+|`controller.service.httpsPort.targetPort` | The target port of the HTTPS port of the Ingress Controller service. | 443 |
+|`controller.serviceAccount.annotations` | The annotations of the Ingress Controller service account. | {} |
+|`controller.serviceAccount.name` | The name of the service account of the Ingress Controller pods. Used for RBAC. | Autogenerated |
+|`controller.serviceAccount.imagePullSecretName` | The name of the secret containing docker registry credentials. Secret must exist in the same namespace as the helm release. | "" |
+|`controller.serviceMonitor.name` | The name of the serviceMonitor. | Autogenerated |
+|`controller.serviceMonitor.create` | Create a ServiceMonitor custom resource. | false |
+|`controller.serviceMonitor.labels` | Kubernetes object labels to attach to the serviceMonitor object. | "" |
+|`controller.serviceMonitor.selectorMatchLabels` | A set of labels to allow the selection of endpoints for the ServiceMonitor. | "" |
+|`controller.serviceMonitor.endpoints` | A list of endpoints allowed as part of this ServiceMonitor. | "" |
+|`controller.reportIngressStatus.enable` | Updates the address field in the status of Ingress resources with an external address of the Ingress Controller. You must also specify the source of the external address either through an external service via `controller.reportIngressStatus.externalService`, `controller.reportIngressStatus.ingressLink` or the `external-status-address` entry in the ConfigMap via `controller.config.entries`. **Note:** `controller.config.entries.external-status-address` takes precedence over the others. | true |
+|`controller.reportIngressStatus.externalService` | Specifies the name of the service with the type LoadBalancer through which the Ingress Controller is exposed externally. The external address of the service is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources. `controller.reportIngressStatus.enable` must be set to `true`. The default is autogenerated and enabled when `controller.service.create` is set to `true` and `controller.service.type` is set to `LoadBalancer`. | Autogenerated |
+|`controller.reportIngressStatus.ingressLink` | Specifies the name of the IngressLink resource, which exposes the Ingress Controller pods via a BIG-IP system. The IP of the BIG-IP system is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources. `controller.reportIngressStatus.enable` must be set to `true`. | "" |
+|`controller.reportIngressStatus.enableLeaderElection` | Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources. `controller.reportIngressStatus.enable` must be set to `true`. | true |
+|`controller.reportIngressStatus.leaderElectionLockName` | Specifies the name of the ConfigMap, within the same namespace as the controller, used as the lock for leader election. controller.reportIngressStatus.enableLeaderElection must be set to true. | Autogenerated |
+|`controller.reportIngressStatus.annotations` | The annotations of the leader election configmap. | {} |
+|`controller.pod.annotations` | The annotations of the Ingress Controller pod. | {} |
+|`controller.pod.extraLabels` | The additional extra labels of the Ingress Controller pod. | {} |
+|`controller.appprotect.enable` | Enables the App Protect WAF module in the Ingress Controller. | false |
+|`controller.appprotectdos.enable` | Enables the App Protect DoS module in the Ingress Controller. | false |
+|`controller.appprotectdos.debug` | Enable debugging for App Protect DoS. | false |
+|`controller.appprotectdos.maxDaemons` | Max number of ADMD instances. | 1 |
+|`controller.appprotectdos.maxWorkers` | Max number of nginx processes to support. | Number of CPU cores in the machine |
+|`controller.appprotectdos.memory` | RAM memory size to consume in MB. | 50% of free RAM in the container or 80MB, the smaller |
+|`controller.readyStatus.enable` | Enables the readiness endpoint `"/nginx-ready"`. The endpoint returns a success code when NGINX has loaded all the config after the startup. This also configures a readiness probe for the Ingress Controller pods that uses the readiness endpoint. | true |
+|`controller.readyStatus.port` | The HTTP port for the readiness endpoint. | 8081 |
+|`controller.readyStatus.initialDelaySeconds` | The number of seconds after the Ingress Controller pod has started before readiness probes are initiated. | 0 |
+|`controller.enableLatencyMetrics` | Enable collection of latency metrics for upstreams. Requires `prometheus.create`. | false |
+|`controller.minReadySeconds` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
+|`controller.autoscaling.enabled` | Enables HorizontalPodAutoscaling. | false |
+|`controller.autoscaling.annotations` | The annotations of the Ingress Controller HorizontalPodAutoscaler. | {} |
+|`controller.autoscaling.minReplicas` | Minimum number of replicas for the HPA. | 1 |
+|`controller.autoscaling.maxReplicas` | Maximum number of replicas for the HPA. | 3 |
+|`controller.autoscaling.targetCPUUtilizationPercentage` | The target CPU utilization percentage. | 50 |
+|`controller.autoscaling.targetMemoryUtilizationPercentage` | The target memory utilization percentage. | 50 |
+|`controller.podDisruptionBudget.enabled` | Enables PodDisruptionBudget. | false |
+|`controller.podDisruptionBudget.annotations` | The annotations of the Ingress Controller pod disruption budget | {} |
+|`controller.podDisruptionBudget.minAvailable` | The number of Ingress Controller pods that should be available. This is a mutually exclusive setting with "maxUnavailable". | 0 |
+|`controller.podDisruptionBudget.maxUnavailable` | The number of Ingress Controller pods that can be unavailable. This is a mutually exclusive setting with "minAvailable". | 0 |
+|`controller.strategy` | Specifies the strategy used to replace old Pods with new ones. Docs for [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) and [Daemonset update strategy](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy) | {} |
+|`controller.disableIPV6` | Disable IPV6 listeners explicitly for nodes that do not support the IPV6 stack. | false |
+|`controller.readOnlyRootFilesystem` | Configure root filesystem as read-only and add volumes for temporary data. | false |
+|`rbac.create` | Configures RBAC. | true |
+|`prometheus.create` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | true |
+|`prometheus.port` | Configures the port to scrape the metrics. | 9113 |
+|`prometheus.scheme` | Configures the HTTP scheme to use for connections to the Prometheus endpoint. | http |
+|`prometheus.secret` | The namespace / name of a Kubernetes TLS Secret. If specified, this secret is used to secure the Prometheus endpoint with TLS connections. | "" |
+|`serviceInsight.create` | Expose NGINX Plus Service Insight endpoint. | false |
+|`serviceInsight.port` | Configures the port to expose endpoints. | 9114 |
+|`serviceInsight.scheme` | Configures the HTTP scheme to use for connections to the Service Insight endpoint. | http |
+|`serviceInsight.secret` | The namespace / name of a Kubernetes TLS Secret. If specified, this secret is used to secure the Service Insight endpoint with TLS connections. | "" |
+|`nginxServiceMesh.enable` | Enable integration with NGINX Service Mesh. See the NGINX Service Mesh [docs](https://docs.nginx.com/nginx-service-mesh/tutorials/kic/deploy-with-kic/) for more details. Requires `controller.nginxplus`. | false |
+|`nginxServiceMesh.enableEgress` | Enable NGINX Service Mesh workloads to route egress traffic through the Ingress Controller. See the NGINX Service Mesh [docs](https://docs.nginx.com/nginx-service-mesh/tutorials/kic/deploy-with-kic/#enabling-egress) for more details. Requires `nginxServiceMesh.enable`. | false |
 
 ## Notes
 * The values-icp.yaml file is used for deploying the Ingress Controller on IBM Cloud Private. See the [blog post](https://www.nginx.com/blog/nginx-ingress-controller-ibm-cloud-private/) for more details.

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -86,7 +86,7 @@ Uninstalling the release does not remove the CRDs. To remove the CRDs, see [Unin
 
 ### Edge Version
 
-To test the latest changes in the Ingress Controller before a new release, you can install the `edge` version. This version is built from the `main` branch of the Ingress Controller repository.
+To test the latest changes in NGINX Ingress Controller before a new release, you can install the `edge` version. This version is built from the `main` branch of the NGINX Ingress Controller repository.
 You can install the `edge` version by specifying the `--version` flag with the value `0.0.0-edge`:
 
 ```console

--- a/docs/content/installation/installation-with-helm.md
+++ b/docs/content/installation/installation-with-helm.md
@@ -8,62 +8,121 @@ docs: "DOCS-602"
 ---
 
 
+## Introduction
+
+This chart deploys the NGINX Ingress Controller in your Kubernetes cluster.
+
 ## Prerequisites
 
-  - A [Kubernetes Version Supported by the Ingress Controller](/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions)
+  - A [Kubernetes Version Supported by the Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/technical-specifications/#supported-kubernetes-versions)
   - Helm 3.0+.
-  - Git.
   - If you’d like to use NGINX Plus:
-    - To pull from the F5 Container registry, configure a docker registry secret using your JWT token from the MyF5 portal by following the instructions from [here](/nginx-ingress-controller/installation/using-the-jwt-token-docker-secret). Make sure to specify the secret using `controller.serviceAccount.imagePullSecretName` parameter.
-    - Alternatively, pull an Ingress Controller image with NGINX Plus and push it to your private registry by following the instructions from [here](/nginx-ingress-controller/installation/pulling-ingress-controller-image).
-    - Alternatively, you can build an Ingress Controller image with NGINX Plus and push it to your private registry by following the instructions from [here](/nginx-ingress-controller/installation/building-ingress-controller-image).
+    - To pull from the F5 Container registry, configure a docker registry secret using your JWT token from the MyF5 portal by following the instructions from [here](https://docs.nginx.com/nginx-ingress-controller/installation/using-the-jwt-token-docker-secret). Make sure to specify the secret using `controller.serviceAccount.imagePullSecretName` parameter.
+    - Alternatively, pull an Ingress Controller image with NGINX Plus and push it to your private registry by following the instructions from [here](https://docs.nginx.com/nginx-ingress-controller/installation/pulling-ingress-controller-image).
+    - Alternatively, you can build an Ingress Controller image with NGINX Plus and push it to your private registry by following the instructions from [here](https://docs.nginx.com/nginx-ingress-controller/installation/building-ingress-controller-image).
     - Update the `controller.image.repository` field of the `values-plus.yaml` accordingly.
-  - If you’d like to use App Protect DoS, please install App Protect DoS Arbitrator helm chart. Make sure to install in the same namespace as the NGINX Ingress Controller. Note that if you install multiple NGINX Ingress Controllers in the same namespace, they will need to share the same Arbitrator because it is not possible to install more than one Arbitrator in a single namespace.
+  - If you’d like to use App Protect DoS, please install App Protect DoS Arbitrator [helm chart](https://github.com/nginxinc/nap-dos-arbitrator-helm-chart). Make sure to install in the same namespace as the NGINX Ingress Controller. Note that if you install multiple NGINX Ingress Controllers in the same namespace, they will need to share the same Arbitrator because it is not possible to install more than one Arbitrator in a single namespace.
 
-## Getting the Chart Sources
-
-This step is required if you're installing the chart using its sources. Additionally, the step is also required for managing the custom resource definitions (CRDs), which the Ingress Controller requires by default, or for upgrading/deleting the CRDs.
-
-1. Clone the Ingress Controller repo:
-    ```console
-    $ git clone https://github.com/nginxinc/kubernetes-ingress.git --branch v3.1.0
-    ```
-2. Change your working directory to /deployments/helm-chart:
-    ```console
-    $ cd kubernetes-ingress/deployments/helm-chart
-    ```
-
-## Adding the Helm Repository
-
-This step is required if you're installing the chart via the helm repository.
-
-```console
-$ helm repo add nginx-stable https://helm.nginx.com/stable
-$ helm repo update
-```
-
-## Installing the Chart
-
-### Installing the CRDs
+## CRDs
 
 By default, the Ingress Controller requires a number of custom resource definitions (CRDs) installed in the cluster. The Helm client will install those CRDs. If the CRDs are not installed, the Ingress Controller pods will not become `Ready`.
 
-If you do not use the custom resources that require those CRDs (which corresponds to `controller.enableCustomResources` set to `false` and `controller.appprotect.enable` set to `false`), the installation of the CRDs can be skipped by specifying `--skip-crds` for the helm install command.
+If you do not use the custom resources that require those CRDs (which corresponds to `controller.enableCustomResources` set to `false` and `controller.appprotect.enable` set to `false` and `controller.appprotectdos.enable` set to `false`), the installation of the CRDs can be skipped by specifying `--skip-crds` for the helm install command.
 
-### Installing via Helm Repository
+### Upgrading the CRDs
+
+To upgrade the CRDs, pull the chart sources as described in [Pulling the Chart](#pulling-the-chart) and then run:
+
+```console
+$ kubectl apply -f crds/
+```
+> **Note**
+>
+> The following warning is expected and can be ignored: `Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply`.
+>
+> Make sure to check the [release notes](https://www.github.com/nginxinc/kubernetes-ingress/releases) for a new release for any special upgrade procedures.
+
+### Uninstalling the CRDs
+
+To remove the CRDs, pull the chart sources as described in [Pulling the Chart](#pulling-the-chart) and then run:
+
+```console
+$ kubectl delete -f crds/
+```
+> **Note**
+>
+> This command will delete all the corresponding custom resources in your cluster across all namespaces. Please ensure there are no custom resources that you want to keep and there are no other Ingress Controller releases running in the cluster.
+
+
+## Managing the Chart via OCI Registry
+### Installing the Chart
 
 To install the chart with the release name my-release (my-release is the name that you choose):
 
 For NGINX:
 ```console
-$ helm install my-release nginx-stable/nginx-ingress
+$ helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.17.0
 ```
 
 For NGINX Plus: (assuming you have pushed the Ingress Controller image `nginx-plus-ingress` to your private registry `myregistry.example.com`)
 ```console
-$ helm install my-release nginx-stable/nginx-ingress --set controller.image.repository=myregistry.example.com/nginx-plus-ingress --set controller.nginxplus=true
+$ helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.17.0 --set controller.image.repository=myregistry.example.com/nginx-plus-ingress --set controller.nginxplus=true
 ```
-### Installing Using Chart Sources
+
+This will install the latest `edge` version of the Ingress Controller from GitHub Container Registry. If you prefer to use Docker Hub, you can replace `ghcr.io/nginxinc/charts/nginx-ingress` with `registry-1.docker.io/nginxcharts/nginx-ingress`.
+
+### Upgrading the Chart
+
+Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a release, see [Upgrading the CRDs](#upgrading-the-crds).
+
+To upgrade the release `my-release`:
+
+```console
+$ helm upgrade my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.17.0
+```
+
+### Uninstalling the Chart
+
+To uninstall/delete the release `my-release`:
+
+```console
+$ helm uninstall my-release
+```
+The command removes all the Kubernetes components associated with the release and deletes the release.
+
+Uninstalling the release does not remove the CRDs. To remove the CRDs, see [Uninstalling the CRDs](#uninstalling-the-crds).
+
+### Edge Version
+
+To test the latest changes in the Ingress Controller before a new release, you can install the `edge` version. This version is built from the `main` branch of the Ingress Controller repository.
+You can install the `edge` version by specifying the `--version` flag with the value `0.0.0-edge`:
+
+```console
+$ helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.0.0-edge
+```
+
+> **Warning**
+>
+> The `edge` version is not intended for production use. It is intended for testing and development purposes only.
+
+
+## Managing the Chart via Sources
+
+### Pulling the Chart
+
+This step is required if you're installing the chart using its sources. Additionally, the step is also required for managing the custom resource definitions (CRDs), which the Ingress Controller requires by default, or for upgrading/deleting the CRDs.
+
+1. Pull the chart sources:
+    ```console
+    $ helm pull oci://ghcr.io/nginxinc/charts/nginx-ingress --untar --version 0.17.0
+    ```
+
+2. Change your working directory to nginx-ingress:
+    ```console
+    $ cd nginx-ingress
+    ```
+
+### Installing the Chart
 
 To install the chart with the release name my-release (my-release is the name that you choose):
 
@@ -79,40 +138,17 @@ $ helm install my-release -f values-plus.yaml .
 
 The command deploys the Ingress Controller in your Kubernetes cluster in the default configuration. The configuration section lists the parameters that can be configured during installation.
 
-When deploying the Ingress Controller, make sure to use your own TLS certificate and key for the default server rather than the default pre-generated ones. Read the [Configuration](#configuration) section below to see how to configure a TLS certificate and key for the default server. Note that the default server returns the Not Found page with the 404 status code for all requests for domains for which there are no Ingress rules defined.
+### Upgrading the Chart
 
-## Upgrading the Chart
-
-### Upgrading the CRDs
-
-Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a release, run the following command to upgrade the CRDs:
-
-```console
-$ kubectl apply -f crds/
-```
-> **Note**: The following warning is expected and can be ignored: `Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply`.
-
-> **Note**: Make sure to check the [release notes](https://www.github.com/nginxinc/kubernetes-ingress/releases) for a new release for any special upgrade procedures.
-
-### Upgrading the Release
+Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a release, see [Upgrading the CRDs](#upgrading-the-crds).
 
 To upgrade the release `my-release`:
-
-#### Upgrade Using Chart Sources:
 
 ```console
 $ helm upgrade my-release .
 ```
 
-#### Upgrade via Helm Repository:
-
-```console
-$ helm upgrade my-release nginx-stable/nginx-ingress
-```
-
-## Uninstalling the Chart
-
-### Uninstalling the Release
+### Uninstalling the Chart
 
 To uninstall/delete the release `my-release`:
 
@@ -120,22 +156,16 @@ To uninstall/delete the release `my-release`:
 $ helm uninstall my-release
 ```
 
-The command removes all the Kubernetes components associated with the release.
+The command removes all the Kubernetes components associated with the release and deletes the release.
 
-### Uninstalling the CRDs
-
-Uninstalling the release does not remove the CRDs. To remove the CRDs, run:
-
-```console
-$ kubectl delete -f crds/
-```
-> **Note**: This command will delete all the corresponding custom resources in your cluster across all namespaces. Please ensure there are no custom resources that you want to keep and there are no other Ingress Controller releases running in the cluster.
+Uninstalling the release does not remove the CRDs. To remove the CRDs, see [Uninstalling the CRDs](#uninstalling-the-crds).
 
 ## Running Multiple Ingress Controllers
 
 If you are running multiple Ingress Controller releases in your cluster with enabled custom resources, the releases will share a single version of the CRDs. As a result, make sure that the Ingress Controller versions match the version of the CRDs. Additionally, when uninstalling a release, ensure that you don’t remove the CRDs until there are no other Ingress Controller releases running in the cluster.
 
-See [running multiple Ingress Controllers](/nginx-ingress-controller/installation/running-multiple-ingress-controllers/) for more details.
+See [running multiple Ingress Controllers](https://docs.nginx.com/nginx-ingress-controller/installation/running-multiple-ingress-controllers/) for more details.
+
 
 ## Configuration
 
@@ -143,124 +173,135 @@ The following tables lists the configurable parameters of the NGINX Ingress Cont
 
 {{% table %}}
 |Parameter | Description | Default |
-| ---| ---| --- |
-|``controller.name`` | The name of the Ingress Controller daemonset or deployment. | Autogenerated |
-|``controller.kind`` | The kind of the Ingress Controller installation - deployment or daemonset. | deployment |
-|``controller.nginxplus`` | Deploys the Ingress Controller for NGINX Plus. | false |
-|``controller.nginxReloadTimeout`` | The timeout in milliseconds which the Ingress Controller will wait for a successful NGINX reload after a change or at the initial start. | 60000 |
-|``controller.appprotect.enable`` | Enables the App Protect WAF module in the Ingress Controller. | false |
-|``controller.appprotectdos.enable`` | Enables the App Protect DoS module in the Ingress Controller. | false |
-|``controller.appprotectdos.debug`` | Enables App Protect DoS debug logs. | false |
-|``controller.appprotectdos.maxWorkers`` | Max number of nginx processes to support. | Number of CPU cores in the machine
-|``controller.appprotectdos.maxDaemons`` | Max number of ADMD instances. | 1
-|``controller.appprotectdos.memory`` | RAM memory size to consume in MB. | 50% of free RAM in the container or 80MB, the smaller
-|``controller.hostNetwork`` | Enables the Ingress Controller pods to use the host's network namespace. | false |
-|``controller.nginxDebug`` | Enables debugging for NGINX. Uses the ``nginx-debug`` binary. Requires ``error-log-level: debug`` in the ConfigMap via ``controller.config.entries``. | false |
-|``controller.logLevel`` | The log level of the Ingress Controller. | 1 |
-|``controller.image.repository`` | The image repository of the Ingress Controller. | nginx/nginx-ingress |
-|``controller.image.digest`` | The digest of the Ingress Controller image. Digest has precedence over tag | None |
-|``controller.image.tag`` | The tag of the Ingress Controller image. | 3.1.0 |
-|``controller.image.pullPolicy`` | The pull policy for the Ingress Controller image. | IfNotPresent |
-|``controller.lifecycle`` | The lifecycle of the Ingress Controller pods. | {} |
-|``controller.customConfigMap`` | The name of the custom ConfigMap used by the Ingress Controller. If set, then the default config is ignored. | "" |
-|``controller.config.name`` | The name of the ConfigMap used by the Ingress Controller. | Autogenerated |
-|``controller.config.annotations`` | The annotations of the Ingress Controller configmap. | {} |
-|``controller.config.entries`` | The entries of the ConfigMap for customizing NGINX configuration. See [ConfigMap resource docs](/nginx-ingress-controller/configuration/global-configuration/configmap-resource/) for the list of supported ConfigMap keys. | {} |
-|``controller.customPorts`` | A list of custom ports to expose on the NGINX Ingress Controller pod. Follows the conventional Kubernetes yaml syntax for container ports. | [] |
-|``controller.defaultTLS.cert`` | The base64-encoded TLS certificate for the default HTTPS server.  **Note:** By default, a pre-generated self-signed certificate is used. It is recommended that you specify your own certificate. Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. See the [default-server-tls-secret command-line argument](/nginx-ingress-controller/configuration/global-configuration/command-line-#cmdoption-default-server-tls-secret) for more details. | A pre-generated self-signed certificate. |
-|``controller.defaultTLS.key`` | The base64-encoded TLS key for the default HTTPS server. **Note:** By default, a pre-generated key is used. It is recommended that you specify your own key. Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. See the [default-server-tls-secret command-line argument](/nginx-ingress-controller/configuration/global-configuration/command-line-#cmdoption-default-server-tls-secret) for more details. | A pre-generated key. |
-|``controller.defaultTLS.secret`` | The secret with a TLS certificate and key for the default HTTPS server. The value must follow the following format: ``<namespace>/<name>``. Used as an alternative to specifying a certificate and key using ``controller.defaultTLS.cert`` and ``controller.defaultTLS.key`` parameters. **Note:** Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. See the [default-server-tls-secret command-line argument](/nginx-ingress-controller/configuration/global-configuration/command-line-#cmdoption-default-server-tls-secret) for more details. | None |
-|``controller.wildcardTLS.cert`` | The base64-encoded TLS certificate for every Ingress/VirtualServer host that has TLS enabled but no secret specified. If the parameter is not set, for such Ingress/VirtualServer hosts NGINX will break any attempt to establish a TLS connection. | None |
-|``controller.wildcardTLS.key`` | The base64-encoded TLS key for every Ingress/VirtualServer host that has TLS enabled but no secret specified. If the parameter is not set, for such Ingress/VirtualServer hosts NGINX will break any attempt to establish a TLS connection. | None |
-|``controller.wildcardTLS.secret`` | The secret with a TLS certificate and key for every Ingress/VirtualServer host that has TLS enabled but no secret specified. The value must follow the following format: ``<namespace>/<name>``. Used as an alternative to specifying a certificate and key using ``controller.wildcardTLS.cert`` and ``controller.wildcardTLS.key`` parameters. | None |
-|``controller.nodeSelector`` | The node selector for pod assignment for the Ingress Controller pods. | {} |
-|``controller.terminationGracePeriodSeconds`` | The termination grace period of the Ingress Controller pod. | 30 |
-|``controller.tolerations`` | The tolerations of the Ingress Controller pods. | [] |
-|``controller.affinity`` | The affinity of the Ingress Controller pods. | {} |
-|``controller.env`` | The additional environment variables to be set on the Ingress Controller pods. | []
-|``controller.volumes`` | The volumes of the Ingress Controller pods. | [] |
-|``controller.volumeMounts`` | The volumeMounts of the Ingress Controller pods. | [] |
-|``controller.initContainers`` | InitContainers for the Ingress Controller pods. | []
-|``controller.extraContainers`` | Extra (eg. sidecar) containers for the Ingress Controller pods. | []
-|``controller.resources`` | The resources of the Ingress Controller pods. | requests: cpu=100m,memory=128Mi |
-|``controller.replicaCount`` | The number of replicas of the Ingress Controller deployment. | 1 |
-|``controller.ingressClass`` | A class of the Ingress Controller. An IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start. The Ingress Controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class. The Ingress Controller processes all the VirtualServer/VirtualServerRoute/TransportServer resources that do not have the "ingressClassName" field for all versions of kubernetes. | nginx |
-|``controller.setAsDefaultIngress`` | New Ingresses without an ingressClassName field specified will be assigned the class specified in `controller.ingressClass`. | false |
-|``controller.watchNamespace`` | Comma separated list of namespaces the Ingress Controller should watch for resources. By default the Ingress Controller watches all namespaces. Mutually exclusive with `controller.watchNamespaceLabel`. Please note that if configuring multiple namespaces using the Helm cli `--set` option, the string needs to wrapped in double quotes and the commas escaped using a backslash - e.g. ``--set controller.watchNamespace="default\,nginx-ingress"``. | "" |
-|``controller.watchNamespaceLabel`` | Configures the Ingress Controller to watch only those namespaces with label foo=bar. By default the Ingress Controller watches all namespaces. Mutually exclusive with `controller.watchNamespace`. | "" |
-|``controller.watchSecretNamespace`` | Comma separated list of namespaces the Ingress Controller should watch for resources of type Secret. If this arg is not configured, the Ingress Controller watches the same namespaces for all resources. See `controller.watchNamespace` and `controller.watchNamespaceLabel`. Please note that if configuring multiple namespaces using the Helm cli `--set` option, the string needs to wrapped in double quotes and the commas escaped using a backslash - e.g. ``--set controller.watchSecretNamespace="default\,nginx-ingress"``. | "" |
-|``controller.enableCustomResources`` | Enable the custom resources. | true |
-|``controller.enablePreviewPolicies`` | Enable preview policies. This parameter is deprecated. To enable OIDC Policies please use ``controller.enableOIDC`` instead. | false |
-|``controller.enableOIDC`` | Enable OIDC policies. | false |
-|``controller.includeYear`` | Include year in log header. This parameter will be removed in release 2.7 and the year will be included by default. | false |
-|``controller.enableTLSPassthrough`` | Enable TLS Passthrough on port 443. Requires ``controller.enableCustomResources``. | false |
-`controller.enableCertManager` | Enable x509 automated certificate management for VirtualServer resources using cert-manager (cert-manager.io). Requires `controller.enableCustomResources`. | false
-`controller.enableExternalDNS` | Enable integration with ExternalDNS for configuring public DNS entries for VirtualServer resources using [ExternalDNS](https://github.com/kubernetes-sigs/external-dns). Requires `controller.enableCustomResources`. | false
-|``controller.globalConfiguration.create`` | Creates the GlobalConfiguration custom resource. Requires ``controller.enableCustomResources``. | false |
-|``controller.globalConfiguration.spec`` | The spec of the GlobalConfiguration for defining the global configuration parameters of the Ingress Controller. | {} |
-|``controller.enableSnippets`` | Enable custom NGINX configuration snippets in Ingress, VirtualServer, VirtualServerRoute and TransportServer resources. | false |
-|``controller.healthStatus`` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress Controller. | false |
-|``controller.healthStatusURI`` | Sets the URI of health status location in the default server. Requires ``controller.healthStatus``. | "/nginx-health" |
-|``controller.nginxStatus.enable`` | Enable the NGINX stub_status, or the NGINX Plus API. | true |
-|``controller.nginxStatus.port`` | Set the port where the NGINX stub_status or the NGINX Plus API is exposed. | 8080 |
-|``controller.nginxStatus.allowCidrs`` | Add IP/CIDR blocks to the allow list for NGINX stub_status or the NGINX Plus API. Separate multiple IP/CIDR by commas. | 127.0.0.1,::1 |
-|``controller.service.create`` | Creates a service to expose the Ingress Controller pods. | true |
-|``controller.service.type`` | The type of service to create for the Ingress Controller. | LoadBalancer |
-|``controller.service.allocateLoadBalancerNodePorts`` | Whether to automatically allocate NodePorts for the service (bool, LoadBalancers only). | "" |
-|``controller.service.ipFamilyPolicy`` | Dual stack preference. Valid values: ``SingleStack``, ``PreferDualStack``, ``RequireDualStack``. | "" |
-|``controller.service.ipFamilies`` | List of IP families assigned to this service. Valid values: ``IPv4``, ``IPv6``. | "" |
-|``controller.service.externalTrafficPolicy`` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | Local |
-|``controller.service.annotations`` | The annotations of the Ingress Controller service. | {} |
-|``controller.service.extraLabels`` | The extra labels of the service. | {} |
-|``controller.service.loadBalancerIP`` | The static IP address for the load balancer. Requires ``controller.service.type`` set to ``LoadBalancer``. The cloud provider must support this feature. | "" |
-|``controller.service.externalIPs`` | The list of external IPs for the Ingress Controller service. | [] |
-|``controller.service.loadBalancerSourceRanges`` | The IP ranges (CIDR) that are allowed to access the load balancer. Requires ``controller.service.type`` set to ``LoadBalancer``. The cloud provider must support this feature. | [] |
-|``controller.service.name`` | The name of the service. | Autogenerated |
-|``controller.service.customPorts`` | A list of custom ports to expose through the Ingress Controller service. Follows the conventional Kubernetes yaml syntax for service ports. | [] |
-|``controller.service.httpPort.enable`` | Enables the HTTP port for the Ingress Controller service. | true |
-|``controller.service.httpPort.port`` | The HTTP port of the Ingress Controller service. | 80 |
-|``controller.service.httpPort.nodePort`` | The custom NodePort for the HTTP port. Requires ``controller.service.type`` set to ``NodePort``. | "" |
-|``controller.service.httpPort.targetPort`` | The target port of the HTTP port of the Ingress Controller service. | 80 |
-|``controller.service.httpsPort.enable`` | Enables the HTTPS port for the Ingress Controller service. | true |
-|``controller.service.httpsPort.port`` | The HTTPS port of the Ingress Controller service. | 443 |
-|``controller.service.httpsPort.nodePort`` | The custom NodePort for the HTTPS port. Requires ``controller.service.type`` set to ``NodePort``. | "" |
-|``controller.service.httpsPort.targetPort`` | The target port of the HTTPS port of the Ingress Controller service. | 443 |
-|``controller.serviceAccount.name`` | The name of the service account of the Ingress Controller pods. Used for RBAC. | Autogenerated |
-|``controller.serviceAccount.imagePullSecretName`` | The name of the secret containing docker registry credentials. Secret must exist in the same namespace as the helm release. | "" |
-|``controller.reportIngressStatus.enable`` | Updates the address field in the status of Ingress resources with an external address of the Ingress Controller. You must also specify the source of the external address either through an external service via ``controller.reportIngressStatus.externalService``, ``controller.reportIngressStatus.ingressLink`` or the ``external-status-address`` entry in the ConfigMap via ``controller.config.entries``. **Note:** ``controller.config.entries.external-status-address`` takes precedence over the others. | true |
-|``controller.reportIngressStatus.externalService`` | Specifies the name of the service with the type LoadBalancer through which the Ingress Controller is exposed externally. The external address of the service is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources. ``controller.reportIngressStatus.enable`` must be set to ``true``. The default is autogenerated and enabled when ``controller.service.create`` is set to ``true`` and ``controller.service.type`` is set to ``LoadBalancer``. | Autogenerated |
-|``controller.reportIngressStatus.ingressLink`` | Specifies the name of the IngressLink resource, which exposes the Ingress Controller pods via a BIG-IP system. The IP of the BIG-IP system is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources. ``controller.reportIngressStatus.enable`` must be set to ``true``. | "" |
-|``controller.reportIngressStatus.enableLeaderElection`` | Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources. ``controller.reportIngressStatus.enable`` must be set to ``true``. | true |
-|``controller.reportIngressStatus.leaderElectionLockName`` | Specifies the name of the ConfigMap, within the same namespace as the controller, used as the lock for leader election. controller.reportIngressStatus.enableLeaderElection must be set to true. | Autogenerated |
-|``controller.pod.annotations`` | The annotations of the Ingress Controller pod. | {} |
-|``controller.readyStatus.enable`` | Enables the readiness endpoint `"/nginx-ready"`. The endpoint returns a success code when NGINX has loaded all the config after the startup. This also configures a readiness probe for the Ingress Controller pods that uses the readiness endpoint. | true |
-|``controller.readyStatus.port`` | The HTTP port for the readiness endpoint. | 8081 |
-|``controller.readyStatus.initialDelaySeconds`` | The number of seconds after the Ingress Controller pod has started before readiness probes are initiated. | 0 |
-|``controller.enableLatencyMetrics`` | Enable collection of latency metrics for upstreams. Requires ``prometheus.create``. | false |
-|``controller.minReadySeconds`` | Specifies the minimum number of seconds for which a newly created Pod should be ready, without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
-|``controller.autoscaling.enabled`` | Enables HorizontalPodAutoscaling. | false |
-|``controller.autoscaling.annotations`` | The annotations of the Ingress Controller HorizontalPodAutoscaler. | {} |
-|``controller.autoscaling.minReplicas`` | Minimum number of replicas for the HPA. | 1 |
-|``controller.autoscaling.maxReplicas`` | Maximum number of replicas for the HPA. | 3 |
-|``controller.autoscaling.targetCPUUtilizationPercentage`` | The target CPU utilization percentage. | 50 |
-|``controller.autoscaling.targetMemoryUtilizationPercentage`` | The target memory utilization percentage. | 50 |
-|``controller.podDisruptionBudget.enabled`` | Enables PodDisruptionBudget. | false |
-|``controller.podDisruptionBudget.annotations`` | The annotations of the Ingress Controller pod disruption budget | {} |
-|``controller.podDisruptionBudget.minAvailable`` | The number of Ingress Controller pods that should be available. | 0 |
-|``controller.podDisruptionBudget.maxUnavailable`` | The number of Ingress Controller pods that can be unavailable. | 0 |
-|``controller.strategy`` | Specifies the strategy used to replace old Pods with new ones. Docs for [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) and [Daemonset update strategy](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy). | {} |
-| `controller.disableIPV6` | Disable IPV6 listeners explicitly for nodes that do not support the IPV6 stack. | false |
-|``controller.readOnlyRootFilesystem`` | Configure root filesystem as read-only and add volumes for temporary data. | false |
-|``rbac.create`` | Configures RBAC. | true |
-|``prometheus.create`` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | false |
-|``prometheus.port`` | Configures the port to scrape the metrics. | 9113 |
-|``prometheus.scheme`` | Configures the HTTP scheme that requests must use to connect to the Prometheus endpoint. | http |
-|``prometheus.secret`` | Specifies the namespace/name of a Kubernetes TLS secret which can be used to establish a secure HTTPS connection with the Prometheus endpoint. | "" |
-|``serviceInsight.create`` | Expose NGINX Plus Service Insight endpoint. | false |
-|``serviceInsight.port`` | Configures the port to scrape the metrics. | 9114 |
-|``serviceInsight.scheme`` | Configures the HTTP scheme to use for connections to the Service Insight endpoint. | http |
-|``serviceInsight.secret`` | The namespace / name of a Kubernetes TLS Secret. If specified, this secret is used to secure the Service Insight endpoint with TLS connections. | "" |
+| --- | --- | --- |
+|`controller.name` | The name of the Ingress Controller daemonset or deployment. | Autogenerated |
+|`controller.kind` | The kind of the Ingress Controller installation - deployment or daemonset. | deployment |
+|`controller.annotations` | Allows for setting of `annotations` for deployment or daemonset. | {} |
+|`controller.nginxplus` | Deploys the Ingress Controller for NGINX Plus. | false |
+|`controller.nginxReloadTimeout` | The timeout in milliseconds which the Ingress Controller will wait for a successful NGINX reload after a change or at the initial start. | 60000 |
+|`controller.hostNetwork` | Enables the Ingress Controller pods to use the host's network namespace. | false |
+|`controller.dnsPolicy` | DNS policy for the Ingress Controller pods. | ClusterFirst |
+|`controller.nginxDebug` | Enables debugging for NGINX. Uses the `nginx-debug` binary. Requires `error-log-level: debug` in the ConfigMap via `controller.config.entries`. | false |
+|`controller.logLevel` | The log level of the Ingress Controller. | 1 |
+|`controller.image.digest ` | The image digest of the Ingress Controller. | None |
+|`controller.image.repository` | The image repository of the Ingress Controller. | nginx/nginx-ingress |
+|`controller.image.tag` | The tag of the Ingress Controller image. | 3.1.0 |
+|`controller.image.pullPolicy` | The pull policy for the Ingress Controller image. | IfNotPresent |
+|`controller.lifecycle` | The lifecycle of the Ingress Controller pods. | {} |
+|`controller.customConfigMap` | The name of the custom ConfigMap used by the Ingress Controller. If set, then the default config is ignored. | "" |
+|`controller.config.name` | The name of the ConfigMap used by the Ingress Controller. | Autogenerated |
+|`controller.config.annotations` | The annotations of the Ingress Controller configmap. | {} |
+|`controller.config.entries` | The entries of the ConfigMap for customizing NGINX configuration. See [ConfigMap resource docs](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource/) for the list of supported ConfigMap keys. | {} |
+|`controller.customPorts` | A list of custom ports to expose on the NGINX Ingress Controller pod. Follows the conventional Kubernetes yaml syntax for container ports. | [] |
+|`controller.defaultTLS.cert` | The base64-encoded TLS certificate for the default HTTPS server. **Note:** By default, a pre-generated self-signed certificate is used. It is recommended that you specify your own certificate. Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. | A pre-generated self-signed certificate. |
+|`controller.defaultTLS.key` | The base64-encoded TLS key for the default HTTPS server. **Note:** By default, a pre-generated key is used. It is recommended that you specify your own key. Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. | A pre-generated key. |
+|`controller.defaultTLS.secret` | The secret with a TLS certificate and key for the default HTTPS server. The value must follow the following format: `<namespace>/<name>`. Used as an alternative to specifying a certificate and key using `controller.defaultTLS.cert` and `controller.defaultTLS.key` parameters. **Note:** Alternatively, omitting the default server secret completely will configure NGINX to reject TLS connections to the default server. | None |
+|`controller.wildcardTLS.cert` | The base64-encoded TLS certificate for every Ingress/VirtualServer host that has TLS enabled but no secret specified. If the parameter is not set, for such Ingress/VirtualServer hosts NGINX will break any attempt to establish a TLS connection. | None |
+|`controller.wildcardTLS.key` | The base64-encoded TLS key for every Ingress/VirtualServer host that has TLS enabled but no secret specified. If the parameter is not set, for such Ingress/VirtualServer hosts NGINX will break any attempt to establish a TLS connection. | None |
+|`controller.wildcardTLS.secret` | The secret with a TLS certificate and key for every Ingress/VirtualServer host that has TLS enabled but no secret specified. The value must follow the following format: `<namespace>/<name>`. Used as an alternative to specifying a certificate and key using `controller.wildcardTLS.cert` and `controller.wildcardTLS.key` parameters. | None |
+|`controller.nodeSelector` | The node selector for pod assignment for the Ingress Controller pods. | {} |
+|`controller.terminationGracePeriodSeconds` | The termination grace period of the Ingress Controller pod. | 30 |
+|`controller.tolerations` | The tolerations of the Ingress Controller pods. | [] |
+|`controller.affinity` | The affinity of the Ingress Controller pods. | {} |
+|`controller.topologySpreadConstraints` | The topology spread constraints of the Ingress controller pods. | {} |
+|`controller.env` | The additional environment variables to be set on the Ingress Controller pods. | [] |
+|`controller.volumes` | The volumes of the Ingress Controller pods. | [] |
+|`controller.volumeMounts` | The volumeMounts of the Ingress Controller pods. | [] |
+|`controller.initContainers` | InitContainers for the Ingress Controller pods. | [] |
+|`controller.extraContainers` | Extra (eg. sidecar) containers for the Ingress Controller pods. | [] |
+|`controller.resources` | The resources of the Ingress Controller pods. | requests: cpu=100m,memory=128Mi |
+|`controller.replicaCount` | The number of replicas of the Ingress Controller deployment. | 1 |
+|`controller.ingressClass` | A class of the Ingress Controller. An IngressClass resource with the name equal to the class must be deployed. Otherwise, the Ingress Controller will fail to start. The Ingress Controller only processes resources that belong to its class - i.e. have the "ingressClassName" field resource equal to the class. The Ingress Controller processes all the VirtualServer/VirtualServerRoute/TransportServer resources that do not have the "ingressClassName" field for all versions of kubernetes. | nginx |
+|`controller.setAsDefaultIngress` | New Ingresses without an `"ingressClassName"` field specified will be assigned the class specified in `controller.ingressClass`. | false |
+|`controller.watchNamespace` | Comma separated list of namespaces the Ingress Controller should watch for resources. By default the Ingress Controller watches all namespaces. Mutually exclusive with `controller.watchNamespaceLabel`. Please note that if configuring multiple namespaces using the Helm cli `--set` option, the string needs to wrapped in double quotes and the commas escaped using a backslash - e.g. `--set controller.watchNamespace="default\,nginx-ingress"`. | "" |
+|`controller.watchNamespaceLabel` | Configures the Ingress Controller to watch only those namespaces with label foo=bar. By default the Ingress Controller watches all namespaces. Mutually exclusive with `controller.watchNamespace`. | "" |
+|`controller.watchSecretNamespace` | Comma separated list of namespaces the Ingress Controller should watch for resources of type Secret. If this arg is not configured, the Ingress Controller watches the same namespaces for all resources. See `controller.watchNamespace` and `controller.watchNamespaceLabel`. Please note that if configuring multiple namespaces using the Helm cli `--set` option, the string needs to wrapped in double quotes and the commas escaped using a backslash - e.g. `--set controller.watchSecretNamespace="default\,nginx-ingress"`. | "" |
+|`controller.enableCustomResources` | Enable the custom resources. | true |
+|`controller.enablePreviewPolicies` | Enable preview policies. This parameter is deprecated. To enable OIDC Policies please use `controller.enableOIDC` instead. | false |
+|`controller.enableOIDC` | Enable OIDC policies. | false |
+|`controller.enableTLSPassthrough` | Enable TLS Passthrough on port 443. Requires `controller.enableCustomResources`. | false |
+|`controller.enableCertManager` | Enable x509 automated certificate management for VirtualServer resources using cert-manager (cert-manager.io). Requires `controller.enableCustomResources`. | false |
+|`controller.enableExternalDNS` | Enable integration with ExternalDNS for configuring public DNS entries for VirtualServer resources using [ExternalDNS](https://github.com/kubernetes-sigs/external-dns). Requires `controller.enableCustomResources`. | false |
+|`controller.globalConfiguration.create` | Creates the GlobalConfiguration custom resource. Requires `controller.enableCustomResources`. | false |
+|`controller.globalConfiguration.spec` | The spec of the GlobalConfiguration for defining the global configuration parameters of the Ingress Controller. | {} |
+|`controller.enableSnippets` | Enable custom NGINX configuration snippets in Ingress, VirtualServer, VirtualServerRoute and TransportServer resources. | false |
+|`controller.healthStatus` | Add a location "/nginx-health" to the default server. The location responds with the 200 status code for any request. Useful for external health-checking of the Ingress Controller. | false |
+|`controller.healthStatusURI` | Sets the URI of health status location in the default server. Requires `controller.healthStatus`. | "/nginx-health" |
+|`controller.nginxStatus.enable` | Enable the NGINX stub_status, or the NGINX Plus API. | true |
+|`controller.nginxStatus.port` | Set the port where the NGINX stub_status or the NGINX Plus API is exposed. | 8080 |
+|`controller.nginxStatus.allowCidrs` | Add IP/CIDR blocks to the allow list for NGINX stub_status or the NGINX Plus API. Separate multiple IP/CIDR by commas. | 127.0.0.1,::1 |
+|`controller.priorityClassName` | The PriorityClass of the Ingress Controller pods. | None |
+|`controller.service.create` | Creates a service to expose the Ingress Controller pods. | true |
+|`controller.service.type` | The type of service to create for the Ingress Controller. | LoadBalancer |
+|`controller.service.externalTrafficPolicy` | The externalTrafficPolicy of the service. The value Local preserves the client source IP. | Local |
+|`controller.service.annotations` | The annotations of the Ingress Controller service. | {} |
+|`controller.service.extraLabels` | The extra labels of the service. | {} |
+|`controller.service.loadBalancerIP` | The static IP address for the load balancer. Requires `controller.service.type` set to `LoadBalancer`. The cloud provider must support this feature. | "" |
+|`controller.service.externalIPs` | The list of external IPs for the Ingress Controller service. | [] |
+|`controller.service.loadBalancerSourceRanges` | The IP ranges (CIDR) that are allowed to access the load balancer. Requires `controller.service.type` set to `LoadBalancer`. The cloud provider must support this feature. | [] |
+|`controller.service.name` | The name of the service. | Autogenerated |
+|`controller.service.customPorts` | A list of custom ports to expose through the Ingress Controller service. Follows the conventional Kubernetes yaml syntax for service ports. | [] |
+|`controller.service.httpPort.enable` | Enables the HTTP port for the Ingress Controller service. | true |
+|`controller.service.httpPort.port` | The HTTP port of the Ingress Controller service. | 80 |
+|`controller.service.httpPort.nodePort` | The custom NodePort for the HTTP port. Requires `controller.service.type` set to `NodePort`. | "" |
+|`controller.service.httpPort.targetPort` | The target port of the HTTP port of the Ingress Controller service. | 80 |
+|`controller.service.httpsPort.enable` | Enables the HTTPS port for the Ingress Controller service. | true |
+|`controller.service.httpsPort.port` | The HTTPS port of the Ingress Controller service. | 443 |
+|`controller.service.httpsPort.nodePort` | The custom NodePort for the HTTPS port. Requires `controller.service.type` set to `NodePort`. | "" |
+|`controller.service.httpsPort.targetPort` | The target port of the HTTPS port of the Ingress Controller service. | 443 |
+|`controller.serviceAccount.annotations` | The annotations of the Ingress Controller service account. | {} |
+|`controller.serviceAccount.name` | The name of the service account of the Ingress Controller pods. Used for RBAC. | Autogenerated |
+|`controller.serviceAccount.imagePullSecretName` | The name of the secret containing docker registry credentials. Secret must exist in the same namespace as the helm release. | "" |
+|`controller.serviceMonitor.name` | The name of the serviceMonitor. | Autogenerated |
+|`controller.serviceMonitor.create` | Create a ServiceMonitor custom resource. | false |
+|`controller.serviceMonitor.labels` | Kubernetes object labels to attach to the serviceMonitor object. | "" |
+|`controller.serviceMonitor.selectorMatchLabels` | A set of labels to allow the selection of endpoints for the ServiceMonitor. | "" |
+|`controller.serviceMonitor.endpoints` | A list of endpoints allowed as part of this ServiceMonitor. | "" |
+|`controller.reportIngressStatus.enable` | Updates the address field in the status of Ingress resources with an external address of the Ingress Controller. You must also specify the source of the external address either through an external service via `controller.reportIngressStatus.externalService`, `controller.reportIngressStatus.ingressLink` or the `external-status-address` entry in the ConfigMap via `controller.config.entries`. **Note:** `controller.config.entries.external-status-address` takes precedence over the others. | true |
+|`controller.reportIngressStatus.externalService` | Specifies the name of the service with the type LoadBalancer through which the Ingress Controller is exposed externally. The external address of the service is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources. `controller.reportIngressStatus.enable` must be set to `true`. The default is autogenerated and enabled when `controller.service.create` is set to `true` and `controller.service.type` is set to `LoadBalancer`. | Autogenerated |
+|`controller.reportIngressStatus.ingressLink` | Specifies the name of the IngressLink resource, which exposes the Ingress Controller pods via a BIG-IP system. The IP of the BIG-IP system is used when reporting the status of Ingress, VirtualServer and VirtualServerRoute resources. `controller.reportIngressStatus.enable` must be set to `true`. | "" |
+|`controller.reportIngressStatus.enableLeaderElection` | Enable Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources. `controller.reportIngressStatus.enable` must be set to `true`. | true |
+|`controller.reportIngressStatus.leaderElectionLockName` | Specifies the name of the ConfigMap, within the same namespace as the controller, used as the lock for leader election. controller.reportIngressStatus.enableLeaderElection must be set to true. | Autogenerated |
+|`controller.reportIngressStatus.annotations` | The annotations of the leader election configmap. | {} |
+|`controller.pod.annotations` | The annotations of the Ingress Controller pod. | {} |
+|`controller.pod.extraLabels` | The additional extra labels of the Ingress Controller pod. | {} |
+|`controller.appprotect.enable` | Enables the App Protect WAF module in the Ingress Controller. | false |
+|`controller.appprotectdos.enable` | Enables the App Protect DoS module in the Ingress Controller. | false |
+|`controller.appprotectdos.debug` | Enable debugging for App Protect DoS. | false |
+|`controller.appprotectdos.maxDaemons` | Max number of ADMD instances. | 1 |
+|`controller.appprotectdos.maxWorkers` | Max number of nginx processes to support. | Number of CPU cores in the machine |
+|`controller.appprotectdos.memory` | RAM memory size to consume in MB. | 50% of free RAM in the container or 80MB, the smaller |
+|`controller.readyStatus.enable` | Enables the readiness endpoint `"/nginx-ready"`. The endpoint returns a success code when NGINX has loaded all the config after the startup. This also configures a readiness probe for the Ingress Controller pods that uses the readiness endpoint. | true |
+|`controller.readyStatus.port` | The HTTP port for the readiness endpoint. | 8081 |
+|`controller.readyStatus.initialDelaySeconds` | The number of seconds after the Ingress Controller pod has started before readiness probes are initiated. | 0 |
+|`controller.enableLatencyMetrics` | Enable collection of latency metrics for upstreams. Requires `prometheus.create`. | false |
+|`controller.minReadySeconds` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
+|`controller.autoscaling.enabled` | Enables HorizontalPodAutoscaling. | false |
+|`controller.autoscaling.annotations` | The annotations of the Ingress Controller HorizontalPodAutoscaler. | {} |
+|`controller.autoscaling.minReplicas` | Minimum number of replicas for the HPA. | 1 |
+|`controller.autoscaling.maxReplicas` | Maximum number of replicas for the HPA. | 3 |
+|`controller.autoscaling.targetCPUUtilizationPercentage` | The target CPU utilization percentage. | 50 |
+|`controller.autoscaling.targetMemoryUtilizationPercentage` | The target memory utilization percentage. | 50 |
+|`controller.podDisruptionBudget.enabled` | Enables PodDisruptionBudget. | false |
+|`controller.podDisruptionBudget.annotations` | The annotations of the Ingress Controller pod disruption budget | {} |
+|`controller.podDisruptionBudget.minAvailable` | The number of Ingress Controller pods that should be available. This is a mutually exclusive setting with "maxUnavailable". | 0 |
+|`controller.podDisruptionBudget.maxUnavailable` | The number of Ingress Controller pods that can be unavailable. This is a mutually exclusive setting with "minAvailable". | 0 |
+|`controller.strategy` | Specifies the strategy used to replace old Pods with new ones. Docs for [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) and [Daemonset update strategy](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy) | {} |
+|`controller.disableIPV6` | Disable IPV6 listeners explicitly for nodes that do not support the IPV6 stack. | false |
+|`controller.readOnlyRootFilesystem` | Configure root filesystem as read-only and add volumes for temporary data. | false |
+|`rbac.create` | Configures RBAC. | true |
+|`prometheus.create` | Expose NGINX or NGINX Plus metrics in the Prometheus format. | true |
+|`prometheus.port` | Configures the port to scrape the metrics. | 9113 |
+|`prometheus.scheme` | Configures the HTTP scheme to use for connections to the Prometheus endpoint. | http |
+|`prometheus.secret` | The namespace / name of a Kubernetes TLS Secret. If specified, this secret is used to secure the Prometheus endpoint with TLS connections. | "" |
+|`serviceInsight.create` | Expose NGINX Plus Service Insight endpoint. | false |
+|`serviceInsight.port` | Configures the port to expose endpoints. | 9114 |
+|`serviceInsight.scheme` | Configures the HTTP scheme to use for connections to the Service Insight endpoint. | http |
+|`serviceInsight.secret` | The namespace / name of a Kubernetes TLS Secret. If specified, this secret is used to secure the Service Insight endpoint with TLS connections. | "" |
+|`nginxServiceMesh.enable` | Enable integration with NGINX Service Mesh. See the NGINX Service Mesh [docs](https://docs.nginx.com/nginx-service-mesh/tutorials/kic/deploy-with-kic/) for more details. Requires `controller.nginxplus`. | false |
+|`nginxServiceMesh.enableEgress` | Enable NGINX Service Mesh workloads to route egress traffic through the Ingress Controller. See the NGINX Service Mesh [docs](https://docs.nginx.com/nginx-service-mesh/tutorials/kic/deploy-with-kic/#enabling-egress) for more details. Requires `nginxServiceMesh.enable`. | false |
 {{% /table %}}
 
 ## Notes
 * The values-icp.yaml file is used for deploying the Ingress Controller on IBM Cloud Private. See the [blog post](https://www.nginx.com/blog/nginx-ingress-controller-ibm-cloud-private/) for more details.
+* The values-nsm.yaml file is used for deploying the Ingress Controller with NGINX Service Mesh. See the NGINX Service Mesh [docs](https://docs.nginx.com/nginx-service-mesh/tutorials/kic/deploy-with-kic/) for more details.

--- a/hack/common-release-prep.sh
+++ b/hack/common-release-prep.sh
@@ -24,7 +24,10 @@ FILES_TO_UPDATE_IC_VERSION=(
     deployments/helm-chart/values.yaml
 )
 
-FILE_TO_UPDATE_HELM_CHART_VERSION=(deployments/helm-chart/Chart.yaml)
+FILE_TO_UPDATE_HELM_CHART_VERSION=(
+    deployments/helm-chart/Chart.yaml
+    deployments/helm-chart/README.md
+)
 
 DOCS_TO_UPDATE_FOLDER=docs/content
 
@@ -35,6 +38,22 @@ helm_chart_version=$4
 
 sed -i "" "s/$prev_ic_version/$ic_version/g" ${FILES_TO_UPDATE_IC_VERSION[*]}
 sed -i "" "s/$prev_helm_chart_version/$helm_chart_version/g" ${FILE_TO_UPDATE_HELM_CHART_VERSION[*]}
+
+# copy the helm chart README to the docs
+{
+    sed -n '1,10p' docs/content/installation/installation-with-helm.md
+    sed -n '3,$p' deployments/helm-chart/README.md
+} >file2.new && mv file2.new docs/content/installation/installation-with-helm.md
+
+sed -i '' '/^|Parameter | Description | Default |/i\
+{{% table %}}\
+' docs/content/installation/installation-with-helm.md
+
+line_number=$(grep -n -e "|" docs/content/installation/installation-with-helm.md | tail -n 1 | cut -d : -f 1)
+
+sed -i '' "${line_number}a\\
+{{% /table %}}
+" docs/content/installation/installation-with-helm.md
 
 # update repo CHANGELOG
 sed -i "" "1r hack/repo-changelog-template.txt" CHANGELOG.md


### PR DESCRIPTION
The Helm docs on the website are out of date. This PR updates the docs and adds to the release scripts to automate the process. The script will copy `deployments/helm-chart/README.md` to `docs/content/installation/installation-with-helm.md` and add the necessary tags for Hugo to work.
