### PR TITLE
Sign checksum with cosign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       release-url: ${{ steps.release-notes.outputs.release-url }}
     permissions:
       contents: write # for lucacome/draft-release and goreleaser/goreleaser-action to manage releases
+      id-token: write # for goreleaser/goreleaser-action to sign artifacts
     steps:
       - name: Checkout Repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -100,7 +101,11 @@ jobs:
 
       - name: Download Syft
         uses: anchore/sbom-action/download-syft@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1 # v0.14.3
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref_type == 'tag'
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3.1.1
+        if: github.ref_type == 'tag'
 
       - name: Create/Update Draft
         uses: lucacome/draft-release@f6dc37dcdf44be100a649b72c62c628776750190 # v0.2.2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -117,6 +117,18 @@ blobs:
     extra_files:
       - glob: ./dist/**.spdx.json
 
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    certificate: '${artifact}.pem'
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+      - "--yes"
+
 announce:
   slack:
     enabled: true


### PR DESCRIPTION
### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to
Adds config to sign artifacts. Since the checksum contains the SHAs of the artifacts, signing the checksums is enough to ensure that the artifacts were not modified.

GoReleaser uses cosign to sign the artifact and uploads .sig and .pem to the release.