### PR TITLE
Add NodeCount to telemetry data

### DIFF
--- a/deployments/rbac/rbac.yaml
+++ b/deployments/rbac/rbac.yaml
@@ -57,6 +57,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/internal/telemetry/cluster.go
+++ b/internal/telemetry/cluster.go
@@ -1,0 +1,17 @@
+package telemetry
+
+import (
+	"context"
+
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NodeCount returns the total number of nodes in the cluster.
+// It returns an error if the underlying k8s API client errors.
+func (c *Collector) NodeCount(ctx context.Context) (int, error) {
+	nodes, err := c.Config.K8sClientReader.CoreV1().Nodes().List(ctx, metaV1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+	return len(nodes.Items), nil
+}

--- a/internal/telemetry/cluster_test.go
+++ b/internal/telemetry/cluster_test.go
@@ -1,0 +1,94 @@
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nginxinc/kubernetes-ingress/internal/telemetry"
+	apiCoreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	testClient "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNodeCountInAClusterWithThreeNodes(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCollectorForCluserWithNodes(t, node1, node2, node3)
+
+	got, err := c.NodeCount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 3
+	if want != got {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestNodeCountInAClusterWithOneNode(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCollectorForCluserWithNodes(t, node1)
+	got, err := c.NodeCount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 1
+	if want != got {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+// newTestCollectorForClusterWithNodes returns a telemetry collector configured
+// to simulate collecting data on a cluser with provided nodes.
+func newTestCollectorForCluserWithNodes(t *testing.T, nodes ...runtime.Object) *telemetry.Collector {
+	t.Helper()
+
+	c, err := telemetry.NewCollector(
+		telemetry.CollectorConfig{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Config.K8sClientReader = testClient.NewSimpleClientset(nodes...)
+	return c
+}
+
+var (
+	node1 = &apiCoreV1.Node{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "test-node-1",
+			Namespace: "default",
+		},
+		Spec: apiCoreV1.NodeSpec{},
+	}
+
+	node2 = &apiCoreV1.Node{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "test-node-2",
+			Namespace: "default",
+		},
+		Spec: apiCoreV1.NodeSpec{},
+	}
+
+	node3 = &apiCoreV1.Node{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "test-node-3",
+			Namespace: "default",
+		},
+		Spec: apiCoreV1.NodeSpec{},
+	}
+)

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -80,7 +80,7 @@ func (c *Collector) Start(ctx context.Context) {
 func (c *Collector) Collect(ctx context.Context) {
 	glog.V(3).Info("Collecting telemetry data")
 	// TODO: Re-add ctx to BuildReport when collecting Node Count.
-	data, err := c.BuildReport()
+	data, err := c.BuildReport(ctx)
 	if err != nil {
 		glog.Errorf("Error collecting telemetry data: %v", err)
 	}
@@ -92,7 +92,7 @@ func (c *Collector) Collect(ctx context.Context) {
 }
 
 // BuildReport takes context and builds report from gathered telemetry data.
-func (c *Collector) BuildReport() (Data, error) {
+func (c *Collector) BuildReport(ctx context.Context) (Data, error) {
 	d := Data{}
 	var err error
 
@@ -100,5 +100,10 @@ func (c *Collector) BuildReport() (Data, error) {
 		d.NICResourceCounts.VirtualServers, d.NICResourceCounts.VirtualServerRoutes = c.Config.Configurator.GetVirtualServerCounts()
 		d.NICResourceCounts.TransportServers = c.Config.Configurator.GetTransportServerCounts()
 	}
+	nc, err := c.NodeCount(ctx)
+	if err != nil {
+		glog.Errorf("Error collecting telemetry data: Nodes: %v", err)
+	}
+	d.NodeCount = nc
 	return d, err
 }

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -79,7 +79,6 @@ func (c *Collector) Start(ctx context.Context) {
 // It exports data using provided exporter.
 func (c *Collector) Collect(ctx context.Context) {
 	glog.V(3).Info("Collecting telemetry data")
-	// TODO: Re-add ctx to BuildReport when collecting Node Count.
 	data, err := c.BuildReport(ctx)
 	if err != nil {
 		glog.Errorf("Error collecting telemetry data: %v", err)

--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -29,6 +29,7 @@ func (e *StdoutExporter) Export(_ context.Context, data Data) error {
 type Data struct {
 	ProjectMeta       ProjectMeta
 	NICResourceCounts NICResourceCounts
+	NodeCount         int
 }
 
 // ProjectMeta holds metadata for the project.


### PR DESCRIPTION
### Proposed changes

This PR adds the k8s node counting functionality for the telemetry data collector.

Log example after deployment to a local kind cluster with one node:
```shell
I0221 17:08:04.753632       1 collector.go:81] Collecting telemetry data
I0221 17:08:04.779743       1 collector.go:91] Exported telemetry data: {ProjectMeta:{Name: Version:} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0} NodeCount:1}
```

Log example after deployment to a local kind cluster with three nodes:
```shell
I0221 17:15:05.111857       1 collector.go:81] Collecting telemetry data
I0221 17:15:05.130732       1 collector.go:91] Exported telemetry data: {ProjectMeta:{Name: Version:} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0} NodeCount:3}
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
