### PR TITLE
add final job to consolidate the smoke test result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,20 @@ jobs:
           path: ${{ github.workspace }}/tests/${{ steps.smoke-tests.outputs.test-results-name }}.html
         if: always()
 
+  smoke-results:
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    name: Final Smoke Test Results
+    needs: [smoke-tests]
+    steps:
+      - run: |
+          result="${{ needs.smoke-tests.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+
   build-docker:
     name: Build Docker OSS
     needs: [checks, smoke-tests]


### PR DESCRIPTION
### Proposed changes

This change will add a job to the CI workflow to consolidate the smoke test results.  This will allow us to rely on this job for PR status checks of smoke tests.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
