### PR TITLE
Delete the DNSEndpoint resource when VS is deleted & Ratelimit requeues on errors.

### DIFF
--- a/internal/certmanager/cm_controller.go
+++ b/internal/certmanager/cm_controller.go
@@ -40,6 +40,7 @@ import (
 	k8s_nginx "github.com/nginxinc/kubernetes-ingress/pkg/client/clientset/versioned"
 	vsinformers "github.com/nginxinc/kubernetes-ingress/pkg/client/informers/externalversions"
 	listers_v1 "github.com/nginxinc/kubernetes-ingress/pkg/client/listers/configuration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -145,6 +146,11 @@ func (c *CmController) processItem(ctx context.Context, key string) error {
 
 	var vs *conf_v1.VirtualServer
 	vs, err = nsi.vsLister.VirtualServers(namespace).Get(name)
+
+	// VS has been deleted
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
 
 	if err != nil {
 		return err

--- a/internal/externaldns/sync.go
+++ b/internal/externaldns/sync.go
@@ -155,13 +155,16 @@ func buildDNSEndpoint(extdnsLister extdnslisters.DNSEndpointLister, vs *vsapi.Vi
 		return nil, nil, err
 	}
 	var controllerGVK schema.GroupVersionKind = vsGVK
+	ownerRef := *metav1.NewControllerRef(vs, controllerGVK)
+	blockOwnerDeletion := false
+	ownerRef.BlockOwnerDeletion = &blockOwnerDeletion
 
 	dnsEndpoint := &extdnsapi.DNSEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            vs.ObjectMeta.Name,
 			Namespace:       vs.Namespace,
 			Labels:          vs.Labels,
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(vs, controllerGVK)},
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Spec: extdnsapi.DNSEndpointSpec{
 			Endpoints: []*extdnsapi.Endpoint{


### PR DESCRIPTION
### Proposed changes

When a VirtualServer with ExternalDNS enabled is deleted, the corresponding DNSEndpoint resource is not cleaned up. Additionally, we are endlessly re-queuing VS objects with ExternalDNS enabled with errors without rate limiting.
Also, we are not checking if the VS has been deleted before re-queuing, in both the external dns controller, and the cert-manager controller.

This commit rectifies these issues by:
1. Not blocking owner deletion on DNSEndpoints
2. When there is an error processing a DNSEndpoint sync for VirtualServer, the VS is re-added to the queue using rate limiting, with an eventual timeout 
3. When the error processing the item is due to the VS no longer existing, don't return an error and exit quietly.

### Checklist

Closes #4418

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
