### PR TITLE
Ensure `backup` server is removed from upstreams when the Backup Service is deleted

### DIFF
--- a/examples/custom-resources/backup-directive/virtual-server/README.md
+++ b/examples/custom-resources/backup-directive/virtual-server/README.md
@@ -92,7 +92,7 @@ Note that the backup service is configured with cluster domain name of the exter
 Run the below curl command to get a response from your application. In this example we hit the `/coffee` endpoint:
 
    ```shell
-   curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/tea --insecure
+   curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/coffee --insecure
    ```
 
    ```shell
@@ -115,7 +115,7 @@ Run the below curl command to get a response from your application. In this exam
 2. Run the below curl command. Notice that Server name in the response is `coffee-backup-<id>` instead of `coffee-<id>`
 
    ```shell
-   curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/tea --insecure
+   curl --resolve cafe.example.com:$IC_HTTPS_PORT:$IC_IP https://cafe.example.com:$IC_HTTPS_PORT/coffee --insecure
    ```
 
 3. Check response from the backup service

--- a/internal/configs/transportserver.go
+++ b/internal/configs/transportserver.go
@@ -186,9 +186,9 @@ func generateStreamUpstreams(transportServerEx *TransportServerEx, upstreamNamer
 		}
 
 		var backupEndpoints []string
-		if u.Backup != nil && u.BackupPort != nil {
-			backupEnpointsKey := GenerateEndpointsKey(transportServerEx.TransportServer.Namespace, *u.Backup, nil, *u.BackupPort)
-			externalNameSvcKey = GenerateExternalNameSvcKey(transportServerEx.TransportServer.Namespace, *u.Backup)
+		if u.Backup != "" && u.BackupPort != nil {
+			backupEnpointsKey := GenerateEndpointsKey(transportServerEx.TransportServer.Namespace, u.Backup, nil, *u.BackupPort)
+			externalNameSvcKey = GenerateExternalNameSvcKey(transportServerEx.TransportServer.Namespace, u.Backup)
 
 			backupEndpoints = transportServerEx.Endpoints[backupEnpointsKey]
 			_, isExternalNameSvc = transportServerEx.ExternalNameSvcs[externalNameSvcKey]

--- a/internal/configs/transportserver_test.go
+++ b/internal/configs/transportserver_test.go
@@ -598,7 +598,7 @@ func TestGenerateTransportServerConfigForBackupServiceNGINXPlus(t *testing.T) {
 
 	transportServerEx := tsEx()
 	transportServerEx.TransportServer.Spec.Upstreams[0].LoadBalancingMethod = "least_conn"
-	transportServerEx.TransportServer.Spec.Upstreams[0].Backup = createPointerFromString("backup-svc")
+	transportServerEx.TransportServer.Spec.Upstreams[0].Backup = "backup-svc"
 	transportServerEx.TransportServer.Spec.Upstreams[0].BackupPort = createPointerFromUInt16(5090)
 	transportServerEx.Endpoints = map[string][]string{
 		"default/tcp-app-svc:5001": {
@@ -752,7 +752,7 @@ func TestGenerateTransportServerConfig_DoesNotGenerateBackupOnMissingBackupPort(
 
 	transportServerEx := tsEx()
 	transportServerEx.TransportServer.Spec.Upstreams[0].LoadBalancingMethod = "least_conn"
-	transportServerEx.TransportServer.Spec.Upstreams[0].Backup = createPointerFromString("clustertwo.corp.local")
+	transportServerEx.TransportServer.Spec.Upstreams[0].Backup = "clustertwo.corp.local"
 	transportServerEx.TransportServer.Spec.Upstreams[0].BackupPort = nil
 	transportServerEx.Endpoints = map[string][]string{
 		"default/tcp-app-svc:5001": {
@@ -826,7 +826,7 @@ func TestGenerateTransportServerConfig_DoesNotGenerateBackupOnMissingBackupPortA
 
 	transportServerEx := tsEx()
 	transportServerEx.TransportServer.Spec.Upstreams[0].LoadBalancingMethod = "least_conn"
-	transportServerEx.TransportServer.Spec.Upstreams[0].Backup = nil
+	transportServerEx.TransportServer.Spec.Upstreams[0].Backup = ""
 	transportServerEx.TransportServer.Spec.Upstreams[0].BackupPort = nil
 	transportServerEx.Endpoints = map[string][]string{
 		"default/tcp-app-svc:5001": {

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -315,18 +315,18 @@ func (vsc *virtualServerConfigurator) generateBackupEndpointsForUpstream(
 	upstream conf_v1.Upstream,
 	virtualServerEx *VirtualServerEx,
 ) []string {
-	if upstream.Backup == nil || upstream.BackupPort == nil {
+	if upstream.Backup == "" || upstream.BackupPort == nil {
 		return []string{}
 	}
-	externalNameSvcKey := GenerateExternalNameSvcKey(namespace, *upstream.Backup)
+	externalNameSvcKey := GenerateExternalNameSvcKey(namespace, upstream.Backup)
 	_, isExternalNameSvc := virtualServerEx.ExternalNameSvcs[externalNameSvcKey]
 	if isExternalNameSvc && !vsc.isResolverConfigured {
 		msgFmt := "Type ExternalName service %v in upstream %v will be ignored. To use ExternaName services, a resolver must be configured in the ConfigMap"
-		vsc.addWarningf(owner, msgFmt, *upstream.Backup, upstream.Name)
+		vsc.addWarningf(owner, msgFmt, upstream.Backup, upstream.Name)
 		return []string{}
 	}
 
-	backupEndpointsKey := GenerateEndpointsKey(namespace, *upstream.Backup, upstream.Subselector, *upstream.BackupPort)
+	backupEndpointsKey := GenerateEndpointsKey(namespace, upstream.Backup, upstream.Subselector, *upstream.BackupPort)
 	backupEndpoints := virtualServerEx.Endpoints[backupEndpointsKey]
 	if len(backupEndpoints) == 0 {
 		return []string{}
@@ -2442,8 +2442,8 @@ func createUpstreamsForPlus(
 		endpoints := virtualServerEx.Endpoints[endpointsKey]
 
 		backupEndpoints := []string{}
-		if u.Backup != nil {
-			backupEndpointsKey := GenerateEndpointsKey(upstreamNamespace, *u.Backup, u.Subselector, *u.BackupPort)
+		if u.Backup != "" {
+			backupEndpointsKey := GenerateEndpointsKey(upstreamNamespace, u.Backup, u.Subselector, *u.BackupPort)
 			backupEndpoints = virtualServerEx.Endpoints[backupEndpointsKey]
 		}
 		ups := vsc.generateUpstream(virtualServerEx.VirtualServer, upstreamName, u, isExternalNameSvc, endpoints, backupEndpoints)
@@ -2467,8 +2467,8 @@ func createUpstreamsForPlus(
 
 			// BackupService
 			backupEndpoints := []string{}
-			if u.Backup != nil {
-				backupEndpointsKey := GenerateEndpointsKey(upstreamNamespace, *u.Backup, u.Subselector, *u.BackupPort)
+			if u.Backup != "" {
+				backupEndpointsKey := GenerateEndpointsKey(upstreamNamespace, u.Backup, u.Subselector, *u.BackupPort)
 				backupEndpoints = virtualServerEx.Endpoints[backupEndpointsKey]
 			}
 			ups := vsc.generateUpstream(vsr, upstreamName, u, isExternalNameSvc, endpoints, backupEndpoints)

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -1185,7 +1185,7 @@ func TestGenerateVirtualServerConfigWithBackupForNGINXPlus(t *testing.T) {
 
 	virtualServerEx := vsEx()
 	virtualServerEx.VirtualServer.Spec.Upstreams[2].LBMethod = "least_conn"
-	virtualServerEx.VirtualServer.Spec.Upstreams[2].Backup = createPointerFromString("backup-svc")
+	virtualServerEx.VirtualServer.Spec.Upstreams[2].Backup = "backup-svc"
 	virtualServerEx.VirtualServer.Spec.Upstreams[2].BackupPort = createPointerFromUInt16(8090)
 	virtualServerEx.Endpoints = map[string][]string{
 		"default/tea-svc:80": {
@@ -1496,7 +1496,7 @@ func TestGenerateVirtualServerConfig_DoesNotGenerateBackupOnMissingBackupNameFor
 
 	virtualServerEx := vsEx()
 	virtualServerEx.VirtualServer.Spec.Upstreams[2].LBMethod = "least_conn"
-	virtualServerEx.VirtualServer.Spec.Upstreams[2].Backup = nil
+	virtualServerEx.VirtualServer.Spec.Upstreams[2].Backup = ""
 	virtualServerEx.VirtualServer.Spec.Upstreams[2].BackupPort = createPointerFromUInt16(8090)
 	virtualServerEx.Endpoints = map[string][]string{
 		"default/tea-svc:80": {
@@ -1802,7 +1802,7 @@ func TestGenerateVirtualServerConfig_DoesNotGenerateBackupOnMissingBackupPortFor
 
 	virtualServerEx := vsEx()
 	virtualServerEx.VirtualServer.Spec.Upstreams[2].LBMethod = "least_conn"
-	virtualServerEx.VirtualServer.Spec.Upstreams[2].Backup = createPointerFromString("backup-svc")
+	virtualServerEx.VirtualServer.Spec.Upstreams[2].Backup = "backup-svc"
 	virtualServerEx.VirtualServer.Spec.Upstreams[2].BackupPort = nil
 	virtualServerEx.Endpoints = map[string][]string{
 		"default/tea-svc:80": {
@@ -2107,7 +2107,7 @@ func TestGenerateVirtualServerConfig_DoesNotGenerateBackupOnMissingBackupPortAnd
 
 	virtualServerEx := vsEx()
 	virtualServerEx.VirtualServer.Spec.Upstreams[2].LBMethod = "least_conn"
-	virtualServerEx.VirtualServer.Spec.Upstreams[2].Backup = nil
+	virtualServerEx.VirtualServer.Spec.Upstreams[2].Backup = ""
 	virtualServerEx.VirtualServer.Spec.Upstreams[2].BackupPort = nil
 	virtualServerEx.Endpoints = map[string][]string{
 		"default/tea-svc:80": {

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -991,13 +991,6 @@ func createPointerFromUInt16(n uint16) *uint16 {
 	return &n
 }
 
-// createPointerFromString is a helper that takes a string
-// and returns a pointer to the value. It is used for testing
-// BackupService configuration for Virtual and Transport Servers.
-func createPointerFromString(s string) *string {
-	return &s
-}
-
 // vsEx returns Virtual Server Ex config struct.
 // It's safe to modify returned config for parallel test execution.
 func vsEx() VirtualServerEx {

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -3072,16 +3072,16 @@ func (lbc *LoadBalancerController) createVirtualServerEx(virtualServer *conf_v1.
 	// If backup and backup port are defined it generates a backup server entry for the upstream.
 	// Backup Service is of type ExternalName.
 	generateBackupEndpoints := func(endpoints map[string][]string, u conf_v1.Upstream) {
-		if u.Backup == nil || u.BackupPort == nil {
+		if u.Backup == "" || u.BackupPort == nil {
 			return
 		}
-		backupEndpointsKey := configs.GenerateEndpointsKey(virtualServer.Namespace, *u.Backup, u.Subselector, *u.BackupPort)
-		backupEndps, external, err := lbc.getEndpointsForUpstream(virtualServer.Namespace, *u.Backup, *u.BackupPort)
+		backupEndpointsKey := configs.GenerateEndpointsKey(virtualServer.Namespace, u.Backup, u.Subselector, *u.BackupPort)
+		backupEndps, external, err := lbc.getEndpointsForUpstream(virtualServer.Namespace, u.Backup, *u.BackupPort)
 		if err != nil {
 			glog.Warningf("Error getting Endpoints for Upstream %v: %v", u.Name, err)
 		}
 		if err == nil && external {
-			externalNameSvcs[configs.GenerateExternalNameSvcKey(virtualServer.Namespace, *u.Backup)] = true
+			externalNameSvcs[configs.GenerateExternalNameSvcKey(virtualServer.Namespace, u.Backup)] = true
 		}
 		bendps := getIPAddressesFromEndpoints(backupEndps)
 		endpoints[backupEndpointsKey] = bendps
@@ -3606,14 +3606,14 @@ func (lbc *LoadBalancerController) createTransportServerEx(transportServer *conf
 		}
 
 		// If backup defined on Upstream retrieve its external name and port.
-		if u.Backup != nil && u.BackupPort != nil {
-			backupEndpointsKey := configs.GenerateEndpointsKey(transportServer.Namespace, *u.Backup, nil, *u.BackupPort)
-			backupEndps, external, err := lbc.getEndpointsForUpstream(transportServer.Namespace, *u.Backup, *u.BackupPort)
+		if u.Backup != "" && u.BackupPort != nil {
+			backupEndpointsKey := configs.GenerateEndpointsKey(transportServer.Namespace, u.Backup, nil, *u.BackupPort)
+			backupEndps, external, err := lbc.getEndpointsForUpstream(transportServer.Namespace, u.Backup, *u.BackupPort)
 			if err != nil {
 				glog.Warningf("Error getting Endpoints for Upstream %v: %v", u.Name, err)
 			}
 			if err == nil && external {
-				externalNameSvcs[configs.GenerateExternalNameSvcKey(transportServer.Namespace, *u.Backup)] = true
+				externalNameSvcs[configs.GenerateExternalNameSvcKey(transportServer.Namespace, u.Backup)] = true
 			}
 			bendps := getIPAddressesFromEndpoints(backupEndps)
 			endpoints[backupEndpointsKey] = bendps

--- a/internal/k8s/reference_checkers.go
+++ b/internal/k8s/reference_checkers.go
@@ -147,7 +147,7 @@ func (rc *serviceReferenceChecker) IsReferencedByVirtualServer(svcNamespace stri
 		if rc.hasClusterIP && u.UseClusterIP {
 			continue
 		}
-		if u.Service == svcName {
+		if u.Service == svcName || u.Backup == svcName {
 			return true
 		}
 	}
@@ -178,7 +178,7 @@ func (rc *serviceReferenceChecker) IsReferencedByTransportServer(svcNamespace st
 	}
 
 	for _, u := range ts.Spec.Upstreams {
-		if u.Service == svcName {
+		if u.Service == svcName || u.Backup == svcName {
 			return true
 		}
 	}

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -125,7 +125,7 @@ type Upstream struct {
 	UseClusterIP             bool              `json:"use-cluster-ip"`
 	NTLM                     bool              `json:"ntlm"`
 	Type                     string            `json:"type"`
-	Backup                   *string           `json:"backup"`
+	Backup                   string            `json:"backup"`
 	BackupPort               *uint16           `json:"backupPort"`
 }
 
@@ -479,7 +479,7 @@ type TransportServerUpstream struct {
 	MaxConns            *int                        `json:"maxConns"`
 	HealthCheck         *TransportServerHealthCheck `json:"healthCheck"`
 	LoadBalancingMethod string                      `json:"loadBalancingMethod"`
-	Backup              *string                     `json:"backup"`
+	Backup              string                      `json:"backup"`
 	BackupPort          *uint16                     `json:"backupPort"`
 }
 

--- a/pkg/apis/configuration/validation/transportserver_test.go
+++ b/pkg/apis/configuration/validation/transportserver_test.go
@@ -67,7 +67,7 @@ func TestValidateTransportServer_BackupService(t *testing.T) {
 	t.Parallel()
 
 	ts := makeTransportServer()
-	ts.Spec.Upstreams[0].Backup = createPointerFromString("backup-service")
+	ts.Spec.Upstreams[0].Backup = "backup-service"
 	ts.Spec.Upstreams[0].BackupPort = createPointerFromUInt16(5505)
 
 	tsv := createTransportServerValidator()
@@ -97,7 +97,7 @@ func TestValidateTransportServer_FailsOnMissingBackupPort(t *testing.T) {
 	t.Parallel()
 
 	ts := makeTransportServer()
-	ts.Spec.Upstreams[0].Backup = createPointerFromString("backup-service-ts")
+	ts.Spec.Upstreams[0].Backup = "backup-service-ts"
 	// backup port not created, it's nil
 
 	tsv := createTransportServerValidator()
@@ -118,7 +118,7 @@ func TestValidateTransportServer_FailsOnNotSupportedLBMethodForBackup(t *testing
 			t.Parallel()
 
 			ts := makeTransportServer()
-			ts.Spec.Upstreams[0].Backup = createPointerFromString("backup-service")
+			ts.Spec.Upstreams[0].Backup = "backup-service"
 			ts.Spec.Upstreams[0].BackupPort = createPointerFromUInt16(5505)
 			ts.Spec.Upstreams[0].LoadBalancingMethod = lbMethod
 

--- a/pkg/apis/configuration/validation/virtualserver.go
+++ b/pkg/apis/configuration/validation/virtualserver.go
@@ -255,11 +255,11 @@ func validatePositiveIntOrZeroFromPointer(n *int, fieldPath *field.Path) field.E
 	return nil
 }
 
-func validateBackupNameFromPointer(backup *string, fieldPath *field.Path) field.ErrorList {
-	if backup == nil {
+func validateBackupName(backup string, fieldPath *field.Path) field.ErrorList {
+	if backup == "" {
 		return nil
 	}
-	backupName := *backup
+	backupName := backup
 	return validateServiceName(backupName, fieldPath.Child("backup"))
 }
 
@@ -624,15 +624,15 @@ func (vsv *VirtualServerValidator) validateUpstreams(upstreams []v1.Upstream, fi
 //
 // Backup can't be used with load balancing methods: 'hash', 'hash_ip' and 'random'.
 // Ref.: https://nginx.org/en/docs/http/ngx_http_upstream_module.html
-func validateBackup(backup *string, backupPort *uint16, lbMethod string, idxPath *field.Path) field.ErrorList {
-	if backup == nil && backupPort == nil {
+func validateBackup(backup string, backupPort *uint16, lbMethod string, idxPath *field.Path) field.ErrorList {
+	if backup == "" && backupPort == nil {
 		return nil
 	}
 	allErrs := field.ErrorList{}
-	if backup != nil && backupPort == nil {
+	if backup != "" && backupPort == nil {
 		allErrs = append(allErrs, field.Invalid(idxPath.Child("backupPort"), backupPort, "both backup and backup port must be specified"))
 	}
-	if backup == nil && backupPort != nil {
+	if backup == "" && backupPort != nil {
 		allErrs = append(allErrs, field.Invalid(idxPath.Child("backup"), backup, "both backup and backup port must be specified"))
 	}
 
@@ -642,7 +642,7 @@ func validateBackup(backup *string, backupPort *uint16, lbMethod string, idxPath
 		))
 	}
 
-	allErrs = append(allErrs, validateBackupNameFromPointer(backup, idxPath.Child("backup"))...)
+	allErrs = append(allErrs, validateBackupName(backup, idxPath.Child("backup"))...)
 	allErrs = append(allErrs, validateBackupPortFromPointer(backupPort, idxPath.Child("backupPort"))...)
 	return allErrs
 }

--- a/pkg/apis/configuration/validation/virtualserver_test.go
+++ b/pkg/apis/configuration/validation/virtualserver_test.go
@@ -128,7 +128,7 @@ func TestValidateFailsOnMissingBackupPort(t *testing.T) {
 
 	vs := makeVirtualServer()
 	// setup only backup name, missing backup port
-	vs.Spec.Upstreams[1].Backup = createPointerFromString("backup-service")
+	vs.Spec.Upstreams[1].Backup = "backup-service"
 
 	vsv := &VirtualServerValidator{isPlus: true, isDosEnabled: true}
 	err := vsv.ValidateVirtualServer(&vs)
@@ -165,7 +165,7 @@ func TestValidateFailsOnNotSupportedLBMethodForBackup(t *testing.T) {
 			t.Parallel()
 
 			vs := makeVirtualServer()
-			vs.Spec.Upstreams[1].Backup = createPointerFromString("backup-service")
+			vs.Spec.Upstreams[1].Backup = "backup-service"
 			vs.Spec.Upstreams[1].BackupPort = createPointerFromUInt16(8080)
 
 			// Not supported load balancing method
@@ -184,7 +184,7 @@ func TestValidateBackup(t *testing.T) {
 	t.Parallel()
 
 	vs := makeVirtualServer()
-	vs.Spec.Upstreams[1].Backup = createPointerFromString("backup-service")
+	vs.Spec.Upstreams[1].Backup = "backup-service"
 	vs.Spec.Upstreams[1].BackupPort = createPointerFromUInt16(8080)
 
 	vsv := &VirtualServerValidator{isPlus: true, isDosEnabled: true}

--- a/tests/suite/test_transport_server_backup_service.py
+++ b/tests/suite/test_transport_server_backup_service.py
@@ -52,7 +52,7 @@ def ts_externalname_setup(
 ) -> ExternalNameSetup:
     print("------------------------- Deploy External-Backend -----------------------------------")
     external_ns = create_namespace_with_name_from_yaml(kube_apis.v1, "external-ns", f"{TEST_DATA}/common/ns.yaml")
-    external_svc_name = create_service_with_name(kube_apis.v1, external_ns, "external-backend-svc")
+    external_svc_name = create_service_with_name(kube_apis.v1, external_ns, "external-backend-svc", 8443, 8443)
     create_secret_from_yaml(kube_apis.v1, external_ns, secure_app_secret)
     create_configmap_from_yaml(kube_apis.v1, external_ns, secure_app_config_map)
     create_secure_app_deployment_with_name(kube_apis.apps_v1_api, external_ns, "external-backend")
@@ -163,6 +163,7 @@ def transport_server_tls_passthrough_setup(
 
 @pytest.mark.ts
 @pytest.mark.skip_for_nginx_oss
+@pytest.mark.backup_service
 @pytest.mark.parametrize(
     "crd_ingress_controller, transport_server_tls_passthrough_setup",
     [
@@ -288,19 +289,12 @@ class TestTransportServerWithBackupService:
         assert "least_conn;" in result_conf
         assert f"server {ts_externalname_setup.external_host}:8443 resolve backup;" in result_conf
 
+        resp_after_scale = session.get(
+            req_url,
+            headers={"host": transport_server_tls_passthrough_setup.ts_host},
+            verify=False,
+        )
 
-#         resp_after_scale = session.get(
-#             req_url,
-#             headers={"host": transport_server_tls_passthrough_setup.ts_host},
-#             verify=False,
-#         )
-#
-#         print("---")
-#         print(resp_after_scale.status_code)
-#         print("---")
-#
-#         print("---")
-#         print(resp_after_scale.text)
-#         print("---")
-#
-#         scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "secure-app", test_namespace, 1)
+        assert resp_after_scale.status_code == 200
+
+        scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "secure-app", test_namespace, 1)

--- a/tests/suite/test_transport_server_backup_service.py
+++ b/tests/suite/test_transport_server_backup_service.py
@@ -163,7 +163,6 @@ def transport_server_tls_passthrough_setup(
 
 @pytest.mark.ts
 @pytest.mark.skip_for_nginx_oss
-@pytest.mark.backup_service
 @pytest.mark.parametrize(
     "crd_ingress_controller, transport_server_tls_passthrough_setup",
     [

--- a/tests/suite/test_virtual_server_backup_service.py
+++ b/tests/suite/test_virtual_server_backup_service.py
@@ -107,7 +107,6 @@ def vs_externalname_setup(
 @pytest.mark.vs
 @pytest.mark.skip_for_nginx_oss
 @pytest.mark.backup_service
-@pytest.mark.skip
 @pytest.mark.parametrize(
     "crd_ingress_controller, virtual_server_setup",
     [
@@ -150,7 +149,7 @@ class TestVirtualServerWithBackupService:
         )
         wait_before_test()
 
-        print("\nStep 2: Get response from VS with backup service")
+        print("\nStep 1: Get response from VS with backup service")
         print(virtual_server_setup.backend_1_url + "\n")
         res = make_request(
             virtual_server_setup.backend_1_url,
@@ -197,7 +196,7 @@ class TestVirtualServerWithBackupService:
         )
         wait_before_test()
 
-        print("\nStep 2: Get response from VS with backup service")
+        print("\nStep 1: Get response from VS with backup service")
         print(virtual_server_setup.backend_1_url + "\n")
         res = make_request(
             virtual_server_setup.backend_1_url,
@@ -222,11 +221,11 @@ class TestVirtualServerWithBackupService:
         assert "least_conn;" in result_conf
         assert expected_conf_line in result_conf
 
-        print("\nStep 3: Scale deployment to zero replicas")
+        print("\nStep 2: Scale deployment to zero replicas")
         scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "backend1", virtual_server_setup.namespace, 0)
         wait_before_test()
 
-        print("\nStep 4: Get response from backup service")
+        print("\nStep 3: Get response from backup service")
         res_from_backup = make_request(
             virtual_server_setup.backend_1_url,
             virtual_server_setup.vs_host,
@@ -249,11 +248,11 @@ class TestVirtualServerWithBackupService:
         assert "least_conn;" in result_conf
         assert expected_conf_line in result_conf
 
-        print("\nStep 5: Scale deployment back to 2 replicas")
+        print("\nStep 4: Scale deployment back to 2 replicas")
         scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "backend1", virtual_server_setup.namespace, 2)
         wait_before_test()
 
-        print("\nStep 6: Get response")
+        print("\nStep 5: Get response")
         res_after_scaleup = make_request(
             virtual_server_setup.backend_1_url,
             virtual_server_setup.vs_host,
@@ -297,7 +296,7 @@ class TestVirtualServerWithBackupService:
         )
         wait_before_test()
 
-        print("\nStep 2: Get response from VS with backup service")
+        print("\nStep 1: Get response from VS with backup service")
         print(virtual_server_setup.backend_1_url + "\n")
         res = make_request(
             virtual_server_setup.backend_1_url,
@@ -322,11 +321,11 @@ class TestVirtualServerWithBackupService:
         assert "least_conn;" in result_conf
         assert expected_conf_line in result_conf
 
-        print("\nStep 3: Scale deployment to zero replicas")
+        print("\nStep 2: Scale deployment to zero replicas")
         scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "backend1", virtual_server_setup.namespace, 0)
         wait_before_test()
 
-        print("\nStep 4: Get response from backup service")
+        print("\nStep 3: Get response from backup service")
         res_from_backup = make_request(
             virtual_server_setup.backend_1_url,
             virtual_server_setup.vs_host,
@@ -349,11 +348,11 @@ class TestVirtualServerWithBackupService:
         assert "least_conn;" in result_conf
         assert expected_conf_line in result_conf
 
-        print("\nStep 5: Delete backup service by deleting the namespace")
+        print("\nStep 4: Delete backup service by deleting the namespace")
         delete_namespace(kube_apis.v1, "external-ns")
         wait_before_test()
 
-        print("\nStep 6: Get response")
+        print("\nStep 5: Get response")
         res_after_delete = make_request(
             virtual_server_setup.backend_1_url,
             virtual_server_setup.vs_host,

--- a/tests/suite/test_virtual_server_backup_service.py
+++ b/tests/suite/test_virtual_server_backup_service.py
@@ -106,7 +106,6 @@ def vs_externalname_setup(
 
 @pytest.mark.vs
 @pytest.mark.skip_for_nginx_oss
-@pytest.mark.backup_service
 @pytest.mark.parametrize(
     "crd_ingress_controller, virtual_server_setup",
     [

--- a/tests/suite/utils/resources_utils.py
+++ b/tests/suite/utils/resources_utils.py
@@ -409,7 +409,7 @@ def create_service(v1: CoreV1Api, namespace, body) -> str:
     return resp.metadata.name
 
 
-def create_service_with_name(v1: CoreV1Api, namespace, name) -> str:
+def create_service_with_name(v1: CoreV1Api, namespace, name, port=80, targetPort=8080) -> str:
     """
     Create a service with a specific name based on a common yaml manifest.
 
@@ -423,6 +423,8 @@ def create_service_with_name(v1: CoreV1Api, namespace, name) -> str:
         dep = yaml.safe_load(f)
         dep["metadata"]["name"] = name
         dep["spec"]["selector"]["app"] = name.replace("-svc", "")
+        dep["spec"]["ports"][0]["port"] = port
+        dep["spec"]["ports"][0]["targetPort"] = targetPort
         return create_service(v1, namespace, dep)
 
 


### PR DESCRIPTION
### Proposed changes

This change ensure that the `backup` server in an upstream for both TransportServers and VirtualServers is removed when the service is deleted.

This change also changes the `Backup` type in `Upstream` from being a string pointer to a string value. This was done to stay consistent with the data type of `Service` in `Upstream`

Resolves https://github.com/nginxinc/kubernetes-ingress/issues/4774

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
