### PR TITLE
Fix template file spacing for `ssl_protocols` directive

### DIFF
--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -130,10 +130,18 @@ http {
         default upgrade;
         ''      $default_connection_header;
     }
-    {{- if .SSLProtocols}}ssl_protocols {{.SSLProtocols}};{{end}}
-    {{- if .SSLCiphers}}ssl_ciphers "{{.SSLCiphers}}";{{end}}
-    {{- if .SSLPreferServerCiphers}}ssl_prefer_server_ciphers on;{{end}}
-    {{- if .SSLDHParam}}ssl_dhparam {{.SSLDHParam}};{{end}}
+    {{- if .SSLProtocols}}
+    ssl_protocols {{.SSLProtocols}};
+    {{- end}}
+    {{- if .SSLCiphers}}
+    ssl_ciphers "{{.SSLCiphers}}";
+    {{- end}}
+    {{- if .SSLPreferServerCiphers}}
+    ssl_prefer_server_ciphers on;
+    {{- end}}
+    {{- if .SSLDHParam}}
+    ssl_dhparam {{.SSLDHParam}};
+    {{- end}}
 
     {{- if .OpenTracingEnabled}}
     opentracing on;

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -91,10 +91,18 @@ http {
         default upgrade;
         ''      $default_connection_header;
     }
-    {{- if .SSLProtocols}}ssl_protocols {{.SSLProtocols}};{{end}}
-    {{- if .SSLCiphers}}ssl_ciphers "{{.SSLCiphers}}";{{end}}
-    {{- if .SSLPreferServerCiphers}}ssl_prefer_server_ciphers on;{{end}}
-    {{- if .SSLDHParam}}ssl_dhparam {{.SSLDHParam}};{{end}}
+    {{- if .SSLProtocols}}
+    ssl_protocols {{.SSLProtocols}};
+    {{- end}}
+    {{- if .SSLCiphers}}
+    ssl_ciphers "{{.SSLCiphers}}";
+    {{- end}}
+    {{- if .SSLPreferServerCiphers}}
+    ssl_prefer_server_ciphers on;
+    {{- end}}
+    {{- if .SSLDHParam}}
+    ssl_dhparam {{.SSLDHParam}};
+    {{- end}}
 
     {{- if .OpenTracingEnabled}}
     opentracing on;


### PR DESCRIPTION
### Proposed changes
**Before**
```nginx
map $http_upgrade $vs_connection_header {
        default upgrade;
        ''      $default_connection_header;
}ssl_protocols TLSv1.2 TLSv1.3;
```
**After**
```nginx
map $http_upgrade $vs_connection_header {
        default upgrade;
        ''      $default_connection_header;
}
ssl_protocols TLSv1.2 TLSv1.3;
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
