### PR TITLE
Fix permissions in Helm job and Docker update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,7 @@ jobs:
     if: ${{ github.event_name == 'push' && ! startsWith(github.ref, 'refs/heads/release-') }}
     permissions:
       contents: write # for pushing to Helm Charts repository
+      packages: write # for helm to push to GHCR
     steps:
       - name: Checkout Repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -174,6 +174,12 @@ jobs:
       platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
       image: debian
       tag: ${{ needs.variables.outputs.kic-tag }}
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+      id-token: write
+      packages: write
     secrets: inherit
     if: ${{ needs.check.outputs.needs-updating-debian == 'true' }}
 
@@ -185,6 +191,12 @@ jobs:
       platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
       image: alpine
       tag: ${{ needs.variables.outputs.kic-tag }}
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+      id-token: write
+      packages: write
     secrets: inherit
     if: ${{ needs.check.outputs.needs-updating-alpine == 'true' }}
 
@@ -196,5 +208,11 @@ jobs:
       platforms: linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
       image: ubi
       tag: ${{ needs.variables.outputs.kic-tag }}
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+      id-token: write
+      packages: write
     secrets: inherit
     if: ${{ needs.check.outputs.needs-updating-ubi == 'true' }}


### PR DESCRIPTION
### Proposed changes

- The helm job didn't have the permissions needed to push the chart to GHCR
- The calls to the re-usable workflow didn't pass permissions