### PR TITLE
update dockerfile for debian N+

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -69,8 +69,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
 	--mount=type=bind,from=opentracing-lib,target=/tmp/ot/ \
 	apt-get update \
-	&& groupadd --system --gid 101 nginx \ 
- 	&& useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx \ 
+	&& groupadd --system --gid 101 nginx \
+ 	&& useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx \
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
@@ -95,8 +95,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
 	--mount=type=bind,from=opentracing-lib,target=/tmp/ot/ \
 	apt-get update \
-	&& groupadd --system --gid 101 nginx \ 
- 	&& useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx \ 
+	&& groupadd --system --gid 101 nginx \
+ 	&& useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx \
 	## the code below is duplicated from the debian-plus image because NAP doesn't support debian 12
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -69,6 +69,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
 	--mount=type=bind,from=opentracing-lib,target=/tmp/ot/ \
 	apt-get update \
+	&& groupadd --system --gid 101 nginx \ 
+ 	&& useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx \ 
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
 	&& curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
@@ -93,6 +95,8 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
 	--mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
 	--mount=type=bind,from=opentracing-lib,target=/tmp/ot/ \
 	apt-get update \
+	&& groupadd --system --gid 101 nginx \ 
+ 	&& useradd --system --gid nginx --no-create-home --home-dir /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx \ 
 	## the code below is duplicated from the debian-plus image because NAP doesn't support debian 12
 	&& apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https \
 	&& curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \


### PR DESCRIPTION
### Proposed changes

Fixes https://github.com/nginxinc/kubernetes-ingress/issues/4503 by adding user explicitly

N+
```
nginx@test-release-nginx-ingress-controller-6b87ddbc7c-6rnpz:/$ cat /etc/passwd
root:x:0:0:root:/root:/bin/bash
.
.
.
nginx:x:101:101:nginx user:/nonexistent:/bin/false
```

N+ with AP
```
                    appprotect.f5.com/app-protect-security-log-destination: /var/log/nginx/dev-waftests.log
                    appprotect.f5.com/app-protect-security-log-enable: True
Events:
  Type    Reason          Age   From                      Message
  ----    ------          ----  ----                      -------
  Normal  AddedOrUpdated  108s  nginx-ingress-controller  Configuration for default/cafe-ingress was added or updated
~/nginx/kubernetes-ingress/charts/nginx-ingress on main ● ● λ keti test-release-nginx-ingress-controller-6d94695fdb-58x25 -- bash     
nginx@test-release-nginx-ingress-controller-6d94695fdb-58x25:/$ ls /var/log/nginx/
access.log  dev-waftests.log  error.log

nginx@test-release-nginx-ingress-controller-6d94695fdb-58x25:/$ cat /etc/passwd
root:x:0:0:root:/root:/bin/bash
.
.
.
nginx:x:101:101:nginx user:/nonexistent:/bin/false
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
