### PR TITLE
allow each image to have its own cache

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -93,8 +93,8 @@ jobs:
         with:
           file: build/Dockerfile
           context: "."
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max
           target: common
           tags: ${{ steps.meta.outputs.tags }}
           platforms: ${{ matrix.platforms }}
@@ -159,8 +159,8 @@ jobs:
         with:
           file: build/Dockerfile
           context: "."
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max
           target: common
           tags: ${{ steps.meta.outputs.tags }}
           platforms: ${{ matrix.platforms }}
@@ -246,8 +246,8 @@ jobs:
         with:
           file: build/Dockerfile
           context: "."
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ steps.nap_modules.outputs.modules }}
+          cache-to: type=gha,scope=${{ matrix.image }}-${{ steps.nap_modules.outputs.modules }},mode=max
           target: common
           tags: ${{ steps.meta.outputs.tags }}
           platforms: ${{ matrix.platforms }}


### PR DESCRIPTION
### Proposed changes

Reading https://docs.docker.com/build/cache/backends/gha/#scope describes needing to change the scope when caching multiple docker builds to prevent the last image being cached as the only one in the cache.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
