### PR TITLE
Add HPA Custom Behavior

### DIFF
--- a/charts/nginx-ingress/README.md
+++ b/charts/nginx-ingress/README.md
@@ -313,6 +313,7 @@ The following tables lists the configurable parameters of the NGINX Ingress Cont
 |`controller.minReadySeconds` | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
 |`controller.autoscaling.enabled` | Enables HorizontalPodAutoscaling. | false |
 |`controller.autoscaling.annotations` | The annotations of the Ingress Controller HorizontalPodAutoscaler. | {} |
+|`controller.autoscaling.behavior` | Behavior configuration for the HPA. | {} |
 |`controller.autoscaling.minReplicas` | Minimum number of replicas for the HPA. | 1 |
 |`controller.autoscaling.maxReplicas` | Maximum number of replicas for the HPA. | 3 |
 |`controller.autoscaling.targetCPUUtilizationPercentage` | The target CPU utilization percentage. | 50 |

--- a/charts/nginx-ingress/templates/controller-hpa.yaml
+++ b/charts/nginx-ingress/templates/controller-hpa.yaml
@@ -17,6 +17,10 @@ spec:
     name: {{ include "nginx-ingress.controller.fullname" . }}
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
+{{- if .Values.controller.autoscaling.behavior }}
+  behavior:
+{{ toYaml .Values.controller.autoscaling.behavior | indent 4 }}
+{{- end }}
   metrics:
     {{- if .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -153,6 +153,8 @@ controller:
     targetCPUUtilizationPercentage: 50
     ## The target memory utilization percentage.
     targetMemoryUtilizationPercentage: 50
+    ## Custom behavior policies
+    behavior: {}
 
   ## The resources of the Ingress Controller pods.
   resources:


### PR DESCRIPTION
### Proposed changes

There is no issue for this pull request. It is a very basic PR.
It adds the ability to define `spec.behavior` for an `HorizontalPodAutoscaler`.
- Defines it in the `values.yaml` file; defaults to empty.
- References it in the controller hpa template.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
