### PR TITLE
Make fullnameOverride override

### DIFF
--- a/deployments/helm-chart/templates/_helpers.tpl
+++ b/deployments/helm-chart/templates/_helpers.tpl
@@ -68,8 +68,12 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "nginx-ingress.selectorLabels" -}}
+{{- if .Values.selectorLabelsOverride }}
+{{- .Values.selectorLabelsOverride | toYaml }}
+{{- else }}
 app.kubernetes.io/name: {{ include "nginx-ingress.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end}}
 {{- end }}
 
 {{/*

--- a/deployments/helm-chart/templates/_helpers.tpl
+++ b/deployments/helm-chart/templates/_helpers.tpl
@@ -30,7 +30,11 @@ Create a default fully qualified controller name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nginx-ingress.controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride -}}
+{{- else }}
 {{- printf "%s-%s" (include "nginx-ingress.fullname" .) .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Before 3.0.0 all resources were named `nginx-ingress`.  We need to keep that functionality. 

The fullnameOverride currently will use the fullNameOverride plus nginx-ingress or whatever .Values.controller.name is set to. The final result looks like `nginx-ingress-something`. The fullNameOverride should be the final name set and should not be modified after.

Since the deployment or daemonset matchLabels cannot be updated there needs to be a way to revert to the old labels. Adding selectorLabelsOverride allows a user to use the old labels and not force a recreation of the deployment/daemonset.

### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
