### PR TITLE
Update GoReleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -93,36 +93,38 @@ builds:
     tags:
       - aws
 
+changelog:
+  skip: true
+
 archives:
   - id: kubernetes-ingress
     builds: [kubernetes-ingress]
 
-changelog:
-  skip: true
-
-checksum:
-  name_template: 'checksums.txt'
-
 sboms:
   - artifacts: archive
     ids: [kubernetes-ingress]
+    documents:
+      - "${artifact}.spdx.json"
 
 release:
   ids: [kubernetes-ingress]
   extra_files:
-    - glob: ./dist/**.sbom
+    - glob: ./dist/**.spdx.json
 
 blobs:
   - provider: azblob
     bucket: '{{.Env.AZURE_BUCKET_NAME}}'
     extra_files:
-      - glob: ./dist/**.sbom
-
-milestones:
-  - close: true
+      - glob: ./dist/**.spdx.json
 
 announce:
   slack:
     enabled: true
     channel: '#announcements'
     message_template: 'NGINX Ingress Controller {{ .Tag }} is out! Check it out: {{ .ReleaseURL }}'
+
+milestones:
+  - close: true
+
+snapshot:
+  name_template: 'edge'

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 .PHONY: build-goreleaser
 build-goreleaser: ## Build Ingress Controller binary using GoReleaser
 	@goreleaser -v || (code=$$?; printf "\033[0;31mError\033[0m: there was a problem with GoReleaser. Follow the docs to install it https://goreleaser.com/install\n"; exit $$code)
-	GOOS=linux GOPATH=$(shell go env GOPATH) GOARCH=$(ARCH) goreleaser build --rm-dist --debug --snapshot --id kubernetes-ingress --single-target
+	GOOS=linux GOPATH=$(shell go env GOPATH) GOARCH=$(ARCH) goreleaser build --clean --debug --snapshot --id kubernetes-ingress --single-target
 
 .PHONY: debian-image
 debian-image: build ## Create Docker image for Ingress Controller (Debian)


### PR DESCRIPTION
### Proposed changes
Changes:
- Updates the configuration to remove '--rm-dist' deprecated flag
- Changes extension of SBOM artifacts from .sbom to spdx.json to better represent the content of the file (.sbom is an extension that devs at GoReleaser came up with and not standard)
- Adds section to override the version that is injected in the binary for snapshot builds. These are all the builds that are not an official release.
