### PR TITLE
skip pr for get id token step

### DIFF
--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -91,6 +91,7 @@ jobs:
           script: |
             let id_token = await core.getIDToken()
             core.setOutput('id_token', id_token)
+        if: ${{ github.event_name != 'pull_request' && ! startsWith(github.ref, 'refs/heads/release-') }}
 
       - name: Login to NGINX Registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0


### PR DESCRIPTION
### Proposed changes

Fixes pipeline issue on PRs where the `Get Id token` step in  the `build-plus.yml` workflow was failing. This fix works by avoiding this step on PRs

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
