### PR TITLE
Ensure Debian Plus starts assigning users from 101

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -70,6 +70,9 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	--mount=type=bind,from=opentracing-lib,target=/tmp/ot/ \
 	apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https \
+	&& sed -i -e '/^FIRST_SYSTEM_UID\s*=/d' -e '/^FIRST_SYSTEM_GID\s*=/d' /etc/adduser.conf \
+	&& echo FIRST_SYSTEM_UID=101 >> /etc/adduser.conf \
+	&& echo FIRST_SYSTEM_GID=101 >> /etc/adduser.conf \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
 	&& DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \
@@ -95,6 +98,9 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	apt-get update \
 	## the code below is duplicated from the debian-plus image because NAP doesn't support debian 12
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https \
+	&& sed -i -e '/^FIRST_SYSTEM_UID\s*=/d' -e '/^FIRST_SYSTEM_GID\s*=/d' /etc/adduser.conf \
+	&& echo FIRST_SYSTEM_UID=101 >> /etc/adduser.conf \
+	&& echo FIRST_SYSTEM_GID=101 >> /etc/adduser.conf \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
 	&& DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \


### PR DESCRIPTION
### Proposed changes

When running `adduser` or `addgroup`, adduser.conf controls various configuration flags. Notably for us, there is `FIRST_SYSTEM_UID` and `FIRST_SYSTEM_GID` which determine what UIDs and GIDs are assigned for system users.

The Nginx images are historically built with UID 101 for `nginx` user. However, Debian 12 cleaned up its image and UID 100 became available. By default, the range `100-999` is used for system users. That is bad for the Nginx image as UID 101 is expected.

This patch simply ensures the first ID used for package install is 101.

Improves #4503.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork