### PR TITLE
Fix additional Helm-related chart versioning drift in documentation

### DIFF
--- a/docs/content/installation/installing-nic/installation-with-helm.md
+++ b/docs/content/installation/installing-nic/installation-with-helm.md
@@ -66,13 +66,13 @@ To install the chart with the release name my-release (my-release is the name th
 - For NGINX:
 
     ```shell
-    helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.18.1
+    helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 1.0.2
     ```
 
 - For NGINX Plus: (assuming you have pushed the Ingress Controller image `nginx-plus-ingress` to your private registry `myregistry.example.com`)
 
     ```shell
-    helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.18.1 --set controller.image.repository=myregistry.example.com/nginx-plus-ingress --set controller.nginxplus=true
+    helm install my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 1.0.2 --set controller.image.repository=myregistry.example.com/nginx-plus-ingress --set controller.nginxplus=true
     ```
 
 This will install the latest `edge` version of the Ingress Controller from GitHub Container Registry. If you prefer to use Docker Hub, you can replace `ghcr.io/nginxinc/charts/nginx-ingress` with `registry-1.docker.io/nginxcharts/nginx-ingress`.
@@ -84,7 +84,7 @@ Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a re
 To upgrade the release `my-release`:
 
 ```shell
-helm upgrade my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.18.1
+helm upgrade my-release oci://ghcr.io/nginxinc/charts/nginx-ingress --version 1.0.2
 ```
 
 ### Uninstalling the Chart
@@ -121,7 +121,7 @@ This step is required if you're installing the chart using its sources. Addition
 1. Pull the chart sources:
 
     ```shell
-    helm pull oci://ghcr.io/nginxinc/charts/nginx-ingress --untar --version 0.18.1
+    helm pull oci://ghcr.io/nginxinc/charts/nginx-ingress --untar --version 1.0.2
     ```
 
 2. Change your working directory to nginx-ingress:
@@ -244,7 +244,7 @@ The steps you should follow depend on the Helm release name:
     Copy the key=value under ```Selector```, such as:
 
     ```shell
-    Selector:               app=<helm_release_name>-nginx-ingress
+    Selector: app=<helm_release_name>-nginx-ingress
     ```
 
 2. Checkout the latest available tag using `git checkout v3.3.0`

--- a/docs/content/technical-specifications.md
+++ b/docs/content/technical-specifications.md
@@ -23,7 +23,8 @@ We explicitly test NGINX Ingress Controller on a range of Kubernetes platforms f
 {{< bootstrap-table "table table-bordered table-striped table-responsive" >}}
 | NIC Version | Supported Kubernetes Version | NIC Helm Chart Version | NIC Operator Version | NGINX / NGINX Plus version |
 | --- | --- | --- | --- | --- |
-| 3.3.2 | 1.27 - 1.22 | 0.18.1 | 1.5.1 | 1.25.2 / R30 |
+| 3.3.2 | 1.28 - 1.22 | 1.0.2 | 2.0.2 | 1.25.3 / R30 |
+| 3.2.1 | 1.27 - 1.22 | 0.18.1 | 1.5.1 | 1.25.2 / R30 |
 | 3.1.1 | 1.26 - 1.22 | 0.17.1 | 1.4.2 | 1.23.4 / R29 |
 | 3.0.2 | 1.26 - 1.21 | 0.16.2 | 1.3.1 | 1.23.3 / R28 |
 | 2.4.2 | 1.25 - 1.19 | 0.15.2 | 1.2.1 | 1.23.2 / R28 |


### PR DESCRIPTION
### Proposed changes

This PR fixes a few instances of Helm versions drifting in the documentation as a result of rebases from the revamp.

It also fixes a very minor formatting issue related to spacing on one of the affected pages.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
