### PR TITLE
Add NIC metadata (name and version) to telemetry data

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -205,6 +205,7 @@ func main() {
 		WatchNamespaceLabel:          *watchNamespaceLabel,
 		EnableTelemetryReporting:     *enableTelemetryReporting,
 		TelemetryReportingPeriod:     *telemetryReportingPeriod,
+		NICVersion:                   version,
 	}
 
 	lbc := k8s.NewLoadBalancerController(lbcInput)

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -212,6 +212,7 @@ type NewLoadBalancerControllerInput struct {
 	WatchNamespaceLabel          string
 	EnableTelemetryReporting     bool
 	TelemetryReportingPeriod     string
+	NICVersion                   string
 }
 
 // NewLoadBalancerController creates a controller
@@ -351,6 +352,7 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 			CustomK8sClientReader: input.ConfClient,
 			Period:                5 * time.Second,
 			Configurator:          lbc.configurator,
+			Version:               input.NICVersion,
 		}
 		lbc.telemetryChan = make(chan struct{})
 		collector, err := telemetry.NewCollector(

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -53,6 +53,9 @@ type CollectorConfig struct {
 	Period time.Duration
 
 	Configurator *configs.Configurator
+
+	// Version represents NIC version.
+	Version string
 }
 
 // NewCollector takes 0 or more options and creates a new TraceReporter.
@@ -93,9 +96,15 @@ func (c *Collector) Collect(ctx context.Context) {
 
 // BuildReport takes context and builds report from gathered telemetry data.
 func (c *Collector) BuildReport(ctx context.Context) (Data, error) {
-	d := Data{
-		Arch: runtime.GOARCH,
+	pm := ProjectMeta{
+		Name:    "NIC",
+		Version: c.Config.Version,
 	}
+	d := Data{
+		ProjectMeta: pm,
+		Arch:        runtime.GOARCH,
+	}
+
 	var err error
 
 	if c.Config.Configurator != nil {

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -52,6 +52,7 @@ func TestCreateNewCollectorWithCustomExporter(t *testing.T) {
 	cfg := telemetry.CollectorConfig{
 		K8sClientReader: newTestClientset(),
 		Configurator:    newConfigurator(t),
+		Version:         "3.5.0",
 	}
 	c, err := telemetry.NewCollector(cfg, telemetry.WithExporter(exp))
 	if err != nil {
@@ -60,6 +61,10 @@ func TestCreateNewCollectorWithCustomExporter(t *testing.T) {
 	c.Collect(context.Background())
 
 	td := telemetry.Data{
+		ProjectMeta: telemetry.ProjectMeta{
+			Name:    "NIC",
+			Version: "3.5.0",
+		},
 		K8sVersion: "v1.29.2",
 		Arch:       runtime.GOARCH,
 	}
@@ -78,6 +83,7 @@ func TestCollectNodeCountInClusterWithOneNode(t *testing.T) {
 	cfg := telemetry.CollectorConfig{
 		Configurator:    newConfigurator(t),
 		K8sClientReader: newTestClientset(node1),
+		Version:         "3.5.0",
 	}
 
 	c, err := telemetry.NewCollector(cfg, telemetry.WithExporter(exp))
@@ -88,8 +94,8 @@ func TestCollectNodeCountInClusterWithOneNode(t *testing.T) {
 
 	td := telemetry.Data{
 		ProjectMeta: telemetry.ProjectMeta{
-			Name:    "",
-			Version: "",
+			Name:    "NIC",
+			Version: "3.5.0",
 		},
 		NICResourceCounts: telemetry.NICResourceCounts{
 			VirtualServers:      0,
@@ -115,6 +121,7 @@ func TestCollectNodeCountInClusterWithThreeNodes(t *testing.T) {
 	cfg := telemetry.CollectorConfig{
 		Configurator:    newConfigurator(t),
 		K8sClientReader: newTestClientset(node1, node2, node3),
+		Version:         "3.5.0",
 	}
 
 	c, err := telemetry.NewCollector(cfg, telemetry.WithExporter(exp))
@@ -125,8 +132,8 @@ func TestCollectNodeCountInClusterWithThreeNodes(t *testing.T) {
 
 	td := telemetry.Data{
 		ProjectMeta: telemetry.ProjectMeta{
-			Name:    "",
-			Version: "",
+			Name:    "NIC",
+			Version: "3.5.0",
 		},
 		NICResourceCounts: telemetry.NICResourceCounts{
 			VirtualServers:      0,
@@ -152,6 +159,7 @@ func TestCollectClusterIDInClusterWithOneNode(t *testing.T) {
 	cfg := telemetry.CollectorConfig{
 		Configurator:    newConfigurator(t),
 		K8sClientReader: newTestClientset(node1, kubeNS),
+		Version:         "3.5.0",
 	}
 
 	c, err := telemetry.NewCollector(cfg, telemetry.WithExporter(exp))
@@ -162,8 +170,8 @@ func TestCollectClusterIDInClusterWithOneNode(t *testing.T) {
 
 	td := telemetry.Data{
 		ProjectMeta: telemetry.ProjectMeta{
-			Name:    "",
-			Version: "",
+			Name:    "NIC",
+			Version: "3.5.0",
 		},
 		NICResourceCounts: telemetry.NICResourceCounts{
 			VirtualServers:      0,
@@ -190,6 +198,7 @@ func TestCollectK8sVersion(t *testing.T) {
 	cfg := telemetry.CollectorConfig{
 		Configurator:    newConfigurator(t),
 		K8sClientReader: newTestClientset(node1, kubeNS),
+		Version:         "3.5.0",
 	}
 
 	c, err := telemetry.NewCollector(cfg, telemetry.WithExporter(exp))
@@ -200,8 +209,8 @@ func TestCollectK8sVersion(t *testing.T) {
 
 	td := telemetry.Data{
 		ProjectMeta: telemetry.ProjectMeta{
-			Name:    "",
-			Version: "",
+			Name:    "NIC",
+			Version: "3.5.0",
 		},
 		NICResourceCounts: telemetry.NICResourceCounts{
 			VirtualServers:      0,
@@ -233,6 +242,10 @@ func TestCountVirtualServers(t *testing.T) {
 		{
 			testName: "Create and delete 1 VirtualServer",
 			expectedTraceDataOnAdd: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					VirtualServers: 1,
 				},
@@ -240,6 +253,10 @@ func TestCountVirtualServers(t *testing.T) {
 				Arch:       runtime.GOARCH,
 			},
 			expectedTraceDataOnDelete: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					VirtualServers: 0,
 				},
@@ -262,6 +279,10 @@ func TestCountVirtualServers(t *testing.T) {
 		{
 			testName: "Create 2 VirtualServers and delete 2",
 			expectedTraceDataOnAdd: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					VirtualServers: 2,
 				},
@@ -269,6 +290,10 @@ func TestCountVirtualServers(t *testing.T) {
 				Arch:       runtime.GOARCH,
 			},
 			expectedTraceDataOnDelete: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					VirtualServers: 0,
 				},
@@ -300,6 +325,10 @@ func TestCountVirtualServers(t *testing.T) {
 		{
 			testName: "Create 2 VirtualServers and delete 1",
 			expectedTraceDataOnAdd: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					VirtualServers: 2,
 				},
@@ -307,6 +336,10 @@ func TestCountVirtualServers(t *testing.T) {
 				Arch:       runtime.GOARCH,
 			},
 			expectedTraceDataOnDelete: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					VirtualServers: 1,
 				},
@@ -343,6 +376,7 @@ func TestCountVirtualServers(t *testing.T) {
 		c, err := telemetry.NewCollector(telemetry.CollectorConfig{
 			K8sClientReader: newTestClientset(dummyKubeNS),
 			Configurator:    configurator,
+			Version:         "3.5.0",
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -397,6 +431,10 @@ func TestCountTransportServers(t *testing.T) {
 		{
 			testName: "Create and delete 1 TransportServer",
 			expectedTraceDataOnAdd: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					TransportServers: 1,
 				},
@@ -404,6 +442,10 @@ func TestCountTransportServers(t *testing.T) {
 				Arch:       runtime.GOARCH,
 			},
 			expectedTraceDataOnDelete: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					TransportServers: 0,
 				},
@@ -430,6 +472,10 @@ func TestCountTransportServers(t *testing.T) {
 		{
 			testName: "Create 2 and delete 2 TransportServer",
 			expectedTraceDataOnAdd: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					TransportServers: 2,
 				},
@@ -437,6 +483,10 @@ func TestCountTransportServers(t *testing.T) {
 				Arch:       runtime.GOARCH,
 			},
 			expectedTraceDataOnDelete: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					TransportServers: 0,
 				},
@@ -476,6 +526,10 @@ func TestCountTransportServers(t *testing.T) {
 		{
 			testName: "Create 2 and delete 1 TransportServer",
 			expectedTraceDataOnAdd: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					TransportServers: 2,
 				},
@@ -483,6 +537,10 @@ func TestCountTransportServers(t *testing.T) {
 				Arch:       runtime.GOARCH,
 			},
 			expectedTraceDataOnDelete: telemetry.Data{
+				ProjectMeta: telemetry.ProjectMeta{
+					Name:    "NIC",
+					Version: "3.5.0",
+				},
 				NICResourceCounts: telemetry.NICResourceCounts{
 					TransportServers: 1,
 				},
@@ -527,6 +585,7 @@ func TestCountTransportServers(t *testing.T) {
 		c, err := telemetry.NewCollector(telemetry.CollectorConfig{
 			K8sClientReader: newTestClientset(dummyKubeNS),
 			Configurator:    configurator,
+			Version:         "3.5.0",
 		})
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
### Proposed changes

This PR adds NIC metadata (Name, Version) to telemetry.

NIC log example:
```shell
I0227 16:58:42.719659       1 collector.go:85] Collecting telemetry data
I0227 16:58:42.746579       1 collector.go:94] Exported telemetry data: {ProjectMeta:{Name:NIC Version:3.5.0-SNAPSHOT} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0} NodeCount:1 ClusterID:c232007d-76bf-48a5-8dc2-60e017467f0f K8sVersion:v1.29.2 Arch:amd64}
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
