### PR TITLE
Specify `runAsNonRoot` in `daemon-set` manifests

### DIFF
--- a/deployments/daemon-set/nginx-ingress.yaml
+++ b/deployments/daemon-set/nginx-ingress.yaml
@@ -63,6 +63,7 @@ spec:
           allowPrivilegeEscalation: false
 #          readOnlyRootFilesystem: true
           runAsUser: 101 #nginx
+          runAsNonRoot: true
           capabilities:
             drop:
             - ALL

--- a/deployments/daemon-set/nginx-plus-ingress.yaml
+++ b/deployments/daemon-set/nginx-plus-ingress.yaml
@@ -63,6 +63,7 @@ spec:
           allowPrivilegeEscalation: false
 #          readOnlyRootFilesystem: true
           runAsUser: 101 #nginx
+          runAsNonRoot: true
           capabilities:
             drop:
             - ALL


### PR DESCRIPTION
### Proposed changes

This is a no-op change. It aligns the `daemon-set` manifests to match the `deployment` manifests. Both of these currently specify an explicit user ID to run as, therefore the container is guaranteed to be run as non-root.

This `runAsNonRoot: true` instruction would come in as important if the chart no longer specifies `runAsUser`, and someone is packaging their own image without a USER directive in the Dockerfile. Removing the `runAsUser` parameter could be useful as to allow OpenShift to override the UID, in a later change.

This PR aligns the `deployments/daemon-set/` files to match all following related files:

- [`deployments/deployment/nginx-ingress.yaml`](https://github.com/nginxinc/kubernetes-ingress/blob/1407c3adf5b466cc294fa40cb2ef3fb6b827e7b3/deployments/deployment/nginx-ingress.yaml#L65)
- [`deployments/deployment/nginx-plus-ingress.yaml`](https://github.com/nginxinc/kubernetes-ingress/blob/1407c3adf5b466cc294fa40cb2ef3fb6b827e7b3/deployments/deployment/nginx-plus-ingress.yaml#L67)
- [`deployments/helm-chart/templates/controller-daemonset.yaml`](https://github.com/nginxinc/kubernetes-ingress/blob/5d56f7109596cd2b66ca55f1e70edf8815038abd/deployments/helm-chart/templates/controller-daemonset.yaml#L122)
- [`deployments/helm-chart/templates/controller-deployment.yaml`](https://github.com/nginxinc/kubernetes-ingress/blob/5d56f7109596cd2b66ca55f1e70edf8815038abd/deployments/helm-chart/templates/controller-deployment.yaml#L129)

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
