### PR TITLE
add AppProtect version to pod label

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -43,8 +43,10 @@ import (
 var version string
 
 const (
-	nginxVersionLabel = "app.nginx.org/version"
-	versionLabel      = "app.kubernetes.io/version"
+	nginxVersionLabel      = "app.nginx.org/version"
+	versionLabel           = "app.kubernetes.io/version"
+	appProtectVersionLabel = "appprotect.f5.com/version"
+	appProtectVersionPath  = "/opt/app_protect/VERSION"
 )
 
 func main() {
@@ -71,7 +73,12 @@ func main() {
 
 	nginxVersion := getNginxVersionInfo(nginxManager)
 
-	updateSelfWithVersionInfo(kubeClient, version, nginxVersion)
+	var appProtectVersion string
+	if *appProtect {
+		appProtectVersion = getAppProtectVersionInfo()
+	}
+
+	updateSelfWithVersionInfo(kubeClient, version, nginxVersion, appProtectVersion)
 
 	templateExecutor, templateExecutorV2 := createTemplateExecutors()
 
@@ -400,6 +407,19 @@ func getNginxVersionInfo(nginxManager nginx.Manager) string {
 		glog.Fatal("NGINX Plus binary found without NGINX Plus flag (-nginx-plus)")
 	}
 	return nginxVersion
+}
+
+func getAppProtectVersionInfo() string {
+	if _, err := os.Stat(appProtectVersionPath); err != nil {
+		glog.Fatalf("Cannot find AppProtect VERSION file %v", appProtectVersionPath)
+	}
+	v, err := os.ReadFile(appProtectVersionPath)
+	if err != nil {
+		glog.Fatalf("Cannot open AppProtect VERSION file %v", appProtectVersionPath)
+	}
+	version := strings.TrimSpace(string(v))
+	glog.Infof("Using AppProtect Version %s", version)
+	return version
 }
 
 func startApAgentsAndPlugins(nginxManager nginx.Manager) (chan error, chan error) {
@@ -766,7 +786,7 @@ func processConfigMaps(kubeClient *kubernetes.Clientset, cfgParams *configs.Conf
 	return cfgParams
 }
 
-func updateSelfWithVersionInfo(kubeClient *kubernetes.Clientset, version string, nginxVersion string) {
+func updateSelfWithVersionInfo(kubeClient *kubernetes.Clientset, version string, nginxVersion string, appProtectVersion string) {
 	pod, err := kubeClient.CoreV1().Pods(os.Getenv("POD_NAMESPACE")).Get(context.TODO(), os.Getenv("POD_NAME"), meta_v1.GetOptions{})
 	if err != nil {
 		glog.Errorf("Error getting pod: %v", err)
@@ -783,6 +803,9 @@ func updateSelfWithVersionInfo(kubeClient *kubernetes.Clientset, version string,
 	replacer := strings.NewReplacer(" ", "-", "(", "", ")", "")
 	nginxVer = replacer.Replace(nginxVer)
 	labels[nginxVersionLabel] = nginxVer
+	if appProtectVersion != "" {
+		labels[appProtectVersionLabel] = appProtectVersion
+	}
 	labels[versionLabel] = strings.TrimPrefix(version, "v")
 	newPod.ObjectMeta.Labels = labels
 

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -74,7 +74,7 @@ func main() {
 	nginxVersion := getNginxVersionInfo(nginxManager)
 
 	var appProtectVersion string
-	if *appProtect {
+	if *appProtect || *appProtectDos {
 		appProtectVersion = getAppProtectVersionInfo()
 	}
 

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -74,7 +74,7 @@ func main() {
 	nginxVersion := getNginxVersionInfo(nginxManager)
 
 	var appProtectVersion string
-	if *appProtect || *appProtectDos {
+	if *appProtect {
 		appProtectVersion = getAppProtectVersionInfo()
 	}
 

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -412,7 +412,7 @@ func getNginxVersionInfo(nginxManager nginx.Manager) string {
 func getAppProtectVersionInfo() string {
 	v, err := os.ReadFile(appProtectVersionPath)
 	if err != nil {
-		glog.Fatalf("Cannot read AppProtect VERSION file, %s", err.Error())
+		glog.Fatalf("Cannot detect the AppProtect version, %s", err.Error())
 	}
 	version := strings.TrimSpace(string(v))
 	glog.Infof("Using AppProtect Version %s", version)

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -410,12 +410,9 @@ func getNginxVersionInfo(nginxManager nginx.Manager) string {
 }
 
 func getAppProtectVersionInfo() string {
-	if _, err := os.Stat(appProtectVersionPath); err != nil {
-		glog.Fatalf("Cannot find AppProtect VERSION file %v", appProtectVersionPath)
-	}
 	v, err := os.ReadFile(appProtectVersionPath)
 	if err != nil {
-		glog.Fatalf("Cannot open AppProtect VERSION file %v", appProtectVersionPath)
+		glog.Fatalf("Cannot read AppProtect VERSION file, %s", err.Error())
 	}
 	version := strings.TrimSpace(string(v))
 	glog.Infof("Using AppProtect Version %s", version)


### PR DESCRIPTION
### Proposed changes

Adds the `appprotect.f5.com/version` label to the `nginx-ingress` pod when AppProtect is in use

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
