### PR TITLE
ensure latest tag is used for GIT_TAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # variables that should not be overridden by the user
-GIT_TAG = $(shell git describe --tags --abbrev=0 || echo untagged)
+GIT_TAG = $(shell git tag --sort=-version:refname | head -n1 || echo untagged)
 VERSION = $(GIT_TAG)-SNAPSHOT
 PLUS_ARGS = --secret id=nginx-repo.crt,src=nginx-repo.crt --secret id=nginx-repo.key,src=nginx-repo.key
 


### PR DESCRIPTION
### Proposed changes

Update to make sure the version variable is the latest tag

```
$ make build
Docker version 24.0.6, build ed223bc
go version go1.21.4 darwin/arm64
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=v3.4.0-SNAPSHOT" -o nginx-ingress github.com/nginxinc/kubernetes-ingress/cmd/nginx-ingress
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
