### PR TITLE
Add missing platforms in base image build

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -97,6 +97,7 @@ jobs:
           cache-to: type=gha,mode=max
           target: common
           tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platforms }}
           pull: true
           push: true
           build-args: |
@@ -162,6 +163,7 @@ jobs:
           cache-to: type=gha,mode=max
           target: common
           tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platforms }}
           pull: true
           push: true
           build-args: |
@@ -248,6 +250,7 @@ jobs:
           cache-to: type=gha,mode=max
           target: common
           tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platforms }}
           pull: true
           push: true
           build-args: |


### PR DESCRIPTION
### Proposed changes

Base images currently only build amd64 images, platform flag is needed to cover other architectures.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
