### PR TITLE
trim image sha256 from release update workflow

### DIFF
--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Set NGINX versions
         id: versions
         run: |
-          nginx=library/$(grep -E "FROM nginx.*debian" < build/Dockerfile | awk -F" " '{print $2}')
-          nginx_alpine=library/$(grep -E "FROM nginx.*alpine" < build/Dockerfile | awk -F" " '{print $2}')
-          nginx_ubi=$(grep -m1 "FROM nginx.*ubi" < build/Dockerfile | awk -F" " '{print $2}')
+          nginx=library/$(grep -E "FROM nginx.*debian" < build/Dockerfile | awk -F" " '{print $2}' | cut -d '@' -f 1)
+          nginx_alpine=library/$(grep -E "FROM nginx.*alpine" < build/Dockerfile | awk -F" " '{print $2}' | cut -d '@' -f 1)
+          nginx_ubi=$(grep -m1 "FROM nginx.*ubi" < build/Dockerfile | awk -F" " '{print $2}' | cut -d '@' -f 1)
           echo "matrix=[{\"version\": \"${nginx}\", \"distro\": \"debian\"}, {\"version\": \"${nginx_alpine}\", \"distro\": \"alpine\"}, {\"version\": \"${nginx_ubi}\", \"distro\": \"ubi\"}]" >> $GITHUB_OUTPUT
 
       - name: Set Go MD5sums


### PR DESCRIPTION
### Proposed changes

The workflow to patch the released OSS images was failing.  This was due to the sha256 sum of the image being present on the image tag.  This change trims the sha256 from the tag.

Example:
`library/nginx:1.25.3@sha256:2bdc49f2f8ae8d8dc50ed00f2ee56d00385c6f8bc8a8b320d0a294d9e3b49026` now becomes `library/nginx:1.25.3`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
