### PR TITLE
build test image on the forked workflow

### DIFF
--- a/.github/actions/smoke-tests/action.yaml
+++ b/.github/actions/smoke-tests/action.yaml
@@ -112,6 +112,7 @@ runs:
         token_format: access_token
         workload_identity_provider: ${{ inputs.gcr-workload-identity-secret }}
         service_account: ${{ inputs.gcr-service-account-secret }}
+      if: github.event.pull_request.head.repo.full_name == github.repository
 
     - name: Login to GCR
       uses: docker/login-action@v3
@@ -119,13 +120,7 @@ runs:
         registry: gcr.io
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
-
-    - name: Check if image exists
-      id: check-image
-      run: |
-        docker manifest inspect ${{ inputs.test-image }}
-      shell: bash
-      continue-on-error: true
+      if: github.event.pull_request.head.repo.full_name == github.repository
 
     - name: Build Test-Runner Container
       uses: docker/build-push-action@v3
@@ -135,8 +130,7 @@ runs:
         cache-from: type=gha,scope=test-runner
         tags: ${{ inputs.test-image }}
         pull: true
-        push: true
-      if: steps.check-image.outcome == 'failure'
+      if: github.event.pull_request.head.repo.full_name != github.repository
 
     - name: Run Smoke Tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,16 +320,41 @@ jobs:
       - name: Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+        if: github.event.pull_request.head.repo.full_name == github.repository
+
+      - name: Login to GCR
+        uses: docker/login-action@v3
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+        if: github.event.pull_request.head.repo.full_name == github.repository
+
+      - name: Check if image exists
+        id: check-image
+        run: |
+          docker manifest inspect "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/test-runner:${{ hashFiles('./tests/requirements.txt') || 'latest' }}"
+        shell: bash
+        continue-on-error: true
+        if: github.event.pull_request.head.repo.full_name == github.repository
+
       - name: Build Test-Runner Container
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+        uses: docker/build-push-action@v3
         with:
           file: tests/Dockerfile
           context: "."
           cache-from: type=gha,scope=test-runner
-          cache-to: type=gha,scope=test-runner,mode=max
-          tags: test-runner:${{ github.sha }}
+          tags: "gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/test-runner:${{ hashFiles('./tests/requirements.txt') || 'latest' }}"
           pull: true
-          load: true
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.check-image.outcome == 'failure' || github.event.pull_request.head.repo.full_name != github.repository }}
 
   smoke-tests:
     name: ${{ matrix.images.label }} ${{ matrix.images.image }} smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,9 @@ jobs:
     name: Setup Matrix for Smoke Tests
     runs-on: ubuntu-22.04
     needs: [binaries, checks]
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
### Proposed changes

Contributors using forked PR's are not able to pull the test container image for smoke tests.  This change builds the image on forked PR's.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
