### PR TITLE
Bump the actions group with 2 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Download Syft
-        uses: anchore/sbom-action/download-syft@41f7a6c033dbcdf78917f23b652c8b8146298c85 # v0.15.4
+        uses: anchore/sbom-action/download-syft@24b0d5238516480139aa8bc6f92eeb7b54a9eb0a # v0.15.5
         if: github.ref_type == 'tag'
 
       - name: Install Cosign
@@ -187,7 +187,7 @@ jobs:
         if: ${{ needs.checks.outputs.binary_cache_hit != 'true' }}
 
       - name: Download Syft
-        uses: anchore/sbom-action/download-syft@41f7a6c033dbcdf78917f23b652c8b8146298c85 # v0.15.4
+        uses: anchore/sbom-action/download-syft@24b0d5238516480139aa8bc6f92eeb7b54a9eb0a # v0.15.5
         if: github.ref_type == 'tag'
 
       - name: Install Cosign

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: reviewdog/action-actionlint@9ccda195fd3a290c8596db7f1958c897deaa8c76 # v1.40.0
+      - uses: reviewdog/action-actionlint@6a38513dd4d2e818798c5c73d0870adbb82de4a4 # v1.41.0
         with:
           actionlint_flags: -shellcheck ""
 


### PR DESCRIPTION
Bumps the actions group with 2 updates: [anchore/sbom-action](https://github.com/anchore/sbom-action) and [reviewdog/action-actionlint](https://github.com/reviewdog/action-actionlint).


Updates `anchore/sbom-action` from 0.15.4 to 0.15.5
- [Release notes](https://github.com/anchore/sbom-action/releases)
- [Commits](https://github.com/anchore/sbom-action/compare/41f7a6c033dbcdf78917f23b652c8b8146298c85...24b0d5238516480139aa8bc6f92eeb7b54a9eb0a)

Updates `reviewdog/action-actionlint` from 1.40.0 to 1.41.0
- [Release notes](https://github.com/reviewdog/action-actionlint/releases)
- [Commits](https://github.com/reviewdog/action-actionlint/compare/9ccda195fd3a290c8596db7f1958c897deaa8c76...6a38513dd4d2e818798c5c73d0870adbb82de4a4)

---
updated-dependencies:
- dependency-name: anchore/sbom-action dependency-type: direct:production update-type: version-update:semver-patch dependency-group: actions
- dependency-name: reviewdog/action-actionlint dependency-type: direct:production update-type: version-update:semver-minor dependency-group: actions ...
