### PR TITLE
Update Makefile references to tests/Dockerfile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,7 @@ KUBE_CONFIG_FOLDER = $${HOME}/.kube
 KIND_KUBE_CONFIG_FOLDER = $${HOME}/.kube/kind
 SHOW_IC_LOGS = no
 PYTEST_ARGS =
-DOCKERFILEPATH = docker/Dockerfile
+DOCKERFILEPATH = Dockerfile
 IP_FAMILY=dual
 
 
@@ -64,7 +64,7 @@ run-tests-in-kind: update-test-kind-config ## Run tests in Kind
 
 .PHONY: create-kind-cluster
 create-kind-cluster: ## Create Kind cluster
-	$(eval KIND_IMAGE=$(shell grep -m1 'FROM kindest/node' <docker/Dockerfile | awk -F'[ ]' '{print $$2}'))
+	$(eval KIND_IMAGE=$(shell grep -m1 'FROM kindest/node' <Dockerfile | awk -F'[ ]' '{print $$2}'))
 	kind create cluster --image $(KIND_IMAGE) --config=<(sed 's/dual/${IP_FAMILY}/' ./ci-files/ci-kind-config.yaml)
 	kind export kubeconfig --kubeconfig $(KIND_KUBE_CONFIG_FOLDER)/config
 


### PR DESCRIPTION
### Proposed changes

Change `tests/Makefile` local references of `tests/Dockerfile` from `docker/Dockerfile` to `Dockerfile`.

Related issue: [4625](https://github.com/nginxinc/kubernetes-ingress/issues/4625)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
