### PR TITLE
Added if to hostport on hostnetwork config value

### DIFF
--- a/deployments/helm-chart/templates/controller-daemonset.yaml
+++ b/deployments/helm-chart/templates/controller-daemonset.yaml
@@ -87,10 +87,14 @@ spec:
         ports:
         - name: http
           containerPort: 80
+{{- if .Values.controller.hostNetwork }}
           hostPort: 80
+{{- end }}
         - name: https
           containerPort: 443
+{{- if .Values.controller.hostNetwork }}
           hostPort: 443
+{{- end }}
 {{ if .Values.controller.customPorts }}
 {{ toYaml .Values.controller.customPorts | indent 8 }}
 {{ end }}


### PR DESCRIPTION
### Proposed changes
The chart inserts "HostPort" in the daemonset also when "HostNetwork" is setted to "false", do not set hostPort in this case.

Setting the controller.hostNetwork: false should not set hostPort in the deployment or daemonset.
This can be fixed in helm chart, inserting in templates/controller-daemonset.yaml a if statement around the two host port.

Thanks
Stefano