### PR TITLE
Update to use context in metadata-action

### DIFF
--- a/.github/workflows/build-oss.yml
+++ b/.github/workflows/build-oss.yml
@@ -12,9 +12,6 @@ on:
       tag:
         required: false
         type: string
-      sha_long:
-        required: false
-        type: string
 
 defaults:
   run:
@@ -101,6 +98,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e # v4.4.0
         with:
+          context: ${{ inputs.tag != '' && 'git' || 'workflow' }}
           images: |
             name=nginx/nginx-ingress
             name=ghcr.io/nginxinc/kubernetes-ingress
@@ -121,7 +119,6 @@ jobs:
             org.opencontainers.image.description=NGINX Ingress Controller for Kubernetes
             org.opencontainers.image.documentation=https://docs.nginx.com/nginx-ingress-controller
             org.opencontainers.image.vendor=NGINX Inc <kubernetes@nginx.com>
-            org.opencontainers.image.revision=${{ inputs.sha_long != '' && inputs.sha_long || github.sha }}
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/main/README.md
             io.artifacthub.package.logo-url=https://docs.nginx.com/nginx-ingress-controller/images/icons/NGINX-Ingress-Controller-product-icon.svg
             io.artifacthub.package.maintainers=[{"name":"NGINX Inc","email":"kubernetes@nginx.com"}]
@@ -178,7 +175,6 @@ jobs:
     needs: build
     uses: ./.github/workflows/updates-notification.yml
     with:
-      sha_long: ${{ inputs.sha_long }}
       tag: ${{ inputs.tag }}
       version: ${{ needs.build.outputs.version }}
       image_digest: ${{ needs.build.outputs.image_digest }}

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -2,7 +2,7 @@ name: Update Docker Images
 
 on:
   schedule:
-    - cron: '0 1 * * *' # run every day at 01:00 UTC
+    - cron: "0 1 * * *" # run every day at 01:00 UTC
   workflow_dispatch:
 
 defaults:
@@ -14,15 +14,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   variables:
     name: Get versions of base images
     runs-on: ubuntu-22.04
     outputs:
       kic-tag: ${{ steps.kic.outputs.tag }}
       versions: ${{ steps.versions.outputs.matrix }}
-      sha_short: ${{ steps.vars.outputs.sha_short }}
-      sha_long: ${{ steps.vars.outputs.sha_long }}
       k8s_version: ${{ steps.vars.outputs.k8s_version }}
     steps:
       - name: Checkout Repository
@@ -48,8 +45,6 @@ jobs:
       - name: Set other variables
         id: vars
         run: |
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "sha_long=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "k8s_version=$(grep -m1 'FROM kindest/node' <tests/docker/Dockerfile | awk -F'[:v]' '{print $3}')" >> $GITHUB_OUTPUT
 
   check:
@@ -163,7 +158,6 @@ jobs:
       platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
       image: debian
       tag: ${{ needs.variables.outputs.kic-tag }}
-      sha_long: ${{ needs.variables.outputs.sha_long }}
     secrets: inherit
     if: ${{ needs.check.outputs.needs-updating-debian == 'true' }}
 
@@ -175,7 +169,6 @@ jobs:
       platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
       image: alpine
       tag: ${{ needs.variables.outputs.kic-tag }}
-      sha_long: ${{ needs.variables.outputs.sha_long }}
     secrets: inherit
     if: ${{ needs.check.outputs.needs-updating-alpine == 'true' }}
 
@@ -187,6 +180,5 @@ jobs:
       platforms: linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
       image: ubi
       tag: ${{ needs.variables.outputs.kic-tag }}
-      sha_long: ${{ needs.variables.outputs.sha_long }}
     secrets: inherit
     if: ${{ needs.check.outputs.needs-updating-ubi == 'true' }}

--- a/.github/workflows/updates-notification.yml
+++ b/.github/workflows/updates-notification.yml
@@ -9,9 +9,6 @@ on:
       version:
         required: true
         type: string
-      sha_long:
-        required: true
-        type: string
       image_digest:
         required: true
         type: string
@@ -28,13 +25,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
-          ref: ${{ inputs.sha_long }}
+          ref: ${{ inputs.tag }}
       - name: Get variables for Slack
         id: slack
         run: |
           echo "message=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
           echo "date=$(date +%s)" >> $GITHUB_OUTPUT
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "sha_long=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Send Notification
         uses: 8398a7/action-slack@fbd6aa58ba854a740e11a35d0df80cb5d12101d8 # v3.15.1
         with:
@@ -64,7 +62,7 @@ jobs:
                 },
                 {
                   title: "Commit Hash",
-                  value: `<https://github.com/${{ github.repository }}/commit/${{ inputs.sha_long }}|${{ steps.slack.outputs.sha_short }}>`,
+                  value: `<https://github.com/${{ github.repository }}/commit/${{ steps.slack.outputs.sha_long }}|${{ steps.slack.outputs.sha_short }}>`,
                   short: true
                 }],
                 footer: "Update DockerHub Image",


### PR DESCRIPTION
### Proposed changes

`docker/metadata-action` now supports setting the context for generating the metadata.
When the workflow runs to update the docker images, we checkout the `tag` and the action can now read info like the `sha` from the appropriate context.

