### PR TITLE
Add an option to set telemetry reporting period

### DIFF
--- a/cmd/nginx-ingress/flags.go
+++ b/cmd/nginx-ingress/flags.go
@@ -204,6 +204,7 @@ var (
 	enableDynamicSSLReload = flag.Bool(dynamicSSLReloadParam, true, "Enable reloading of SSL Certificates without restarting the NGINX process.")
 
 	enableTelemetryReporting = flag.Bool("enable-telemetry-reporting", true, "Enable gathering and reporting of product related telemetry.")
+	telemetryReportingPeriod = flag.String("telemetry-reporting-period", "24h", "Sets a telemetry reporting period.")
 
 	startupCheckFn func() error
 )
@@ -386,6 +387,12 @@ func validationChecks() {
 		logLevelValidationError := validateAppProtectLogLevel(*appProtectLogLevel)
 		if logLevelValidationError != nil {
 			glog.Fatalf("Invalid value for app-protect-log-level: %v", *appProtectLogLevel)
+		}
+	}
+
+	if telemetryReportingPeriod != nil {
+		if err := validateReportingPeriod(*telemetryReportingPeriod); err != nil {
+			glog.Fatalf("Invalid value for telemetry-reporting-period: %v", err)
 		}
 	}
 }

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -202,6 +202,7 @@ func main() {
 		IsIPV6Disabled:               *disableIPV6,
 		WatchNamespaceLabel:          *watchNamespaceLabel,
 		EnableTelemetryReporting:     *enableTelemetryReporting,
+		TelemetryReportingPeriod:     *telemetryReportingPeriod,
 	}
 
 	lbc := k8s.NewLoadBalancerController(lbcInput)

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -211,6 +211,7 @@ type NewLoadBalancerControllerInput struct {
 	IsIPV6Disabled               bool
 	WatchNamespaceLabel          string
 	EnableTelemetryReporting     bool
+	TelemetryReportingPeriod     string
 }
 
 // NewLoadBalancerController creates a controller
@@ -280,7 +281,7 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 	if input.EnableTelemetryReporting {
 		lbc.telemetryChan = make(chan struct{})
 		collector, err := telemetry.NewCollector(
-			telemetry.WithTimePeriod("24h"),
+			telemetry.WithTimePeriod(input.TelemetryReportingPeriod),
 		)
 		if err != nil {
 			glog.Fatalf("failed to initialize telemetry collector: %v", err)

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -3764,6 +3764,7 @@ func TestNewTelemetryCollector(t *testing.T) {
 			input: NewLoadBalancerControllerInput{
 				KubeClient:               fake.NewSimpleClientset(),
 				EnableTelemetryReporting: true,
+				TelemetryReportingPeriod: "24h",
 			},
 			expectedCollector: telemetry.Collector{
 				Period:   24 * time.Hour,


### PR DESCRIPTION
This option is added for testing purposes. The minimum time period is set to 1 minute

### Proposed changes

This PR reinstates an option that allows to set telemetry reporting period to a min 1 minute. The option is added for testing purpose.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
