### PR TITLE
indent to annotations key in leader-elec cm

### DIFF
--- a/deployments/helm-chart/templates/controller-leader-election-configmap.yaml
+++ b/deployments/helm-chart/templates/controller-leader-election-configmap.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nginx-ingress.labels" . | nindent 4 }}
-  {{- if .Values.controller.reportIngressStatus.annotations }}
-annotations:
-  {{ toYaml .Values.controller.reportIngressStatus.annotations | indent 4 }}
-  {{- end }}
-  {{- end }}
+{{- if .Values.controller.reportIngressStatus.annotations }}
+  annotations:
+{{ toYaml .Values.controller.reportIngressStatus.annotations | indent 4 }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
### Proposed changes
- Add correct indentation to `controller-leader-election` configmap helm template

Under current implementation `helm install/upgrade `throws a warning when `reportIngressStatus.annotations` is set in values.yaml
```
W0503 10:44:02.820672   62266 warnings.go:70] unknown field "annotations"
```
### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
