### PR TITLE
add two spaces to the end of lines of community call section of the readme

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     rev: v4.5.0
     hooks:
       - id: trailing-whitespace
+        exclude: '(\.md$)'
       - id: end-of-file-fixer
       - id: check-yaml
         args: [--allow-multiple-documents]

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ This repo provides an implementation of an Ingress Controller for NGINX and NGIN
 
 We value community input and would love to see you at our next community call. At these calls, we discuss PRs by community members as well as issues, discussions and feature requests.
 
-**When**: Every other Monday at 4 PM Irish Time.
-**Zoom Link**: [KIC - GitHub Issues Triage](https://f5networks.zoom.us/j/91421953779?pwd=197738)
-**Password**: 197738
-**Slack**: Join our channel `#nginx-ingress-controller` on the [NGINX Community Slack](https://nginxcommunity.slack.com/channels/nginx-ingress-controller) for updates and discussions.
+**When**: Every other Monday at 4 PM Irish Time.  
+**Zoom Link**: [KIC - GitHub Issues Triage](https://f5networks.zoom.us/j/91421953779?pwd=197738)  
+**Password**: `197738`  
+**Slack**: Join our channel `#nginx-ingress-controller` on the [NGINX Community Slack](https://nginxcommunity.slack.com/channels/nginx-ingress-controller) for updates and discussions.  
 
 | **Date**      | **Irish Time** | **GMT**  |
 | -------------- | -------------- | -------- |

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ This repo provides an implementation of an Ingress Controller for NGINX and NGIN
 
 ## Join Our Next Community Call!
 
-We value community input and would love to see you at our next community call. At these calls, we discuss PRs by community members as well as issues, discussions and feature requests.  
+We value community input and would love to see you at our next community call. At these calls, we discuss PRs by community members as well as issues, discussions and feature requests.
 
-**When**: Every other Monday at 4 PM Irish Time.  
-**Zoom Link**: [KIC - GitHub Issues Triage](https://f5networks.zoom.us/j/91421953779?pwd=197738)  
-**Password**: 197738 
-**Slack**: Join our channel `#nginx-ingress-controller` on the [NGINX Community Slack](https://nginxcommunity.slack.com/channels/nginx-ingress-controller) for updates and discussions.  
+**When**: Every other Monday at 4 PM Irish Time.
+**Zoom Link**: [KIC - GitHub Issues Triage](https://f5networks.zoom.us/j/91421953779?pwd=197738)
+**Password**: 197738
+**Slack**: Join our channel `#nginx-ingress-controller` on the [NGINX Community Slack](https://nginxcommunity.slack.com/channels/nginx-ingress-controller) for updates and discussions.
 
 | **Date**      | **Irish Time** | **GMT**  |
 | -------------- | -------------- | -------- |

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ This repo provides an implementation of an Ingress Controller for NGINX and NGIN
 
 ## Join Our Next Community Call!
 
-We value community input and would love to see you at our next community call. At these calls, we discuss PRs by community members as well as issues, discussions and feature requests.
+We value community input and would love to see you at our next community call. At these calls, we discuss PRs by community members as well as issues, discussions and feature requests.  
 
-**When**: Every other Monday at 4 PM Irish Time.
-**Zoom Link**: [KIC - GitHub Issues Triage](https://f5networks.zoom.us/j/91421953779?pwd=197738)
-**Password**: 197738
-**Slack**: Join our channel `#nginx-ingress-controller` on the [NGINX Community Slack](https://nginxcommunity.slack.com/channels/nginx-ingress-controller) for updates and discussions.
+**When**: Every other Monday at 4 PM Irish Time.  
+**Zoom Link**: [KIC - GitHub Issues Triage](https://f5networks.zoom.us/j/91421953779?pwd=197738)  
+**Password**: 197738 
+**Slack**: Join our channel `#nginx-ingress-controller` on the [NGINX Community Slack](https://nginxcommunity.slack.com/channels/nginx-ingress-controller) for updates and discussions.  
 
 | **Date**      | **Irish Time** | **GMT**  |
 | -------------- | -------------- | -------- |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repo provides an implementation of an Ingress Controller for NGINX and NGIN
 
 ---
 
-## Join Our Next Community Call!
+## Join Our Next Community Call
 
 We value community input and would love to see you at our next community call. At these calls, we discuss PRs by community members as well as issues, discussions and feature requests.
 


### PR DESCRIPTION
### Proposed changes

The readme viewer in VsCode made it look like I had new lines in the previous PR. I have added them here
Here is how it will look now with spaces at thend. Tested on the github mardkown preview
<img width="1448" alt="image" src="https://github.com/nginxinc/kubernetes-ingress/assets/20595836/fd5dd12e-ec76-459b-b340-d49c89708412">
Trailing whitespaces are still looked at for markdown files by `markdownlint-cli2` and 2 spaces to break a line is valid by default with that tool.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
