### PR TITLE
Remove explicit `fsGroup` definition

### DIFF
--- a/deployments/daemon-set/nginx-ingress.yaml
+++ b/deployments/daemon-set/nginx-ingress.yaml
@@ -22,7 +22,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-#        fsGroup: 101 #nginx
 #      volumes:
 #      - name: nginx-etc
 #        emptyDir: {}

--- a/deployments/daemon-set/nginx-plus-ingress.yaml
+++ b/deployments/daemon-set/nginx-plus-ingress.yaml
@@ -22,7 +22,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-#        fsGroup: 101 #nginx
 #      volumes:
 #      - name: nginx-etc
 #        emptyDir: {}

--- a/deployments/deployment/nginx-ingress.yaml
+++ b/deployments/deployment/nginx-ingress.yaml
@@ -23,7 +23,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-#        fsGroup: 101 #nginx
 #      volumes:
 #      - name: nginx-etc
 #        emptyDir: {}

--- a/deployments/deployment/nginx-plus-ingress.yaml
+++ b/deployments/deployment/nginx-plus-ingress.yaml
@@ -23,7 +23,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-#        fsGroup: 101 #nginx
 #      volumes:
 #      - name: nginx-etc
 #        emptyDir: {}

--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -42,9 +42,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-{{- if .Values.controller.readOnlyRootFilesystem }}
-        fsGroup: 101 #nginx
-{{- end }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
 {{- if .Values.controller.nodeSelector }}
       nodeSelector:

--- a/deployments/helm-chart/templates/controller-deployment.yaml
+++ b/deployments/helm-chart/templates/controller-deployment.yaml
@@ -80,9 +80,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-{{- if .Values.controller.readOnlyRootFilesystem }}
-        fsGroup: 101 #nginx
-{{- end }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}

--- a/docs/content/configuration/security.md
+++ b/docs/content/configuration/security.md
@@ -60,10 +60,6 @@ When using manifests instead of Helm, uncomment the following sections of the de
 Refer to the below code-block for guidance:
 
 ```
-#        fsGroup: 101 #nginx
-.
-.
-.
 #      volumes:
 #      - name: nginx-etc
 #        emptyDir: {}


### PR DESCRIPTION
### Proposed changes

There is no use-case that is relevant for enforcing the `fsGroup` as the default user's group. Our `nginx` user will already have access to the volumes being created, as they are made with `g+rwx`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
