### PR TITLE
Use OIDC to login to GCR

### DIFF
--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -51,12 +51,21 @@ jobs:
       - name: Docker Buildx
         uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
 
-      - name: GCR Login
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@e8df18b60c5dd38ba618c121b779307266153fbf # v1.1.0
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+        if: github.event_name != 'pull_request'
+
+      - name: Login to GCR
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GCR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
         if: github.event_name != 'pull_request'
 
       - name: Configure AWS Credentials


### PR DESCRIPTION
### Proposed changes
Similarly too #3740 this removes static credentials and uses OIDC to login to GCR.
