### PR TITLE
extract the first image tag to pass to Trivy

### DIFF
--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Extract image name for Trivy
         id: trivy-tag
         run: |
-          tag=$(echo $DOCKER_METADATA_OUTPUT_JSON | jq -r '.tags[] | select(contains("f5-gcs-7899"))' )
+          tag=$(echo $DOCKER_METADATA_OUTPUT_JSON | jq -r '[ .tags[] | select(contains("f5-gcs-7899"))] | .[0]')
           echo "tag=$tag" >> $GITHUB_OUTPUT
         if: ${{ inputs.publish-image }}
 


### PR DESCRIPTION
### Proposed changes

Nightly jobs were failing to extract the correct image name to pass to the Trivy scanner.  We now select the first tag from the list of GCR tags.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
