### PR TITLE
Add annotations for controlling request rate limiting

### DIFF
--- a/docs/content/configuration/ingress-resources/advanced-configuration-with-annotations.md
+++ b/docs/content/configuration/ingress-resources/advanced-configuration-with-annotations.md
@@ -175,6 +175,18 @@ The table below summarizes the available annotations.
 |``nginx.org/use-cluster-ip`` | N/A | Enables using the Cluster IP and port of the service instead of the default behavior of using the IP and port of the pods. When this field is enabled, the fields that configure NGINX behavior related to multiple upstream servers (like ``lb-method`` and ``next-upstream``) will have no effect, as NGINX Ingress Controller will configure NGINX with only one upstream server that will match the service Cluster IP.   | ``False`` |  |
 {{% /table %}}
 
+### Rate limiting
+
+{{% table %}}
+|Annotation | ConfigMap Key | Description | Default | Example |
+| ---| ---| ---| ---| --- |
+|``nginx.org/limit-req`` | N/A | Enables request-rate-limiting for this ingress by creating a [limit_req_zone](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone) and matching [limit_req](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req) for each location. All servers/locations of one ingress share the same zone. | N/A | 200r/s |
+|``nginx.org/limit-req-zone-size`` | N/A | Configures the size of the created [limit_req_zone](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone). | 10m | 20m |
+|``nginx.org/limit-req-burst`` | N/A | Configures the burst-parameter of the [limit_req](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req) directive. | N/A | 100 |
+|``nginx.org/limit-req-delay`` | N/A | Configures the delay-parameter of the [limit_req](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req) directive. 0 means nodelay. | 0 | 100 |
+|``nginx.org/limit-req-status`` | N/A | Configures the [limit_req_status](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status) directive.  | 429 | 503 |
+{{% /table %}}
+
 ### Snippets and Custom Templates
 
 {{% table %}}

--- a/docs/content/configuration/ingress-resources/advanced-configuration-with-annotations.md
+++ b/docs/content/configuration/ingress-resources/advanced-configuration-with-annotations.md
@@ -180,11 +180,15 @@ The table below summarizes the available annotations.
 {{% table %}}
 |Annotation | ConfigMap Key | Description | Default | Example |
 | ---| ---| ---| ---| --- |
-|``nginx.org/limit-req`` | N/A | Enables request-rate-limiting for this ingress by creating a [limit_req_zone](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone) and matching [limit_req](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req) for each location. All servers/locations of one ingress share the same zone. | N/A | 200r/s |
+|``nginx.org/limit-req-rate`` | N/A | Enables request-rate-limiting for this ingress by creating a [limit_req_zone](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone) and matching [limit_req](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req) for each location. All servers/locations of one ingress share the same zone. Must have unit r/s or r/m. | N/A | 200r/s |
+|``nginx.org/limit-req-key`` | N/A | The key to which the rate limit is applied. Can contain text, variables, or a combination of them. Variables must be surrounded by ${}. | ${binary_remote_addr} | ${binary_remote_addr} |
 |``nginx.org/limit-req-zone-size`` | N/A | Configures the size of the created [limit_req_zone](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone). | 10m | 20m |
+|``nginx.org/limit-req-delay`` | N/A | Configures the delay-parameter of the [limit_req](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req) directive. | 0 | 100 |
+|``nginx.org/limit-req-no-delay`` | N/A | Configures the nodelay-parameter of the [limit_req](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req) directive. | false | true |
 |``nginx.org/limit-req-burst`` | N/A | Configures the burst-parameter of the [limit_req](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req) directive. | N/A | 100 |
-|``nginx.org/limit-req-delay`` | N/A | Configures the delay-parameter of the [limit_req](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req) directive. 0 means nodelay. | 0 | 100 |
-|``nginx.org/limit-req-status`` | N/A | Configures the [limit_req_status](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status) directive.  | 429 | 503 |
+|``nginx.org/limit-req-dry-run`` | N/A | Enables the dry run mode. In this mode, the rate limit is not actually applied, but the number of excessive requests is accounted as usual in the shared memory zone. | false | true |
+|``nginx.org/limit-req-log-level`` | N/A | Sets the desired logging level for cases when the server refuses to process requests due to rate exceeding, or delays request processing. Allowed values are info, notice, warn or error. | error | info |
+|``nginx.org/limit-req-reject-code`` | N/A | Sets the status code to return in response to rejected requests. Must fall into the range 400..599. | 429 | 503 |
 {{% /table %}}
 
 ### Snippets and Custom Templates

--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -78,11 +78,15 @@ var minionInheritanceList = map[string]bool{
 	"nginx.org/max-fails":                true,
 	"nginx.org/max-conns":                true,
 	"nginx.org/fail-timeout":             true,
-	"nginx.org/limit-req":                true,
+	"nginx.org/limit-req-rate":           true,
+	"nginx.org/limit-req-key":            true,
 	"nginx.org/limit-req-zone-size":      true,
-	"nginx.org/limit-req-burst":          true,
 	"nginx.org/limit-req-delay":          true,
-	"nginx.org/limit-req-status":         true,
+	"nginx.org/limit-req-no-delay":       true,
+	"nginx.org/limit-req-burst":          true,
+	"nginx.org/limit-req-dry-run":        true,
+	"nginx.org/limit-req-log-level":      true,
+	"nginx.org/limit-req-reject-code":    true,
 }
 
 var validPathRegex = map[string]bool{
@@ -419,18 +423,14 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 		}
 	}
 
-	if requestRateLimit, exists := ingEx.Ingress.Annotations["nginx.org/limit-req"]; exists {
+	if requestRateLimit, exists := ingEx.Ingress.Annotations["nginx.org/limit-req-rate"]; exists {
 		cfgParams.LimitReqRate = requestRateLimit
+	}
+	if requestRateKey, exists := ingEx.Ingress.Annotations["nginx.org/limit-req-key"]; exists {
+		cfgParams.LimitReqKey = requestRateKey
 	}
 	if requestRateZoneSize, exists := ingEx.Ingress.Annotations["nginx.org/limit-req-zone-size"]; exists {
 		cfgParams.LimitReqZoneSize = requestRateZoneSize
-	}
-	if requestRateBurst, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/limit-req-burst", ingEx.Ingress); exists {
-		if err != nil {
-			glog.Error(err)
-		} else {
-			cfgParams.LimitReqBurst = requestRateBurst
-		}
 	}
 	if requestRateDelay, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/limit-req-delay", ingEx.Ingress); exists {
 		if err != nil {
@@ -439,11 +439,35 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 			cfgParams.LimitReqDelay = requestRateDelay
 		}
 	}
-	if requestRateStatus, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/limit-req-status", ingEx.Ingress); exists {
+	if requestRateNoDelay, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, "nginx.org/limit-req-no-delay", ingEx.Ingress); exists {
 		if err != nil {
 			glog.Error(err)
 		} else {
-			cfgParams.LimitReqStatus = requestRateStatus
+			cfgParams.LimitReqNoDelay = requestRateNoDelay
+		}
+	}
+	if requestRateBurst, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/limit-req-burst", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfgParams.LimitReqBurst = requestRateBurst
+		}
+	}
+	if requestRateDryRun, exists, err := GetMapKeyAsBool(ingEx.Ingress.Annotations, "nginx.org/limit-req-dry-run", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfgParams.LimitReqDryRun = requestRateDryRun
+		}
+	}
+	if requestRateLogLevel, exists := ingEx.Ingress.Annotations["nginx.org/limit-req-log-level"]; exists {
+		cfgParams.LimitReqLogLevel = requestRateLogLevel
+	}
+	if requestRateRejectCode, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/limit-req-reject-code", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfgParams.LimitReqRejectCode = requestRateRejectCode
 		}
 	}
 

--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -78,6 +78,11 @@ var minionInheritanceList = map[string]bool{
 	"nginx.org/max-fails":                true,
 	"nginx.org/max-conns":                true,
 	"nginx.org/fail-timeout":             true,
+	"nginx.org/limit-req":                true,
+	"nginx.org/limit-req-zone-size":      true,
+	"nginx.org/limit-req-burst":          true,
+	"nginx.org/limit-req-delay":          true,
+	"nginx.org/limit-req-status":         true,
 }
 
 var validPathRegex = map[string]bool{
@@ -413,6 +418,35 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 			cfgParams.UseClusterIP = useClusterIP
 		}
 	}
+
+	if requestRateLimit, exists := ingEx.Ingress.Annotations["nginx.org/limit-req"]; exists {
+		cfgParams.LimitReqRate = requestRateLimit
+	}
+	if requestRateZoneSize, exists := ingEx.Ingress.Annotations["nginx.org/limit-req-zone-size"]; exists {
+		cfgParams.LimitReqZoneSize = requestRateZoneSize
+	}
+	if requestRateBurst, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/limit-req-burst", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfgParams.LimitReqBurst = requestRateBurst
+		}
+	}
+	if requestRateDelay, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/limit-req-delay", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfgParams.LimitReqDelay = requestRateDelay
+		}
+	}
+	if requestRateStatus, exists, err := GetMapKeyAsInt(ingEx.Ingress.Annotations, "nginx.org/limit-req-status", ingEx.Ingress); exists {
+		if err != nil {
+			glog.Error(err)
+		} else {
+			cfgParams.LimitReqStatus = requestRateStatus
+		}
+	}
+
 	return cfgParams
 }
 

--- a/internal/configs/annotations.go
+++ b/internal/configs/annotations.go
@@ -433,12 +433,14 @@ func parseAnnotations(ingEx *IngressEx, baseCfgParams *ConfigParams, isPlus bool
 	return cfgParams
 }
 
-// parseRateLimitAnnotations parses rate-limiting-related annotations and places them into cfgParams. Occuring errors are collected and returned, but do not abort parsing.
+// parseRateLimitAnnotations parses rate-limiting-related annotations and places them into cfgParams. Occurring errors are collected and returned, but do not abort parsing.
+//
+//gocyclo:ignore
 func parseRateLimitAnnotations(annotations map[string]string, cfgParams *ConfigParams, context apiObject) []error {
 	errors := make([]error, 0)
 	if requestRateLimit, exists := annotations["nginx.org/limit-req-rate"]; exists {
 		if rate, err := ParseRequestRate(requestRateLimit); err != nil {
-			errors = append(errors, fmt.Errorf("Ingress %s/%s: Invalid value for nginx.org/limit-req-rate: got %s: %v", context.GetNamespace(), context.GetName(), requestRateLimit, err))
+			errors = append(errors, fmt.Errorf("Ingress %s/%s: Invalid value for nginx.org/limit-req-rate: got %s: %w", context.GetNamespace(), context.GetName(), requestRateLimit, err))
 		} else {
 			cfgParams.LimitReqRate = rate
 		}
@@ -448,7 +450,7 @@ func parseRateLimitAnnotations(annotations map[string]string, cfgParams *ConfigP
 	}
 	if requestRateZoneSize, exists := annotations["nginx.org/limit-req-zone-size"]; exists {
 		if size, err := ParseSize(requestRateZoneSize); err != nil {
-			errors = append(errors, fmt.Errorf("Ingress %s/%s: Invalid value for nginx.org/limit-req-zone-size: got %s: %v", context.GetNamespace(), context.GetName(), requestRateZoneSize, err))
+			errors = append(errors, fmt.Errorf("Ingress %s/%s: Invalid value for nginx.org/limit-req-zone-size: got %s: %w", context.GetNamespace(), context.GetName(), requestRateZoneSize, err))
 		} else {
 			cfgParams.LimitReqZoneSize = size
 		}

--- a/internal/configs/annotations_test.go
+++ b/internal/configs/annotations_test.go
@@ -182,7 +182,7 @@ func TestParseRateLimitAnnotations(t *testing.T) {
 		"nginx.org/limit-req-dry-run":     "true",
 		"nginx.org/limit-req-log-level":   "info",
 	}, NewDefaultConfigParams(false), context); len(errors) > 0 {
-		t.Errorf("Errors when parsing valid limit-req annotations")
+		t.Error("Errors when parsing valid limit-req annotations")
 	}
 
 	if errors := parseRateLimitAnnotations(map[string]string{
@@ -214,5 +214,4 @@ func TestParseRateLimitAnnotations(t *testing.T) {
 	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
 		t.Errorf("No Errors when parsing invalid log level")
 	}
-
 }

--- a/internal/configs/annotations_test.go
+++ b/internal/configs/annotations_test.go
@@ -188,30 +188,30 @@ func TestParseRateLimitAnnotations(t *testing.T) {
 	if errors := parseRateLimitAnnotations(map[string]string{
 		"nginx.org/limit-req-rate": "200",
 	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
-		t.Errorf("No Errors when parsing invalid request rate")
+		t.Error("No Errors when parsing invalid request rate")
 	}
 
 	if errors := parseRateLimitAnnotations(map[string]string{
 		"nginx.org/limit-req-rate": "200r/h",
 	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
-		t.Errorf("No Errors when parsing invalid request rate")
+		t.Error("No Errors when parsing invalid request rate")
 	}
 
 	if errors := parseRateLimitAnnotations(map[string]string{
 		"nginx.org/limit-req-rate": "0r/s",
 	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
-		t.Errorf("No Errors when parsing invalid request rate")
+		t.Error("No Errors when parsing invalid request rate")
 	}
 
 	if errors := parseRateLimitAnnotations(map[string]string{
 		"nginx.org/limit-req-zone-size": "10abc",
 	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
-		t.Errorf("No Errors when parsing invalid zone size")
+		t.Error("No Errors when parsing invalid zone size")
 	}
 
 	if errors := parseRateLimitAnnotations(map[string]string{
 		"nginx.org/limit-req-log-level": "foobar",
 	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
-		t.Errorf("No Errors when parsing invalid log level")
+		t.Error("No Errors when parsing invalid log level")
 	}
 }

--- a/internal/configs/annotations_test.go
+++ b/internal/configs/annotations_test.go
@@ -4,6 +4,9 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestParseRewrites(t *testing.T) {
@@ -158,4 +161,58 @@ func TestMergeMasterAnnotationsIntoMinion(t *testing.T) {
 	if !reflect.DeepEqual(expectedMergedAnnotations, minionAnnotations) {
 		t.Errorf("mergeMasterAnnotationsIntoMinion returned %v, but expected %v", minionAnnotations, expectedMergedAnnotations)
 	}
+}
+
+func TestParseRateLimitAnnotations(t *testing.T) {
+	context := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "context",
+		},
+	}
+
+	if errors := parseRateLimitAnnotations(map[string]string{
+		"nginx.org/limit-req-rate":        "200r/s",
+		"nginx.org/limit-req-key":         "${request_uri}",
+		"nginx.org/limit-req-burst":       "100",
+		"nginx.org/limit-req-delay":       "80",
+		"nginx.org/limit-req-no-delay":    "true",
+		"nginx.org/limit-req-reject-code": "429",
+		"nginx.org/limit-req-zone-size":   "11m",
+		"nginx.org/limit-req-dry-run":     "true",
+		"nginx.org/limit-req-log-level":   "info",
+	}, NewDefaultConfigParams(false), context); len(errors) > 0 {
+		t.Errorf("Errors when parsing valid limit-req annotations")
+	}
+
+	if errors := parseRateLimitAnnotations(map[string]string{
+		"nginx.org/limit-req-rate": "200",
+	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
+		t.Errorf("No Errors when parsing invalid request rate")
+	}
+
+	if errors := parseRateLimitAnnotations(map[string]string{
+		"nginx.org/limit-req-rate": "200r/h",
+	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
+		t.Errorf("No Errors when parsing invalid request rate")
+	}
+
+	if errors := parseRateLimitAnnotations(map[string]string{
+		"nginx.org/limit-req-rate": "0r/s",
+	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
+		t.Errorf("No Errors when parsing invalid request rate")
+	}
+
+	if errors := parseRateLimitAnnotations(map[string]string{
+		"nginx.org/limit-req-zone-size": "10abc",
+	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
+		t.Errorf("No Errors when parsing invalid zone size")
+	}
+
+	if errors := parseRateLimitAnnotations(map[string]string{
+		"nginx.org/limit-req-log-level": "foobar",
+	}, NewDefaultConfigParams(false), context); len(errors) == 0 {
+		t.Errorf("No Errors when parsing invalid log level")
+	}
+
 }

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -114,11 +114,15 @@ type ConfigParams struct {
 
 	SpiffeServerCerts bool
 
-	LimitReqRate     string
-	LimitReqZoneSize string
-	LimitReqBurst    int
-	LimitReqDelay    int
-	LimitReqStatus   int
+	LimitReqRate       string
+	LimitReqKey        string
+	LimitReqZoneSize   string
+	LimitReqDelay      int
+	LimitReqNoDelay    bool
+	LimitReqBurst      int
+	LimitReqDryRun     bool
+	LimitReqLogLevel   string
+	LimitReqRejectCode int
 }
 
 // StaticConfigParams holds immutable NGINX configuration parameters that affect the main NGINX config.
@@ -197,8 +201,10 @@ func NewDefaultConfigParams(isPlus bool) *ConfigParams {
 		MainKeepaliveRequests:         100,
 		VariablesHashBucketSize:       256,
 		VariablesHashMaxSize:          1024,
+		LimitReqKey:                   "${binary_remote_addr}",
 		LimitReqZoneSize:              "10m",
-		LimitReqStatus:                429,
+		LimitReqLogLevel:              "error",
+		LimitReqRejectCode:            429,
 	}
 }
 

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -113,6 +113,12 @@ type ConfigParams struct {
 	SSLPorts []int
 
 	SpiffeServerCerts bool
+
+	LimitReqRate     string
+	LimitReqZoneSize string
+	LimitReqBurst    int
+	LimitReqDelay    int
+	LimitReqStatus   int
 }
 
 // StaticConfigParams holds immutable NGINX configuration parameters that affect the main NGINX config.
@@ -191,6 +197,8 @@ func NewDefaultConfigParams(isPlus bool) *ConfigParams {
 		MainKeepaliveRequests:         100,
 		VariablesHashBucketSize:       256,
 		VariablesHashMaxSize:          1024,
+		LimitReqZoneSize:              "10m",
+		LimitReqStatus:                429,
 	}
 }
 

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -128,6 +128,7 @@ func generateNginxCfg(p NginxCfgParams) (version1.IngressNginxConfig, Warnings) 
 	allWarnings := newWarnings()
 
 	var servers []version1.Server
+	var limitReqZones []version1.LimitReqZone
 
 	for _, rule := range p.ingEx.Ingress.Spec.Rules {
 		// skipping invalid hosts
@@ -265,6 +266,23 @@ func generateNginxCfg(p NginxCfgParams) (version1.IngressNginxConfig, Warnings) 
 				allWarnings.Add(warnings)
 			}
 
+			if cfgParams.LimitReqRate != "" {
+				zoneName := p.ingEx.Ingress.Namespace + "/" + p.ingEx.Ingress.Name
+				loc.LimitReq = &version1.LimitReq{
+					Zone:   zoneName,
+					Burst:  cfgParams.LimitReqBurst,
+					Delay:  cfgParams.LimitReqDelay,
+					Status: cfgParams.LimitReqStatus,
+				}
+				if !limitReqZoneExists(limitReqZones, zoneName) {
+					limitReqZones = append(limitReqZones, version1.LimitReqZone{
+						Name: zoneName,
+						Size: cfgParams.LimitReqZoneSize,
+						Rate: cfgParams.LimitReqRate,
+					})
+				}
+			}
+
 			locations = append(locations, loc)
 
 			if loc.Path == "/" {
@@ -317,6 +335,7 @@ func generateNginxCfg(p NginxCfgParams) (version1.IngressNginxConfig, Warnings) 
 		SpiffeClientCerts:       p.staticParams.NginxServiceMesh && !cfgParams.SpiffeServerCerts,
 		DynamicSSLReloadEnabled: p.staticParams.DynamicSSLReload,
 		StaticSSLPath:           p.staticParams.StaticSSLPath,
+		LimitReqZones:           limitReqZones,
 	}, allWarnings
 }
 
@@ -609,6 +628,7 @@ func generateNginxCfgForMergeableIngresses(p NginxCfgParams) (version1.IngressNg
 	var locations []version1.Location
 	var upstreams []version1.Upstream
 	healthChecks := make(map[string]version1.HealthCheck)
+	var limitReqZones []version1.LimitReqZone
 	var keepalive string
 
 	// replace master with a deepcopy because we will modify it
@@ -704,6 +724,7 @@ func generateNginxCfgForMergeableIngresses(p NginxCfgParams) (version1.IngressNg
 		}
 
 		upstreams = append(upstreams, nginxCfg.Upstreams...)
+		limitReqZones = append(limitReqZones, nginxCfg.LimitReqZones...)
 	}
 
 	masterServer.HealthChecks = healthChecks
@@ -717,7 +738,17 @@ func generateNginxCfgForMergeableIngresses(p NginxCfgParams) (version1.IngressNg
 		SpiffeClientCerts:       p.staticParams.NginxServiceMesh && !p.baseCfgParams.SpiffeServerCerts,
 		DynamicSSLReloadEnabled: p.staticParams.DynamicSSLReload,
 		StaticSSLPath:           p.staticParams.StaticSSLPath,
+		LimitReqZones:           limitReqZones,
 	}, warnings
+}
+
+func limitReqZoneExists(zones []version1.LimitReqZone, zoneName string) bool {
+	for _, zone := range zones {
+		if zone.Name == zoneName {
+			return true
+		}
+	}
+	return false
 }
 
 func isSSLEnabled(isSSLService bool, cfgParams ConfigParams, staticCfgParams *StaticConfigParams) bool {

--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -269,14 +269,18 @@ func generateNginxCfg(p NginxCfgParams) (version1.IngressNginxConfig, Warnings) 
 			if cfgParams.LimitReqRate != "" {
 				zoneName := p.ingEx.Ingress.Namespace + "/" + p.ingEx.Ingress.Name
 				loc.LimitReq = &version1.LimitReq{
-					Zone:   zoneName,
-					Burst:  cfgParams.LimitReqBurst,
-					Delay:  cfgParams.LimitReqDelay,
-					Status: cfgParams.LimitReqStatus,
+					Zone:       zoneName,
+					Burst:      cfgParams.LimitReqBurst,
+					Delay:      cfgParams.LimitReqDelay,
+					NoDelay:    cfgParams.LimitReqNoDelay,
+					DryRun:     cfgParams.LimitReqDryRun,
+					LogLevel:   cfgParams.LimitReqLogLevel,
+					RejectCode: cfgParams.LimitReqRejectCode,
 				}
 				if !limitReqZoneExists(limitReqZones, zoneName) {
 					limitReqZones = append(limitReqZones, version1.LimitReqZone{
 						Name: zoneName,
+						Key:  cfgParams.LimitReqKey,
 						Size: cfgParams.LimitReqZoneSize,
 						Rate: cfgParams.LimitReqRate,
 					})

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -913,10 +913,14 @@ func TestGenerateNginxCfgWithUseClusterIP(t *testing.T) {
 func TestGenerateNginxCfgForLimitReq(t *testing.T) {
 	t.Parallel()
 	cafeIngressEx := createCafeIngressEx()
-	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req"] = "200r/s"
+	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-rate"] = "200r/s"
+	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-key"] = "${request_uri}"
 	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-burst"] = "100"
+	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-no-delay"] = "true"
 	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-delay"] = "80"
-	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-status"] = "429"
+	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-reject-code"] = "503"
+	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-dry-run"] = "true"
+	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-log-level"] = "info"
 	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-zone-size"] = "11m"
 
 	isPlus := false
@@ -925,16 +929,74 @@ func TestGenerateNginxCfgForLimitReq(t *testing.T) {
 	expectedZones := []version1.LimitReqZone{
 		{
 			Name: "default/cafe-ingress",
+			Key:  "${request_uri}",
 			Size: "11m",
 			Rate: "200r/s",
 		},
 	}
 
 	expectedReqs := &version1.LimitReq{
-		Zone:   "default/cafe-ingress",
-		Burst:  100,
-		Delay:  80,
-		Status: 429,
+		Zone:       "default/cafe-ingress",
+		Burst:      100,
+		Delay:      80,
+		NoDelay:    true,
+		DryRun:     true,
+		LogLevel:   "info",
+		RejectCode: 503,
+	}
+
+	result, warnings := generateNginxCfg(NginxCfgParams{
+		ingEx:         &cafeIngressEx,
+		baseCfgParams: configParams,
+		staticParams:  &StaticConfigParams{},
+		isPlus:        isPlus,
+	})
+
+	if !reflect.DeepEqual(result.LimitReqZones, expectedZones) {
+		t.Errorf("generateNginxCfg returned \n%v,  but expected \n%v", result.LimitReqZones, expectedZones)
+	}
+
+	for _, server := range result.Servers {
+		for _, location := range server.Locations {
+			if !reflect.DeepEqual(location.LimitReq, expectedReqs) {
+				t.Errorf("generateNginxCfg returned \n%v,  but expected \n%v", result.LimitReqZones, expectedZones)
+			}
+		}
+	}
+
+	if !reflect.DeepEqual(result.LimitReqZones, expectedZones) {
+		t.Errorf("generateNginxCfg returned \n%v,  but expected \n%v", result.LimitReqZones, expectedZones)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("generateNginxCfg returned warnings: %v", warnings)
+	}
+}
+
+func TestGenerateNginxCfgForLimitReqDefaults(t *testing.T) {
+	t.Parallel()
+	cafeIngressEx := createCafeIngressEx()
+	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-rate"] = "200r/s"
+	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-burst"] = "100"
+	cafeIngressEx.Ingress.Annotations["nginx.org/limit-req-delay"] = "80"
+
+	isPlus := false
+	configParams := NewDefaultConfigParams(isPlus)
+
+	expectedZones := []version1.LimitReqZone{
+		{
+			Name: "default/cafe-ingress",
+			Key:  "${binary_remote_addr}",
+			Size: "10m",
+			Rate: "200r/s",
+		},
+	}
+
+	expectedReqs := &version1.LimitReq{
+		Zone:       "default/cafe-ingress",
+		Burst:      100,
+		Delay:      80,
+		LogLevel:   "error",
+		RejectCode: 429,
 	}
 
 	result, warnings := generateNginxCfg(NginxCfgParams{
@@ -968,26 +1030,32 @@ func TestGenerateNginxCfgForMergeableIngressesForLimitReq(t *testing.T) {
 	t.Parallel()
 	mergeableIngresses := createMergeableCafeIngress()
 
-	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req"] = "200r/s"
+	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req-rate"] = "200r/s"
+	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req-key"] = "${request_uri}"
 	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req-burst"] = "100"
 	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req-delay"] = "80"
-	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req-status"] = "429"
+	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req-no-delay"] = "true"
+	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req-reject-code"] = "429"
 	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req-zone-size"] = "11m"
+	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req-dry-run"] = "true"
+	mergeableIngresses.Minions[0].Ingress.Annotations["nginx.org/limit-req-log-level"] = "info"
 
-	mergeableIngresses.Minions[1].Ingress.Annotations["nginx.org/limit-req"] = "400r/s"
+	mergeableIngresses.Minions[1].Ingress.Annotations["nginx.org/limit-req-rate"] = "400r/s"
 	mergeableIngresses.Minions[1].Ingress.Annotations["nginx.org/limit-req-burst"] = "200"
 	mergeableIngresses.Minions[1].Ingress.Annotations["nginx.org/limit-req-delay"] = "160"
-	mergeableIngresses.Minions[1].Ingress.Annotations["nginx.org/limit-req-status"] = "503"
+	mergeableIngresses.Minions[1].Ingress.Annotations["nginx.org/limit-req-reject-code"] = "503"
 	mergeableIngresses.Minions[1].Ingress.Annotations["nginx.org/limit-req-zone-size"] = "12m"
 
 	expectedZones := []version1.LimitReqZone{
 		{
 			Name: "default/cafe-ingress-coffee-minion",
+			Key:  "${request_uri}",
 			Size: "11m",
 			Rate: "200r/s",
 		},
 		{
 			Name: "default/cafe-ingress-tea-minion",
+			Key:  "${binary_remote_addr}",
 			Size: "12m",
 			Rate: "400r/s",
 		},
@@ -995,16 +1063,20 @@ func TestGenerateNginxCfgForMergeableIngressesForLimitReq(t *testing.T) {
 
 	expectedReqs := map[string]*version1.LimitReq{
 		"cafe-ingress-coffee-minion": {
-			Zone:   "default/cafe-ingress-coffee-minion",
-			Burst:  100,
-			Delay:  80,
-			Status: 429,
+			Zone:       "default/cafe-ingress-coffee-minion",
+			Burst:      100,
+			Delay:      80,
+			LogLevel:   "info",
+			RejectCode: 429,
+			NoDelay:    true,
+			DryRun:     true,
 		},
 		"cafe-ingress-tea-minion": {
-			Zone:   "default/cafe-ingress-tea-minion",
-			Burst:  200,
-			Delay:  160,
-			Status: 503,
+			Zone:       "default/cafe-ingress-tea-minion",
+			Burst:      200,
+			Delay:      160,
+			LogLevel:   "error",
+			RejectCode: 503,
 		},
 	}
 

--- a/internal/configs/parsing_helpers.go
+++ b/internal/configs/parsing_helpers.go
@@ -239,6 +239,30 @@ func ParseSize(s string) (string, error) {
 	return "", errors.New("invalid size string")
 }
 
+var rateRegexp = regexp.MustCompile(`^(\d+)(r/s|r/m)$`)
+
+// ParseRequestRate ensures that the string value is a valid request rate in r/s or r/m and > 0
+func ParseRequestRate(s string) (string, error) {
+	s = strings.TrimSpace(s)
+
+	match := rateRegexp.FindStringSubmatch(s)
+
+	if match == nil {
+		return "", errors.New("String does not match rate-pattern: ^(\\d+)(r/s|r/m)$")
+	}
+
+	number, err := strconv.Atoi(match[1])
+	if err != nil {
+		return "", errors.New("String does not match rate-pattern")
+	}
+
+	if number <= 0 {
+		return "", errors.New("Rate must be >0")
+	}
+
+	return s, nil
+}
+
 // https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers
 var proxyBuffersRegexp = regexp.MustCompile(`^\d+ \d+[kKmM]?$`)
 

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -67,6 +67,7 @@ type HealthCheck struct {
 // LimitReqZone describes a zone used for request rate limiting
 type LimitReqZone struct {
 	Name string
+	Key  string
 	Size string
 	Rate string
 }
@@ -148,10 +149,13 @@ type JWTAuth struct {
 
 // LimitReq configures a request rate limit
 type LimitReq struct {
-	Zone   string
-	Burst  int
-	Delay  int
-	Status int
+	Zone       string
+	Burst      int
+	Delay      int
+	NoDelay    bool
+	RejectCode int
+	DryRun     bool
+	LogLevel   string
 }
 
 // Location describes an NGINX location.

--- a/internal/configs/version1/config.go
+++ b/internal/configs/version1/config.go
@@ -19,6 +19,7 @@ type IngressNginxConfig struct {
 	SpiffeClientCerts       bool
 	DynamicSSLReloadEnabled bool
 	StaticSSLPath           string
+	LimitReqZones           []LimitReqZone
 }
 
 // Ingress holds information about an Ingress resource.
@@ -61,6 +62,13 @@ type HealthCheck struct {
 	Mandatory      bool
 	Headers        map[string]string
 	TimeoutSeconds int64
+}
+
+// LimitReqZone describes a zone used for request rate limiting
+type LimitReqZone struct {
+	Name string
+	Size string
+	Rate string
 }
 
 // Server describes an NGINX server.
@@ -138,6 +146,14 @@ type JWTAuth struct {
 	RedirectLocationName string
 }
 
+// LimitReq configures a request rate limit
+type LimitReq struct {
+	Zone   string
+	Burst  int
+	Delay  int
+	Status int
+}
+
 // Location describes an NGINX location.
 type Location struct {
 	LocationSnippets     []string
@@ -159,6 +175,7 @@ type Location struct {
 	JWTAuth              *JWTAuth
 	BasicAuth            *BasicAuth
 	ServiceName          string
+	LimitReq             *LimitReq
 
 	MinionIngress *Ingress
 }

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -20,7 +20,7 @@ upstream {{$upstream.Name}} {
 {{- end}}
 
 {{range $limitReqZone := .LimitReqZones}}
-limit_req_zone $binary_remote_addr zone={{ $limitReqZone.Name }}:{{$limitReqZone.Size}} rate={{$limitReqZone.Rate}};
+limit_req_zone {{ $limitReqZone.Key }} zone={{ $limitReqZone.Name }}:{{$limitReqZone.Size}} rate={{$limitReqZone.Rate}};
 {{end}}
 
 {{range $server := .Servers}}
@@ -316,8 +316,10 @@ server {
 		{{- end}}
 
 		{{with $location.LimitReq}}
-		limit_req zone={{ $location.LimitReq.Zone }} {{if $location.LimitReq.Burst}}burst={{$location.LimitReq.Burst}}{{end}} {{if $location.LimitReq.Delay}}delay={{$location.LimitReq.Delay}}{{else}}nodelay{{end}};
-		{{if $location.LimitReq.Status}}limit_req_status {{$location.LimitReq.Status}};{{end}}
+		limit_req zone={{ $location.LimitReq.Zone }} {{if $location.LimitReq.Burst}}burst={{$location.LimitReq.Burst}}{{end}} {{if $location.LimitReq.NoDelay}}nodelay{{else if $location.LimitReq.Delay}}delay={{$location.LimitReq.Delay}}{{end}};
+		{{if $location.LimitReq.DryRun}}limit_req_dry_run on;{{end}}
+		{{if $location.LimitReq.LogLevel}}limit_req_log_level {{$location.LimitReq.LogLevel}};{{end}}
+		{{if $location.LimitReq.RejectCode}}limit_req_status {{$location.LimitReq.RejectCode}};{{end}}
 		{{end}}
 	}
 	{{end -}}

--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -19,6 +19,10 @@ upstream {{$upstream.Name}} {
 }
 {{- end}}
 
+{{range $limitReqZone := .LimitReqZones}}
+limit_req_zone $binary_remote_addr zone={{ $limitReqZone.Name }}:{{$limitReqZone.Size}} rate={{$limitReqZone.Rate}};
+{{end}}
+
 {{range $server := .Servers}}
 server {
 	{{- if $server.SpiffeCerts}}
@@ -310,6 +314,11 @@ server {
 		proxy_pass http://{{$location.Upstream.Name}}{{$location.Rewrite}};
 		{{- end}}
 		{{- end}}
+
+		{{with $location.LimitReq}}
+		limit_req zone={{ $location.LimitReq.Zone }} {{if $location.LimitReq.Burst}}burst={{$location.LimitReq.Burst}}{{end}} {{if $location.LimitReq.Delay}}delay={{$location.LimitReq.Delay}}{{else}}nodelay{{end}};
+		{{if $location.LimitReq.Status}}limit_req_status {{$location.LimitReq.Status}};{{end}}
+		{{end}}
 	}
 	{{end -}}
 	{{- if $server.GRPCOnly}}

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -10,6 +10,10 @@ upstream {{$upstream.Name}} {
 }
 {{end -}}
 
+{{range $limitReqZone := .LimitReqZones}}
+limit_req_zone $binary_remote_addr zone={{ $limitReqZone.Name }}:{{$limitReqZone.Size}} rate={{$limitReqZone.Rate}};
+{{end}}
+
 {{range $server := .Servers}}
 server {
 	{{- if $server.SpiffeCerts}}
@@ -223,6 +227,11 @@ server {
 		proxy_pass http://{{$location.Upstream.Name}}{{$location.Rewrite}};
 		{{- end}}
 		{{- end}}
+
+		{{with $location.LimitReq}}
+		limit_req zone={{ $location.LimitReq.Zone }} {{if $location.LimitReq.Burst}}burst={{$location.LimitReq.Burst}}{{end}} {{if $location.LimitReq.Delay}}delay={{$location.LimitReq.Delay}}{{else}}nodelay{{end}};
+		{{if $location.LimitReq.Status}}limit_req_status {{$location.LimitReq.Status}};{{end}}
+		{{end}}
 	}
 	{{end -}}
 	{{- if $server.GRPCOnly}}

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -11,7 +11,7 @@ upstream {{$upstream.Name}} {
 {{end -}}
 
 {{range $limitReqZone := .LimitReqZones}}
-limit_req_zone $binary_remote_addr zone={{ $limitReqZone.Name }}:{{$limitReqZone.Size}} rate={{$limitReqZone.Rate}};
+limit_req_zone {{ $limitReqZone.Key }} zone={{ $limitReqZone.Name }}:{{$limitReqZone.Size}} rate={{$limitReqZone.Rate}};
 {{end}}
 
 {{range $server := .Servers}}
@@ -229,8 +229,10 @@ server {
 		{{- end}}
 
 		{{with $location.LimitReq}}
-		limit_req zone={{ $location.LimitReq.Zone }} {{if $location.LimitReq.Burst}}burst={{$location.LimitReq.Burst}}{{end}} {{if $location.LimitReq.Delay}}delay={{$location.LimitReq.Delay}}{{else}}nodelay{{end}};
-		{{if $location.LimitReq.Status}}limit_req_status {{$location.LimitReq.Status}};{{end}}
+		limit_req zone={{ $location.LimitReq.Zone }} {{if $location.LimitReq.Burst}}burst={{$location.LimitReq.Burst}}{{end}} {{if $location.LimitReq.NoDelay}}nodelay{{else if $location.LimitReq.Delay}}delay={{$location.LimitReq.Delay}}{{end}};
+		{{if $location.LimitReq.DryRun}}limit_req_dry_run on;{{end}}
+		{{if $location.LimitReq.LogLevel}}limit_req_log_level {{$location.LimitReq.LogLevel}};{{end}}
+		{{if $location.LimitReq.RejectCode}}limit_req_status {{$location.LimitReq.RejectCode}};{{end}}
 		{{end}}
 	}
 	{{end -}}

--- a/internal/configs/version1/template_test.go
+++ b/internal/configs/version1/template_test.go
@@ -2,6 +2,7 @@ package version1
 
 import (
 	"bytes"
+	"strconv"
 	"strings"
 	"testing"
 	"text/template"
@@ -967,6 +968,126 @@ func TestExecuteTemplate_ForIngressForNGINXWithHTTP2Off(t *testing.T) {
 
 	for _, want := range unwantDirectives {
 		if strings.Contains(ingConf, want) {
+			t.Errorf("want %q in generated config", want)
+		}
+	}
+}
+
+func TestExecuteTemplate_ForIngressForNGINXWithRequestRateLimit(t *testing.T) {
+	t.Parallel()
+
+	tmpl := newNGINXIngressTmpl(t)
+	buf := &bytes.Buffer{}
+
+	err := tmpl.Execute(buf, ingressCfgRequestRateLimit)
+	t.Log(buf.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ingConf := buf.String()
+
+	limitReq := ingressCfgRequestRateLimit.Servers[0].Locations[0].LimitReq
+
+	wantDirectives := []string{
+		"limit_req_zone $binary_remote_addr zone=default/myingress:10m rate=200r/s;",
+		"limit_req zone=default/myingress burst=" + strconv.Itoa(limitReq.Burst) + " delay=" + strconv.Itoa(limitReq.Delay) + ";",
+		"limit_req_status " + strconv.Itoa(limitReq.Status) + ";",
+	}
+
+	for _, want := range wantDirectives {
+		if !strings.Contains(ingConf, want) {
+			t.Errorf("want %q in generated config", want)
+		}
+	}
+}
+
+func TestExecuteTemplate_ForIngressForNGINXWithRequestRateLimitMinions(t *testing.T) {
+	t.Parallel()
+
+	tmpl := newNGINXIngressTmpl(t)
+	buf := &bytes.Buffer{}
+
+	err := tmpl.Execute(buf, ingressCfgRequestRateLimitMinions)
+	t.Log(buf.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ingConf := buf.String()
+
+	limitReqTea := ingressCfgRequestRateLimitMinions.Servers[0].Locations[0].LimitReq
+	limitReqCoffee := ingressCfgRequestRateLimitMinions.Servers[0].Locations[1].LimitReq
+
+	wantDirectives := []string{
+		"limit_req_zone $binary_remote_addr zone=default/tea-minion:10m rate=200r/s;",
+		"limit_req_zone $binary_remote_addr zone=default/coffee-minion:20m rate=400r/s;",
+		"limit_req zone=" + limitReqTea.Zone + " burst=" + strconv.Itoa(limitReqTea.Burst) + " delay=" + strconv.Itoa(limitReqTea.Delay) + ";",
+		"limit_req zone=" + limitReqCoffee.Zone + " burst=" + strconv.Itoa(limitReqCoffee.Burst) + " delay=" + strconv.Itoa(limitReqCoffee.Delay) + ";",
+		"limit_req_status " + strconv.Itoa(limitReqTea.Status) + ";",
+		"limit_req_status " + strconv.Itoa(limitReqCoffee.Status) + ";",
+	}
+
+	for _, want := range wantDirectives {
+		if !strings.Contains(ingConf, want) {
+			t.Errorf("want %q in generated config", want)
+		}
+	}
+}
+
+func TestExecuteTemplate_ForIngressForNGINXPlusWithRequestRateLimit(t *testing.T) {
+	t.Parallel()
+
+	tmpl := newNGINXPlusIngressTmpl(t)
+	buf := &bytes.Buffer{}
+
+	err := tmpl.Execute(buf, ingressCfgRequestRateLimit)
+	t.Log(buf.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ingConf := buf.String()
+
+	limitReq := ingressCfgRequestRateLimit.Servers[0].Locations[0].LimitReq
+
+	wantDirectives := []string{
+		"limit_req_zone $binary_remote_addr zone=default/myingress:10m rate=200r/s;",
+		"limit_req zone=default/myingress burst=" + strconv.Itoa(limitReq.Burst) + " delay=" + strconv.Itoa(limitReq.Delay) + ";",
+		"limit_req_status " + strconv.Itoa(limitReq.Status) + ";",
+	}
+
+	for _, want := range wantDirectives {
+		if !strings.Contains(ingConf, want) {
+			t.Errorf("want %q in generated config", want)
+		}
+	}
+}
+
+func TestExecuteTemplate_ForIngressForNGINXPlusWithRequestRateLimitMinions(t *testing.T) {
+	t.Parallel()
+
+	tmpl := newNGINXPlusIngressTmpl(t)
+	buf := &bytes.Buffer{}
+
+	err := tmpl.Execute(buf, ingressCfgRequestRateLimitMinions)
+	t.Log(buf.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ingConf := buf.String()
+
+	limitReqTea := ingressCfgRequestRateLimitMinions.Servers[0].Locations[0].LimitReq
+	limitReqCoffee := ingressCfgRequestRateLimitMinions.Servers[0].Locations[1].LimitReq
+
+	wantDirectives := []string{
+		"limit_req_zone $binary_remote_addr zone=default/tea-minion:10m rate=200r/s;",
+		"limit_req_zone $binary_remote_addr zone=default/coffee-minion:20m rate=400r/s;",
+		"limit_req zone=" + limitReqTea.Zone + " burst=" + strconv.Itoa(limitReqTea.Burst) + " delay=" + strconv.Itoa(limitReqTea.Delay) + ";",
+		"limit_req zone=" + limitReqCoffee.Zone + " burst=" + strconv.Itoa(limitReqCoffee.Burst) + " delay=" + strconv.Itoa(limitReqCoffee.Delay) + ";",
+		"limit_req_status " + strconv.Itoa(limitReqTea.Status) + ";",
+		"limit_req_status " + strconv.Itoa(limitReqCoffee.Status) + ";",
+	}
+
+	for _, want := range wantDirectives {
+		if !strings.Contains(ingConf, want) {
 			t.Errorf("want %q in generated config", want)
 		}
 	}
@@ -2117,6 +2238,178 @@ var (
 		Ingress: Ingress{
 			Name:      "cafe-ingress",
 			Namespace: "default",
+		},
+	}
+
+	// Ingress Config that includes a request rate limit
+	ingressCfgRequestRateLimit = IngressNginxConfig{
+		Ingress: Ingress{
+			Name:      "myingress",
+			Namespace: "default",
+		},
+		Servers: []Server{
+			{
+				Name:         "test.example.com",
+				ServerTokens: "off",
+				StatusZone:   "test.example.com",
+				JWTAuth: &JWTAuth{
+					Key:                  "/etc/nginx/secrets/key.jwk",
+					Realm:                "closed site",
+					Token:                "$cookie_auth_token",
+					RedirectLocationName: "@login_url-default-cafe-ingress",
+				},
+				SSL:               true,
+				SSLCertificate:    "secret.pem",
+				SSLCertificateKey: "secret.pem",
+				SSLPorts:          []int{443},
+				SSLRedirect:       true,
+				Locations: []Location{
+					{
+						Path:                "/tea",
+						Upstream:            testUpstream,
+						ProxyConnectTimeout: "10s",
+						ProxyReadTimeout:    "10s",
+						ProxySendTimeout:    "10s",
+						ClientMaxBodySize:   "2m",
+						JWTAuth: &JWTAuth{
+							Key:   "/etc/nginx/secrets/location-key.jwk",
+							Realm: "closed site",
+							Token: "$cookie_auth_token",
+						},
+						LimitReq: &LimitReq{
+							Zone:   "default/myingress",
+							Burst:  100,
+							Delay:  50,
+							Status: 429,
+						},
+					},
+					{
+						Path:                "/coffee",
+						Upstream:            testUpstream,
+						ProxyConnectTimeout: "10s",
+						ProxyReadTimeout:    "10s",
+						ProxySendTimeout:    "10s",
+						ClientMaxBodySize:   "2m",
+						JWTAuth: &JWTAuth{
+							Key:   "/etc/nginx/secrets/location-key.jwk",
+							Realm: "closed site",
+							Token: "$cookie_auth_token",
+						},
+						LimitReq: &LimitReq{
+							Zone:   "default/myingress",
+							Burst:  100,
+							Delay:  50,
+							Status: 429,
+						},
+					},
+				},
+				HealthChecks: map[string]HealthCheck{"test": healthCheck},
+				JWTRedirectLocations: []JWTRedirectLocation{
+					{
+						Name:     "@login_url-default-cafe-ingress",
+						LoginURL: "https://test.example.com/login",
+					},
+				},
+			},
+		},
+		LimitReqZones: []LimitReqZone{
+			{
+				Name: "default/myingress",
+				Size: "10m",
+				Rate: "200r/s",
+			},
+		},
+	}
+
+	ingressCfgRequestRateLimitMinions = IngressNginxConfig{
+		Ingress: Ingress{
+			Name:      "myingress",
+			Namespace: "default",
+		},
+		Servers: []Server{
+			{
+				Name:         "test.example.com",
+				ServerTokens: "off",
+				StatusZone:   "test.example.com",
+				JWTAuth: &JWTAuth{
+					Key:                  "/etc/nginx/secrets/key.jwk",
+					Realm:                "closed site",
+					Token:                "$cookie_auth_token",
+					RedirectLocationName: "@login_url-default-cafe-ingress",
+				},
+				SSL:               true,
+				SSLCertificate:    "secret.pem",
+				SSLCertificateKey: "secret.pem",
+				SSLPorts:          []int{443},
+				SSLRedirect:       true,
+				Locations: []Location{
+					{
+						Path:                "/tea",
+						Upstream:            testUpstream,
+						ProxyConnectTimeout: "10s",
+						ProxyReadTimeout:    "10s",
+						ProxySendTimeout:    "10s",
+						ClientMaxBodySize:   "2m",
+						JWTAuth: &JWTAuth{
+							Key:   "/etc/nginx/secrets/location-key.jwk",
+							Realm: "closed site",
+							Token: "$cookie_auth_token",
+						},
+						MinionIngress: &Ingress{
+							Name:      "tea-minion",
+							Namespace: "default",
+						},
+						LimitReq: &LimitReq{
+							Zone:   "default/tea-minion",
+							Burst:  100,
+							Delay:  50,
+							Status: 429,
+						},
+					},
+					{
+						Path:                "/coffee",
+						Upstream:            testUpstream,
+						ProxyConnectTimeout: "10s",
+						ProxyReadTimeout:    "10s",
+						ProxySendTimeout:    "10s",
+						ClientMaxBodySize:   "2m",
+						JWTAuth: &JWTAuth{
+							Key:   "/etc/nginx/secrets/location-key.jwk",
+							Realm: "closed site",
+							Token: "$cookie_auth_token",
+						},
+						MinionIngress: &Ingress{
+							Name:      "coffee-minion",
+							Namespace: "default",
+						},
+						LimitReq: &LimitReq{
+							Zone:   "default/coffee-minion",
+							Burst:  200,
+							Delay:  100,
+							Status: 503,
+						},
+					},
+				},
+				HealthChecks: map[string]HealthCheck{"test": healthCheck},
+				JWTRedirectLocations: []JWTRedirectLocation{
+					{
+						Name:     "@login_url-default-cafe-ingress",
+						LoginURL: "https://test.example.com/login",
+					},
+				},
+			},
+		},
+		LimitReqZones: []LimitReqZone{
+			{
+				Name: "default/tea-minion",
+				Size: "10m",
+				Rate: "200r/s",
+			},
+			{
+				Name: "default/coffee-minion",
+				Size: "20m",
+				Rate: "400r/s",
+			},
 		},
 	}
 )


### PR DESCRIPTION
### Proposed changes

This implements #4603.
Ingress resources can now have annotations to control request-rate-limiting.

Key points:
- Rate-limits apply per ingress object (all routes/paths of an ingress share a common limit_req_zone and have common settings)
- Supports different limits per path using minions. (Each mergeable minion can have separate rate-limiting configuration. Each minion uses it's own zone.
- By default, no rate-limit is applied. limit_req_status defaults to 429. Zone size defaults to 10m.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork