### PR TITLE
Use regexp2 pkg for path validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.42
 	github.com/aws/aws-sdk-go-v2/service/marketplacemetering v1.16.0
 	github.com/cert-manager/cert-manager v1.13.1
+	github.com/dlclark/regexp2 v1.10.0
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/glog v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
+github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/dlclark/regexp2"
 	"github.com/nginxinc/kubernetes-ingress/internal/configs"
 	ap_validation "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/validation"
 	networking "k8s.io/api/networking/v1"
@@ -871,8 +872,11 @@ func validatePath(path string, pathType *networking.PathType, fieldPath *field.P
 	return allErrs
 }
 
+// validateRegexPath validates correctness of the string representing the path.
+//
+// Internally it uses Perl5 compatible regexp2 package.
 func validateRegexPath(path string, fieldPath *field.Path) field.ErrorList {
-	if _, err := regexp.Compile(path); err != nil {
+	if _, err := regexp2.Compile(path, 0); err != nil {
 		return field.ErrorList{field.Invalid(fieldPath, path, fmt.Sprintf("must be a valid regular expression: %v", err))}
 	}
 	if err := ValidateEscapedString(path, "*.jpg", "^/images/image_*.png$"); err != nil {

--- a/internal/k8s/validation_test.go
+++ b/internal/k8s/validation_test.go
@@ -3630,6 +3630,10 @@ func TestValidateRegexPath(t *testing.T) {
 			regexPath: "/[0-9a-z]{4}[0-9]+",
 			msg:       "regexp with curly braces",
 		},
+		{
+			regexPath: "~ ^/coffee/(?!.*\\/latte)(?!.*\\/americano)(.*)",
+			msg:       "regexp with Perl5 regex",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dlclark/regexp2"
 	"github.com/nginxinc/kubernetes-ingress/internal/configs"
 	v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1233,8 +1234,11 @@ func validateRoutePath(path string, fieldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
+// validateRegexPath validates correctness of the string representing the path.
+//
+// Internally it uses Perl5 compatible regexp2 package.
 func validateRegexPath(path string, fieldPath *field.Path) field.ErrorList {
-	if _, err := regexp.Compile(path); err != nil {
+	if _, err := regexp2.Compile(path, 0); err != nil {
 		return field.ErrorList{field.Invalid(fieldPath, path, fmt.Sprintf("must be a valid regular expression: %v", err))}
 	}
 	if err := ValidateEscapedString(path, "*.jpg", "^/images/image_*.png$"); err != nil {

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -1470,6 +1470,10 @@ func TestValidateRegexPath(t *testing.T) {
 			regexPath: "~ [0-9a-z]{4}[0-9]+",
 			msg:       "regexp with curly braces",
 		},
+		{
+			regexPath: "~ ^/coffee/(?!.*\\/latte)(?!.*\\/americano)(.*)",
+			msg:       "regex with backtracking",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Proposed changes

This PR fixes issue #797 and introduces following change:

- paths with regex expressions are verified using `regexp2` [package](https://github.com/dlclark/regexp2). The package implements Perl5 and .NET compatible regex engine


Testing:

Create VS:
```shell
apiVersion: k8s.nginx.org/v1
kind: VirtualServer
metadata:
  name: cafe
  namespace: default
spec:
  host: cafe.example.com
  upstreams:
  - name: tea
    service: tea-svc
    port: 80
  routes:
  - path: /tea
    action:
      pass: tea
  - path: /coffee
    route: default/coffee
```

Create VSR:
```shell
apiVersion: k8s.nginx.org/v1
kind: VirtualServerRoute
metadata:
  name: coffee
  namespace: default
spec:
  host: cafe.example.com
  upstreams:
  - name: latte
    service: latte-svc
    port: 80
  - name: espresso
    service: espresso-svc
    port: 80
  subroutes:
  - path: ~ ^/coffee/latte$ # it's works
    action:
      pass: latte
  - path: ~ ^/coffee/(?!.*\/latte)(?!.*\/americano)(.*) # it isn't working
    action:
      pass: espresso
```

Verify VSR is created and NIC is not reporting errors:

```shell
$ kubectl describe vsr coffee
Name:         coffee
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  k8s.nginx.org/v1
Kind:         VirtualServerRoute
Metadata:
  Creation Timestamp:  2023-10-03T16:34:18Z
  Generation:          1
  Resource Version:    291887
  UID:                 f57cd1fd-d8eb-4864-ba63-f2cb36578b1b
Spec:
  Host:  cafe.example.com
  Subroutes:
    Action:
      Pass:  latte
    Path:    ~ ^/coffee/latte$
    Action:
      Pass:  espresso
    Path:    ~ ^/coffee/(?!.*\/latte)(?!.*\/americano)(.*)
  Upstreams:
    Name:     latte
    Port:     80
    Service:  latte-svc
    Name:     espresso
    Port:     80
    Service:  espresso-svc
Status:
  Message:        Configuration for default/coffee was added or updated
  Reason:         AddedOrUpdated
  Referenced By:
  State:          Valid
Events:
  Type    Reason          Age   From                      Message
  ----    ------          ----  ----                      -------
  Normal  AddedOrUpdated  15s   nginx-ingress-controller  Configuration for default/coffee was added or updated
```

IC logs:
```shell
2023/10/03 16:34:19 [notice] 22#22: signal 29 (SIGIO) received
I1003 16:34:19.046547       1 event.go:298] Event(v1.ObjectReference{Kind:"VirtualServer", Namespace:"default", Name:"cafe", UID:"7f98147e-5127-4cb2-b4ec-5a11e178513c", APIVersion:"k8s.nginx.org/v1", ResourceVersion:"291855", FieldPath:""}): type: 'Normal' reason: 'AddedOrUpdated' Configuration for default/cafe was added or updated
I1003 16:34:19.046746       1 event.go:298] Event(v1.ObjectReference{Kind:"VirtualServerRoute", Namespace:"default", Name:"coffee", UID:"f57cd1fd-d8eb-4864-ba63-f2cb36578b1b", APIVersion:"k8s.nginx.org/v1", ResourceVersion:"291863", FieldPath:""}): type: 'Normal' reason: 'AddedOrUpdated' Configuration for default/coffee was added or updated
I1003 16:34:33.426801       1 leaderelection.go:260] successfully acquired lease nginx-ingress/nginx-ingress-leader-election
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
