### PR TITLE
Add docs team as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @nginxinc/kic
+/docs/ @nginxinc/kic @nginxinc/nginx-docs


### PR DESCRIPTION
### Proposed changes

Adds @nginxinc/nginx-docs as codeowners for the docs.
