### PR TITLE
Add ClusterID to telemetry data

### DIFF
--- a/internal/telemetry/cluster.go
+++ b/internal/telemetry/cluster.go
@@ -16,10 +16,10 @@ func (c *Collector) NodeCount(ctx context.Context) (int, error) {
 	return len(nodes.Items), nil
 }
 
-// ClusterID returns the UID of the kube-dns service representing cluster id.
+// ClusterID returns the UID of the kube-system namespace representing cluster id.
 // It returns an error if the underlying k8s API client errors.
 func (c *Collector) ClusterID(ctx context.Context) (string, error) {
-	cluster, err := c.Config.K8sClientReader.CoreV1().Services("kube-system").Get(ctx, "kube-dns", metaV1.GetOptions{})
+	cluster, err := c.Config.K8sClientReader.CoreV1().Namespaces().Get(ctx, "kube-system", metaV1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/internal/telemetry/cluster.go
+++ b/internal/telemetry/cluster.go
@@ -15,3 +15,13 @@ func (c *Collector) NodeCount(ctx context.Context) (int, error) {
 	}
 	return len(nodes.Items), nil
 }
+
+// ClusterID returns the UID of the kube-dns service representing cluster id.
+// It returns an error if the underlying k8s API client errors.
+func (c *Collector) ClusterID(ctx context.Context) (string, error) {
+	cluster, err := c.Config.K8sClientReader.CoreV1().Services("kube-system").Get(ctx, "kube-dns", metaV1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return string(cluster.UID), nil
+}

--- a/internal/telemetry/cluster_test.go
+++ b/internal/telemetry/cluster_test.go
@@ -14,7 +14,7 @@ import (
 func TestNodeCountInAClusterWithThreeNodes(t *testing.T) {
 	t.Parallel()
 
-	c := newTestCollectorForCluserWithNodes(t, node1, node2, node3)
+	c := newTestCollectorForClusterWithNodes(t, node1, node2, node3)
 
 	got, err := c.NodeCount(context.Background())
 	if err != nil {
@@ -29,7 +29,7 @@ func TestNodeCountInAClusterWithThreeNodes(t *testing.T) {
 func TestNodeCountInAClusterWithOneNode(t *testing.T) {
 	t.Parallel()
 
-	c := newTestCollectorForCluserWithNodes(t, node1)
+	c := newTestCollectorForClusterWithNodes(t, node1)
 	got, err := c.NodeCount(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -43,7 +43,7 @@ func TestNodeCountInAClusterWithOneNode(t *testing.T) {
 func TestClusterIDRetrievesK8sClusterUID(t *testing.T) {
 	t.Parallel()
 
-	c := newTestCollectorForCluserWithNodes(t, node1, kubeNS)
+	c := newTestCollectorForClusterWithNodes(t, node1, kubeNS)
 
 	got, err := c.ClusterID(context.Background())
 	if err != nil {
@@ -59,7 +59,7 @@ func TestClusterIDRetrievesK8sClusterUID(t *testing.T) {
 func TestClusterIDErrorsOnNotExistingService(t *testing.T) {
 	t.Parallel()
 
-	c := newTestCollectorForCluserWithNodes(t, node1)
+	c := newTestCollectorForClusterWithNodes(t, node1)
 	_, err := c.ClusterID(context.Background())
 	if err == nil {
 		t.Error("want error, got nil")
@@ -68,7 +68,7 @@ func TestClusterIDErrorsOnNotExistingService(t *testing.T) {
 
 // newTestCollectorForClusterWithNodes returns a telemetry collector configured
 // to simulate collecting data on a cluser with provided nodes.
-func newTestCollectorForCluserWithNodes(t *testing.T, nodes ...runtime.Object) *telemetry.Collector {
+func newTestCollectorForClusterWithNodes(t *testing.T, nodes ...runtime.Object) *telemetry.Collector {
 	t.Helper()
 
 	c, err := telemetry.NewCollector(

--- a/internal/telemetry/cluster_test.go
+++ b/internal/telemetry/cluster_test.go
@@ -40,6 +40,32 @@ func TestNodeCountInAClusterWithOneNode(t *testing.T) {
 	}
 }
 
+func TestClusterIDRetrievesK8sClusterUID(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCollectorForCluserWithNodes(t, node1, kubeDNS)
+
+	got, err := c.ClusterID(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "329766ff-5d78-4c9e-8736-7faad1f2e937"
+	if want != got {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestClusterIDErrorsOnNotExistingService(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCollectorForCluserWithNodes(t, node1)
+	_, err := c.ClusterID(context.Background())
+	if err == nil {
+		t.Error("want error, got nil")
+	}
+}
+
 // newTestCollectorForClusterWithNodes returns a telemetry collector configured
 // to simulate collecting data on a cluser with provided nodes.
 func newTestCollectorForCluserWithNodes(t *testing.T, nodes ...runtime.Object) *telemetry.Collector {
@@ -90,5 +116,31 @@ var (
 			Namespace: "default",
 		},
 		Spec: apiCoreV1.NodeSpec{},
+	}
+
+	kubeDNS = &apiCoreV1.Service{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "kube-dns",
+			Namespace: "kube-system",
+			UID:       "329766ff-5d78-4c9e-8736-7faad1f2e937",
+		},
+		Spec: apiCoreV1.ServiceSpec{},
+	}
+
+	dummyKubeDNS = &apiCoreV1.Service{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "kube-dns",
+			Namespace: "kube-system",
+			UID:       "",
+		},
+		Spec: apiCoreV1.ServiceSpec{},
 	}
 )

--- a/internal/telemetry/cluster_test.go
+++ b/internal/telemetry/cluster_test.go
@@ -43,7 +43,7 @@ func TestNodeCountInAClusterWithOneNode(t *testing.T) {
 func TestClusterIDRetrievesK8sClusterUID(t *testing.T) {
 	t.Parallel()
 
-	c := newTestCollectorForCluserWithNodes(t, node1, kubeDNS)
+	c := newTestCollectorForCluserWithNodes(t, node1, kubeNS)
 
 	got, err := c.ClusterID(context.Background())
 	if err != nil {
@@ -118,29 +118,27 @@ var (
 		Spec: apiCoreV1.NodeSpec{},
 	}
 
-	kubeDNS = &apiCoreV1.Service{
+	kubeNS = &apiCoreV1.Namespace{
 		TypeMeta: metaV1.TypeMeta{
-			Kind:       "Service",
+			Kind:       "Namespace",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "kube-dns",
-			Namespace: "kube-system",
-			UID:       "329766ff-5d78-4c9e-8736-7faad1f2e937",
+			Name: "kube-system",
+			UID:  "329766ff-5d78-4c9e-8736-7faad1f2e937",
 		},
-		Spec: apiCoreV1.ServiceSpec{},
+		Spec: apiCoreV1.NamespaceSpec{},
 	}
 
-	dummyKubeDNS = &apiCoreV1.Service{
+	dummyKubeNS = &apiCoreV1.Namespace{
 		TypeMeta: metaV1.TypeMeta{
-			Kind:       "Service",
+			Kind:       "Namespace",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "kube-dns",
-			Namespace: "kube-system",
-			UID:       "",
+			Name: "kube-system",
+			UID:  "",
 		},
-		Spec: apiCoreV1.ServiceSpec{},
+		Spec: apiCoreV1.NamespaceSpec{},
 	}
 )

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -104,5 +104,11 @@ func (c *Collector) BuildReport(ctx context.Context) (Data, error) {
 		glog.Errorf("Error collecting telemetry data: Nodes: %v", err)
 	}
 	d.NodeCount = nc
+
+	cID, err := c.ClusterID(ctx)
+	if err != nil {
+		glog.Errorf("Error collecting telemetry data: ClusterID: %v", err)
+	}
+	d.ClusterID = cID
 	return d, err
 }

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -134,6 +134,42 @@ func TestCollectNodeCountInClusterWithThreeNodes(t *testing.T) {
 	}
 }
 
+func TestCollectClusterIDInClusterWithOneNode(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	exp := &telemetry.StdoutExporter{Endpoint: buf}
+	cfg := telemetry.CollectorConfig{
+		Configurator:    newConfigurator(t),
+		K8sClientReader: testClient.NewSimpleClientset(node1, kubeDNS),
+	}
+
+	c, err := telemetry.NewCollector(cfg, telemetry.WithExporter(exp))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Collect(context.Background())
+
+	td := telemetry.Data{
+		ProjectMeta: telemetry.ProjectMeta{
+			Name:    "",
+			Version: "",
+		},
+		NICResourceCounts: telemetry.NICResourceCounts{
+			VirtualServers:      0,
+			VirtualServerRoutes: 0,
+			TransportServers:    0,
+		},
+		NodeCount: 1,
+		ClusterID: "329766ff-5d78-4c9e-8736-7faad1f2e937",
+	}
+	want := fmt.Sprintf("%+v", td)
+	got := buf.String()
+	if !cmp.Equal(want, got) {
+		t.Error(cmp.Diff(want, got))
+	}
+}
+
 func TestCountVirtualServers(t *testing.T) {
 	t.Parallel()
 
@@ -243,7 +279,7 @@ func TestCountVirtualServers(t *testing.T) {
 		configurator := newConfigurator(t)
 
 		c, err := telemetry.NewCollector(telemetry.CollectorConfig{
-			K8sClientReader: testClient.NewSimpleClientset(),
+			K8sClientReader: testClient.NewSimpleClientset(dummyKubeDNS),
 			Configurator:    configurator,
 		})
 		if err != nil {
@@ -415,7 +451,7 @@ func TestCountTransportServers(t *testing.T) {
 		configurator := newConfigurator(t)
 
 		c, err := telemetry.NewCollector(telemetry.CollectorConfig{
-			K8sClientReader: testClient.NewSimpleClientset(),
+			K8sClientReader: testClient.NewSimpleClientset(dummyKubeDNS),
 			Configurator:    configurator,
 		})
 		if err != nil {

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -141,7 +141,7 @@ func TestCollectClusterIDInClusterWithOneNode(t *testing.T) {
 	exp := &telemetry.StdoutExporter{Endpoint: buf}
 	cfg := telemetry.CollectorConfig{
 		Configurator:    newConfigurator(t),
-		K8sClientReader: testClient.NewSimpleClientset(node1, kubeDNS),
+		K8sClientReader: testClient.NewSimpleClientset(node1, kubeNS),
 	}
 
 	c, err := telemetry.NewCollector(cfg, telemetry.WithExporter(exp))
@@ -279,7 +279,7 @@ func TestCountVirtualServers(t *testing.T) {
 		configurator := newConfigurator(t)
 
 		c, err := telemetry.NewCollector(telemetry.CollectorConfig{
-			K8sClientReader: testClient.NewSimpleClientset(dummyKubeDNS),
+			K8sClientReader: testClient.NewSimpleClientset(dummyKubeNS),
 			Configurator:    configurator,
 		})
 		if err != nil {
@@ -451,7 +451,7 @@ func TestCountTransportServers(t *testing.T) {
 		configurator := newConfigurator(t)
 
 		c, err := telemetry.NewCollector(telemetry.CollectorConfig{
-			K8sClientReader: testClient.NewSimpleClientset(dummyKubeDNS),
+			K8sClientReader: testClient.NewSimpleClientset(dummyKubeNS),
 			Configurator:    configurator,
 		})
 		if err != nil {

--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -30,6 +30,7 @@ type Data struct {
 	ProjectMeta       ProjectMeta
 	NICResourceCounts NICResourceCounts
 	NodeCount         int
+	ClusterID         string
 }
 
 // ProjectMeta holds metadata for the project.


### PR DESCRIPTION
### Proposed changes

This PR adds functionality to collect K8s ClusterID and add it to the telemetry data. 

Logs:

```shell
I0222 12:24:10.058225       1 collector.go:81] Collecting telemetry data
I0222 12:24:10.079962       1 collector.go:90] Exported telemetry data: {ProjectMeta:{Name: Version:} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0} NodeCount:1 ClusterID:bac905ad-d17b-4a94-b081-798c2373a7e2}
```


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
