### PR TITLE
Update dependabot config after refactor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,11 +25,6 @@ updates:
     schedule:
       interval: weekly
 
-  - package-ecosystem: pip
-    directory: /perf-tests
-    schedule:
-      interval: weekly
-
   - package-ecosystem: gomod
     directory: /docs
     schedule:


### PR DESCRIPTION
### Proposed changes
The requirements file for perf-tests was removed in https://github.com/nginxinc/kubernetes-ingress/pull/4085 so we need to remove it from the config file.
