### PR TITLE
Fixed validation for VSR exact & regex subroutes

### DIFF
--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -1479,7 +1479,7 @@ func (vsv *VirtualServerValidator) validateVirtualServerRouteSubroutes(routes []
 		isRouteFieldForbidden := true
 		routeErrs := vsv.validateRoute(r, idxPath, upstreamNames, isRouteFieldForbidden, namespace)
 
-		if vsPath != "" && !strings.HasPrefix(r.Path, vsPath) && !isRegexOrExactMatch(r.Path) {
+		if vsPath != "" && !strings.HasPrefix(r.Path, vsPath) {
 			msg := fmt.Sprintf("must start with '%s'", vsPath)
 			routeErrs = append(routeErrs, field.Invalid(idxPath, r.Path, msg))
 		}


### PR DESCRIPTION
Since a VSR may only contain a single subroute when using exact or regex matching skipping route validation here is incorrect.

Correctly configured VSRs for regex or exact will be validated (and terminate) earlier in function, ie. where VS path is regex + only 1 subroute + subroute syntax check passes.

Resolves ticket: [4727](https://github.com/nginxinc/kubernetes-ingress/issues/4727)

X -- I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
N/a -- I have added tests that prove my fix is effective or that my feature works
No --  I have checked that all unit tests pass after adding my changes
N/A --  I have updated necessary documentation
X -- I have rebased my branch onto main
X --  I will ensure my PR is targeting the main branch and pulling from my branch from my own fork




