### PR TITLE
Reverse order of NAPDOS maxDaemons and maxWorkers in Helm chart

### DIFF
--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -171,8 +171,8 @@ spec:
           - -enable-app-protect-dos={{ .Values.controller.appprotectdos.enable }}
   {{- if .Values.controller.appprotectdos.enable }}
           - -app-protect-dos-debug={{ .Values.controller.appprotectdos.debug }}
-          - -app-protect-dos-max-daemons={{ .Values.controller.appprotectdos.maxWorkers }}
-          - -app-protect-dos-max-workers={{ .Values.controller.appprotectdos.maxDaemons }}
+          - -app-protect-dos-max-daemons={{ .Values.controller.appprotectdos.maxDaemons }}
+          - -app-protect-dos-max-workers={{ .Values.controller.appprotectdos.maxWorkers }}
           - -app-protect-dos-memory={{ .Values.controller.appprotectdos.memory }}
   {{ end }}
           - -nginx-configmaps=$(POD_NAMESPACE)/{{ include "nginx-ingress.configName" . }}

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -176,8 +176,8 @@ spec:
           - -enable-app-protect-dos={{ .Values.controller.appprotectdos.enable }}
 {{- if .Values.controller.appprotectdos.enable }}
           - -app-protect-dos-debug={{ .Values.controller.appprotectdos.debug }}
-          - -app-protect-dos-max-daemons={{ .Values.controller.appprotectdos.maxWorkers }}
-          - -app-protect-dos-max-workers={{ .Values.controller.appprotectdos.maxDaemons }}
+          - -app-protect-dos-max-daemons={{ .Values.controller.appprotectdos.maxDaemons }}
+          - -app-protect-dos-max-workers={{ .Values.controller.appprotectdos.maxWorkers }}
           - -app-protect-dos-memory={{ .Values.controller.appprotectdos.memory }}
 {{ end }}
           - -nginx-configmaps=$(POD_NAMESPACE)/{{ include "nginx-ingress.configName" . }}


### PR DESCRIPTION
### Proposed changes
The values of `-app-protect-dos-max-daemons` and `-app-protect-dos-max-workers` were reversed in the Helm chart templates - this commit rectifies the issue.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
