### PR TITLE
Issue 4471: Update README linking to correct complete example

### DIFF
--- a/examples/custom-resources/basic-configuration/README.md
+++ b/examples/custom-resources/basic-configuration/README.md
@@ -6,7 +6,7 @@ resource. The application, called cafe, lets you get either tea via the tea serv
 You indicate your drink preference with the URI of your HTTP request: URIs ending with `/tea` get you tea and URIs
 ending with `/coffee` get you coffee.
 
-The example is similar to the [complete example](../../ingress-resources/complete-example/README.md). 
+The example is similar to the [complete example](../../ingress-resources/complete-example/README.md).
 However, instead of the Ingress resource, we use the VirtualServer.
 
 ## Prerequisites

--- a/examples/custom-resources/basic-configuration/README.md
+++ b/examples/custom-resources/basic-configuration/README.md
@@ -6,8 +6,8 @@ resource. The application, called cafe, lets you get either tea via the tea serv
 You indicate your drink preference with the URI of your HTTP request: URIs ending with `/tea` get you tea and URIs
 ending with `/coffee` get you coffee.
 
-The example is similar to the [complete example](../../ingress-resources/complete-example/README.md). However, instead of the
-Ingress resource, we use the VirtualServer.
+The example is similar to the [complete example](../../ingress-resources/complete-example/README.md). 
+However, instead of the Ingress resource, we use the VirtualServer.
 
 ## Prerequisites
 

--- a/examples/custom-resources/basic-configuration/README.md
+++ b/examples/custom-resources/basic-configuration/README.md
@@ -6,7 +6,7 @@ resource. The application, called cafe, lets you get either tea via the tea serv
 You indicate your drink preference with the URI of your HTTP request: URIs ending with `/tea` get you tea and URIs
 ending with `/coffee` get you coffee.
 
-The example is similar to the [complete example](../../examples/complete-example/README.md). However, instead of the
+The example is similar to the [complete example](../../ingress-resources/complete-example/README.md). However, instead of the
 Ingress resource, we use the VirtualServer.
 
 ## Prerequisites


### PR DESCRIPTION
### Proposed changes
The link to the complete-example is broken in the readme at this link: https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/custom-resources/basic-configuration/README.md

The README link to "complete example" now points to: https://github.com/nginxinc/kubernetes-ingress/tree/main/examples/ingress-resources/complete-example

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
