### PR TITLE
Create tags for OSS images on release branch

### DIFF
--- a/.github/workflows/build-oss.yml
+++ b/.github/workflows/build-oss.yml
@@ -110,6 +110,7 @@ jobs:
           tags: |
             type=edge
             type=ref,event=pr
+            type=ref,event=branch,enable=${{ startsWith(github.ref, 'refs/heads/release-') }}
             type=schedule,enable=${{ inputs.tag == '' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
### Proposed changes
Enables creating a tag for the OSS Docker images in release branches