### PR TITLE
Use NGINX Version method to format the pod label string

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -79,7 +79,7 @@ func main() {
 		appProtectVersion = getAppProtectVersionInfo()
 	}
 
-	go updateSelfWithVersionInfo(kubeClient, version, nginxVersion.String(), appProtectVersion, 10, time.Second*5)
+	go updateSelfWithVersionInfo(kubeClient, version, appProtectVersion, nginxVersion, 10, time.Second*5)
 
 	templateExecutor, templateExecutorV2 := createTemplateExecutors()
 
@@ -789,10 +789,7 @@ func processConfigMaps(kubeClient *kubernetes.Clientset, cfgParams *configs.Conf
 	return cfgParams
 }
 
-func updateSelfWithVersionInfo(kubeClient *kubernetes.Clientset, version, nginxVersion, appProtectVersion string, maxRetries int, waitTime time.Duration) {
-	nginxVer := strings.TrimSuffix(strings.Split(nginxVersion, "/")[1], "\n")
-	replacer := strings.NewReplacer(" ", "-", "(", "", ")", "")
-	nginxVer = replacer.Replace(nginxVer)
+func updateSelfWithVersionInfo(kubeClient *kubernetes.Clientset, version, appProtectVersion string, nginxVersion nginx.Version, maxRetries int, waitTime time.Duration) {
 	podUpdated := false
 
 	for i := 0; (i < maxRetries || maxRetries == 0) && !podUpdated; i++ {
@@ -812,7 +809,7 @@ func updateSelfWithVersionInfo(kubeClient *kubernetes.Clientset, version, nginxV
 			labels = make(map[string]string)
 		}
 
-		labels[nginxVersionLabel] = nginxVer
+		labels[nginxVersionLabel] = nginxVersion.Format()
 		labels[versionLabel] = strings.TrimPrefix(version, "v")
 		if appProtectVersion != "" {
 			labels[appProtectVersionLabel] = appProtectVersion


### PR DESCRIPTION
### Proposed changes

This PR introduces a change of how the NGINX Pod Label is parsed. The label format remains the same.

Tests:

**N+**


```shell
kubectl describe pod -n nginx-ingress nginx-ingress-7c4bc86f6d-4z4gk

Name:             nginx-ingress-7c4bc86f6d-4z4gk
Namespace:        nginx-ingress
Priority:         0
Service Account:  nginx-ingress
Node:             local-control-plane/172.18.0.2
Start Time:       Wed, 31 Jan 2024 10:20:26 +0000
Labels:           app=nginx-ingress
                  app.kubernetes.io/name=nginx-ingress
                  app.kubernetes.io/version=3.5.0-SNAPSHOT
                  app.nginx.org/version=1.25.3-nginx-plus-r31
                  pod-template-hash=7c4bc86f6d
```


**N OSS**:

```shell
kubectl describe pod -n nginx-ingress nginx-ingress-569d85c4cb-4jt2c

Name:             nginx-ingress-569d85c4cb-4jt2c
Namespace:        nginx-ingress
Priority:         0
Service Account:  nginx-ingress
Node:             local-control-plane/172.18.0.2
Start Time:       Wed, 31 Jan 2024 10:27:43 +0000
Labels:           app=nginx-ingress
                  app.kubernetes.io/name=nginx-ingress
                  app.kubernetes.io/version=3.5.0-SNAPSHOT
                  app.nginx.org/version=1.25.3
                  pod-template-hash=569d85c4cb
```


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
