### PR TITLE
Improve formatting of load balance method and ssl_certificate_key in configs

### DIFF
--- a/internal/configs/version1/nginx-plus.ingress.tmpl
+++ b/internal/configs/version1/nginx-plus.ingress.tmpl
@@ -3,7 +3,9 @@
 {{- range $upstream := .Upstreams}}
 upstream {{$upstream.Name}} {
 	zone {{$upstream.Name}} {{if ne $upstream.UpstreamZoneSize "0"}}{{$upstream.UpstreamZoneSize}}{{else}}512k{{end}};
-	{{- if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
+	{{- if $upstream.LBMethod }}
+	{{$upstream.LBMethod}};
+	{{- end}}
 	{{- range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}}
 	    {{- if $server.SlowStart}} slow_start={{$server.SlowStart}}{{end}}{{if $server.Resolve}} resolve{{end}};{{end}}

--- a/internal/configs/version1/nginx.ingress.tmpl
+++ b/internal/configs/version1/nginx.ingress.tmpl
@@ -3,7 +3,9 @@
 {{- range $upstream := .Upstreams}}
 upstream {{$upstream.Name}} {
 	{{- if ne $upstream.UpstreamZoneSize "0"}}zone {{$upstream.Name}} {{$upstream.UpstreamZoneSize}};{{end}}
-	{{- if $upstream.LBMethod }}{{$upstream.LBMethod}};{{end}}
+	{{- if $upstream.LBMethod }}
+	{{$upstream.LBMethod}};
+	{{- end}}
 	{{- range $server := $upstream.UpstreamServers}}
 	server {{$server.Address}} max_fails={{$server.MaxFails}} fail_timeout={{$server.FailTimeout}} max_conns={{$server.MaxConns}};{{end}}
 	{{- if $.Keepalive}}keepalive {{$.Keepalive}};{{end}}

--- a/internal/configs/version2/nginx-plus.transportserver.tmpl
+++ b/internal/configs/version2/nginx-plus.transportserver.tmpl
@@ -2,7 +2,6 @@
 {{- range $u := .Upstreams }}
 upstream {{ $u.Name }} {
     zone {{ $u.Name }} 256k;
-
     {{- if $u.LoadBalancingMethod }}
     {{ $u.LoadBalancingMethod }};
     {{- end }}

--- a/internal/configs/version2/nginx-plus.virtualserver.tmpl
+++ b/internal/configs/version2/nginx-plus.virtualserver.tmpl
@@ -2,8 +2,9 @@
 {{ range $u := .Upstreams }}
 upstream {{ $u.Name }} {
     zone {{ $u.Name }} {{ if ne $u.UpstreamZoneSize "0" }}{{ $u.UpstreamZoneSize }}{{ else }}512k{{ end }};
-
-    {{- if $u.LBMethod }}{{ $u.LBMethod }};{{ end }}
+    {{- if $u.LBMethod }}
+    {{ $u.LBMethod }};
+    {{- end }}
 
     {{- range $s := $u.Servers }}
     server {{ $s.Address }} max_fails={{ $u.MaxFails }} fail_timeout={{ $u.FailTimeout }}{{ if $u.SlowStart }} slow_start={{ $u.SlowStart }}{{ end }} max_conns={{ $u.MaxConns }}{{ if $u.Resolve }} resolve{{ end }};
@@ -114,7 +115,7 @@ server {
     ssl_certificate_key {{ makeSecretPath "/etc/nginx/secrets/spiffe_key.pem" $.StaticSSLPath "$secret_dir_path" $.DynamicSSLReloadEnabled }};
        {{- else }}
     ssl_certificate {{ makeSecretPath $ssl.Certificate $.StaticSSLPath "$secret_dir_path" $.DynamicSSLReloadEnabled }};
-	ssl_certificate_key {{ makeSecretPath $ssl.CertificateKey $.StaticSSLPath "$secret_dir_path" $.DynamicSSLReloadEnabled }};
+    ssl_certificate_key {{ makeSecretPath $ssl.CertificateKey $.StaticSSLPath "$secret_dir_path" $.DynamicSSLReloadEnabled }};
         {{- end }}
     {{- else }}
       {{- if $.SpiffeCerts }}

--- a/internal/configs/version2/nginx.transportserver.tmpl
+++ b/internal/configs/version2/nginx.transportserver.tmpl
@@ -2,7 +2,6 @@
 {{- range $u := .Upstreams }}
 upstream {{ $u.Name }} {
     zone {{ $u.Name }} 256k;
-
     {{- if $u.LoadBalancingMethod }}
     {{ $u.LoadBalancingMethod }};
     {{- end }}

--- a/internal/configs/version2/nginx.virtualserver.tmpl
+++ b/internal/configs/version2/nginx.virtualserver.tmpl
@@ -2,8 +2,9 @@
 {{ range $u := .Upstreams }}
 upstream {{ $u.Name }} {
     {{- if ne $u.UpstreamZoneSize "0" }}zone {{ $u.Name }} {{ $u.UpstreamZoneSize }};{{ end }}
-
-    {{- if $u.LBMethod }}{{ $u.LBMethod }};{{ end }}
+    {{- if $u.LBMethod }}
+    {{ $u.LBMethod }};
+    {{- end }}
 
     {{- range $s := $u.Servers }}
     server {{ $s.Address }} max_fails={{ $u.MaxFails }} fail_timeout={{ $u.FailTimeout }} max_conns={{ $u.MaxConns }};


### PR DESCRIPTION
### Proposed changes
Fixes #4951 

nginx -T before
```
//TODO
```

nginx -T after
```nginx
upstream vs_default_cafe_coffee {
    zone vs_default_cafe_coffee 512k;
    random two least_conn;
    server 10.244.0.4:8080 max_fails=1 fail_timeout=10s max_conns=0;
    server 10.244.0.5:8080 max_fails=1 fail_timeout=10s max_conns=0;

    
}

upstream vs_default_cafe_tea {
    zone vs_default_cafe_tea 512k;
    random two least_conn;
    server 10.244.0.6:8080 max_fails=1 fail_timeout=10s max_conns=0;

    
}


server {
    listen 80;
    listen [::]:80;


    server_name cafe.example.com;
    status_zone cafe.example.com;
    set $resource_type "virtualserver";
    set $resource_name "cafe";
    set $resource_namespace "default";
    listen 443 ssl;
    listen [::]:443 ssl;

    ssl_certificate $secret_dir_path/default-cafe-secret;
    ssl_certificate_key $secret_dir_path/default-cafe-secret;
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
