### PR TITLE
cleanup kind cluster configuration management

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,13 +45,8 @@ run-tests: ## Run tests
 	docker run --rm -v $(KUBE_CONFIG_FOLDER):/root/.kube $(TEST_PREFIX):$(TEST_TAG) --context=$(CONTEXT) --image=$(BUILD_IMAGE) --image-pull-policy=$(PULL_POLICY) --deployment-type=$(DEPLOYMENT_TYPE) --ic-type=$(IC_TYPE) --service=$(SERVICE) --node-ip=$(NODE_IP) --show-ic-logs=$(SHOW_IC_LOGS) $(PYTEST_ARGS)
 
 
-.PHONY: update-test-kind-config ## Update Kind config
-update-test-kind-config:
-	sed -ir "s|server:.*|server: https://$(strip $(K8S_CLUSTER_NAME))-control-plane:6443|" $(KIND_KUBE_CONFIG_FOLDER)/config
-
-
 .PHONY: run-tests-in-kind
-run-tests-in-kind: update-test-kind-config ## Run tests in Kind
+run-tests-in-kind: ## Run tests in Kind
 	docker run --network=kind --rm \
 		-v $(KIND_KUBE_CONFIG_FOLDER):/root/.kube \
 		-v $(ROOT_DIR)/tests:/workspace/tests \
@@ -72,8 +67,8 @@ create-kind-cluster: $(KIND_KUBE_CONFIG_FOLDER) ## Create a Kind K8S cluster
 		--name $(K8S_CLUSTER_NAME) \
 		--image=kindest/node:v$(K8S_CLUSTER_VERSION) \
 		--config=<(sed 's/dual/${IP_FAMILY}/' $(ROOT_DIR)/tests/ci-files/ci-kind-config.yaml) \
-		--kubeconfig $(KIND_KUBE_CONFIG_FOLDER)/config \
 		--wait $(K8S_TIMEOUT)
+	@kind get kubeconfig --name $(K8S_CLUSTER_NAME) --internal > $(KIND_KUBE_CONFIG_FOLDER)/config
 
 
 .PHONY: delete-kind-cluster


### PR DESCRIPTION
### Proposed changes

Currently the kube config for kind clusters is created in `~/.kube/kind/config` which requires switching config files often during local development. This separate config file is so that it can be easily mounted into the smoke test container.

This change instead adds the config to the default location (`~/.kube/config`) and still creates `~/.kube/kind/config` using `kind get kubeconfig`. It also uses the `--internal` flag when getting the config to avoid the need to manually update the config file with the internal docker network address of the cluster.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
