### PR TITLE
Update labeler to official action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,29 @@
+change:
+  - head-branch: ['^change/']
+
 enhancement:
-- branch: ['feature/**', 'feat/**', 'enhancement/**', 'enh/**']
+  - head-branch: ['^feature/', '^feat/', '^enhancement/', '^enh/']
 
 bug:
-- branch: ['fix/**', 'bug/**']
+  - head-branch: ['^fix/', '^bug/']
 
 chore:
-- branch: ['chore/**']
+  - head-branch: ['^chore/']
 
 tests:
-- branch: ['tests/**', 'test/**']
-- tests/**/*
-- perf-tests/**/*
+  - any:
+      - head-branch: ['^tests/', '^test/']
+      - changed-files: ['tests/**/*', 'perf-tests/**/*']
+  - all:
+      - changed-files: ['!tests/requirements.txt', '!perf-tests/requirements.txt']
 
 documentation:
-- branch: ['docs/**', 'doc/**']
-- '**/*.md'
+  - head-branch: ['^docs/', '^doc/']
+  - changed-files: '**/*.md'
 
 dependencies:
-- branch: ['deps/**', 'dep/**', 'dependabot/**']
-- go.mod
-- go.sum
+  - head-branch: ['^deps/', '^dep/', '^dependabot/', 'pre-commit-ci-update-config']
+  - changed-files: ['go.mod', 'go.sum']
 
 helm_chart:
-- deployments/helm-chart/**/*
+  - changed-files: ['deployments/helm-chart/**/*']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,7 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
-permissions:  # added using https://github.com/step-security/secure-workflows
+permissions:
   contents: read
 
 jobs:
@@ -10,8 +10,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: joshdales/labeler@7b1327b4c44a8794dfc7573d60637cd60ce4b697 # if https://github.com/actions/labeler/pull/203 is merged, use the official action actions/labeler
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@4f052778de9a9b80cb16cfb9079b02287285a4cb # v5.0.0-alpha.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Proposed changes
Changes:
- Updates the version of the labeler to the official actions/labeler
- Updates the config to the new format
- Adds missing `change` label to the config
- Adds PRs from pre-commit to the`dependencies` label
- Adds new logic (now possible with the new format) that prevents from adding the `test` label in dependency updates
