### PR TITLE
Read Prometheus key/cert from memory

### DIFF
--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -1,23 +1,22 @@
 package metrics
 
 import (
+	"context"
+	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
+	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/golang/glog"
-	config "github.com/nginxinc/kubernetes-ingress/internal/configs"
-	"github.com/nginxinc/kubernetes-ingress/internal/nginx"
 	prometheusClient "github.com/nginxinc/nginx-prometheus-exporter/client"
 	nginxCollector "github.com/nginxinc/nginx-prometheus-exporter/collector"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	api_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
-
-// metricsEndpoint is the path where prometheus metrics will be exposed
-const metricsEndpoint = "/metrics"
 
 // NewNginxMetricsClient creates an NginxClient to fetch stats from NGINX over an unix socket
 func NewNginxMetricsClient(httpClient *http.Client) (*prometheusClient.NginxClient, error) {
@@ -25,75 +24,109 @@ func NewNginxMetricsClient(httpClient *http.Client) (*prometheusClient.NginxClie
 }
 
 // RunPrometheusListenerForNginx runs an http server to expose Prometheus metrics for NGINX
-func RunPrometheusListenerForNginx(port int, client *prometheusClient.NginxClient, registry *prometheus.Registry, constLabels map[string]string, prometheusSecret *api_v1.Secret) {
+func RunPrometheusListenerForNginx(port int, client *prometheusClient.NginxClient, registry *prometheus.Registry, constLabels map[string]string, prometheusSecret *v1.Secret) {
 	registry.MustRegister(nginxCollector.NewNginxCollector(client, "nginx_ingress_nginx", constLabels))
 	runServer(strconv.Itoa(port), registry, prometheusSecret)
 }
 
 // RunPrometheusListenerForNginxPlus runs an http server to expose Prometheus metrics for NGINX Plus
-func RunPrometheusListenerForNginxPlus(port int, nginxPlusCollector prometheus.Collector, registry *prometheus.Registry, prometheusSecret *api_v1.Secret) {
+func RunPrometheusListenerForNginxPlus(port int, nginxPlusCollector prometheus.Collector, registry *prometheus.Registry, prometheusSecret *v1.Secret) {
 	registry.MustRegister(nginxPlusCollector)
 	runServer(strconv.Itoa(port), registry, prometheusSecret)
 }
 
-func runServer(port string, registry prometheus.Gatherer, prometheusSecret *api_v1.Secret) {
-	http.Handle(metricsEndpoint, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+// runServer starts the metrics server.
+func runServer(port string, registry prometheus.Gatherer, prometheusSecret *v1.Secret) {
+	addr := fmt.Sprintf(":%s", port)
+	ms, err := NewMetricsServer(addr, registry, prometheusSecret)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	glog.Infof("Starting prometheus listener on: %s/metrics", addr)
+	glog.Fatal(ms.ListenAndServe())
+}
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		_, err := w.Write([]byte(`<html>
+// MetricsServer holds information about NIC metrics server.
+type MetricsServer struct {
+	Server   *http.Server
+	URL      string
+	Registry prometheus.Gatherer
+}
+
+// NewMetricsServer creates HTTP server for serving NIC metrics for Prometheus.
+//
+// Metrics are exposed on the `/metrics` endpoint.
+func NewMetricsServer(addr string, registry prometheus.Gatherer, secret *v1.Secret) (*MetricsServer, error) {
+	ms := MetricsServer{
+		Server: &http.Server{
+			Addr:         addr,
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		},
+		URL:      fmt.Sprintf("http://%s/", addr),
+		Registry: registry,
+	}
+	// Secrets are read from K8s API. If the secret for Prometheus is present
+	// we configure Metrics Server with the key and cert.
+	if secret != nil {
+		tlsCert, err := makeCert(secret)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create TLS cert: %w", err)
+		}
+		ms.Server.TLSConfig = &tls.Config{
+			Certificates: []tls.Certificate{tlsCert},
+			MinVersion:   tls.VersionTLS12,
+		}
+		ms.URL = fmt.Sprintf("https://%s/", addr)
+	}
+	return &ms, nil
+}
+
+// Home is a handler for serving metrics home page.
+func (ms *MetricsServer) Home(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte(`<html>
 			<head><title>NGINX Ingress Controller</title></head>
 			<body>
 			<h1>NGINX Ingress Controller</h1>
 			<p><a href='/metrics'>Metrics</a></p>
 			</body>
 			</html>`))
-		if err != nil {
-			glog.Warningf("Error while sending a response for the '/' path: %v", err)
-		}
-	})
-	address := fmt.Sprintf(":%v", port)
-	glog.Infof("Starting Prometheus listener on: %v%v", address, metricsEndpoint)
-	if prometheusSecret == nil {
-		glog.Fatal("Error in Prometheus listener server: ", http.ListenAndServe(address, nil))
-	} else {
-		// Unfortunately, http.ListenAndServeTLS() takes a filename instead of cert/key data, so we
-		// Write the cert and key to a temporary file. We create a unique file name to prevent collisions.
-		certFileName := "nginx-prometheus.cert"
-		keyFileName := "nginx-prometheus.key"
-		certFile, err := createTLSFile(prometheusSecret.Data[api_v1.TLSCertKey], certFileName)
-		if err != nil {
-			glog.Fatal("failed to create cert file for prometheus: %w", err)
-		}
-
-		keyFile, err := createTLSFile(prometheusSecret.Data[api_v1.TLSPrivateKeyKey], keyFileName)
-		if err != nil {
-			glog.Fatal("failed to create key file for prometheus: %w", err)
-		}
-
-		glog.Fatal("Error in Prometheus listener server: ", http.ListenAndServeTLS(address, certFile.Name(), keyFile.Name(), nil))
+	if err != nil {
+		glog.Errorf("error while sending a response for the '/' path: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
 	}
 }
 
-func createTLSFile(data []byte, name string) (*os.File, error) {
-	_, err := os.Stat(config.DefaultSecretPath)
-	if err != nil {
-		return nil, fmt.Errorf("got error %w when attempting access %s", err, config.DefaultSecretPath)
+// ListenAndServe starts metrics server.
+func (ms *MetricsServer) ListenAndServe() error {
+	mux := chi.NewRouter()
+	mux.Get("/", ms.Home)
+	mux.Handle("/metrics", promhttp.HandlerFor(ms.Registry, promhttp.HandlerOpts{}))
+	ms.Server.Handler = mux
+	if ms.Server.TLSConfig != nil {
+		return ms.Server.ListenAndServeTLS("", "")
 	}
+	return ms.Server.ListenAndServe()
+}
 
-	f, err := os.CreateTemp(config.DefaultSecretPath, name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file: %w", err)
+// Shutdown shuts down metrics server.
+func (ms *MetricsServer) Shutdown(ctx context.Context) error {
+	return ms.Server.Shutdown(ctx)
+}
+
+// makeCert takes K8s Secret and returns tls Certificate for the server.
+// It errors if either cert, or key are not present in the Secret.
+func makeCert(s *v1.Secret) (tls.Certificate, error) {
+	cert, ok := s.Data[v1.TLSCertKey]
+	if !ok {
+		return tls.Certificate{}, errors.New("missing tls cert")
 	}
-
-	err = f.Chmod(nginx.TLSSecretFileMode)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't change the mode of the temp file %v: %w", f.Name(), err)
+	key, ok := s.Data[v1.TLSPrivateKeyKey]
+	if !ok {
+		return tls.Certificate{}, errors.New("missing tls key")
 	}
-
-	_, err = f.Write(data)
-	if err != nil {
-		return f, fmt.Errorf("failed to write to temp file: %w", err)
-	}
-
-	return f, nil
+	return tls.X509KeyPair(cert, key)
 }


### PR DESCRIPTION
### Proposed changes

This PR addresses the following:
- cert and key files for metrics server are not stored on container's FS (I/O ops is eliminated)
- tls cert for metrics server is created immediately from prometheus k8s cert when the metrics server starts
- the mechanism is exactly the same as introduced in the `service insight` server

Tested manually on a local kind cluster.
Existing Python integration tests cover the functionality.


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
