### PR TITLE
fixes commit SHA in docs/go.sum

### DIFF
--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/nginxinc/nginx-hugo-theme v0.37.0 h1:bRxwtzpgud0Th4+wvx5To+B3f1j8WKP4HcV6leoCNSQ=
+github.com/nginxinc/nginx-hugo-theme v0.37.0 h1:kiWaP2RvbxFLUnPnS5/vOi4XB4zc2YCYlbHlnr0K2xA=
 github.com/nginxinc/nginx-hugo-theme v0.37.0/go.mod h1:DPNgSS5QYxkjH/BfH4uPDiTfODqWJ50NKZdorguom8M=


### PR DESCRIPTION
### Proposed changes

- The release tag for nginx-hugo-theme v0.37.0 was deleted and re-created, which caused hugo to return a security error when downloading the theme. Because I know the DocOps team deleted and re-created the release, I replaced the old SHA in the go.sum file with the correct, newer one to resolve the issue.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
