### PR TITLE
Ignore lint errors about package comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,8 +269,11 @@ jobs:
       - name: Check if base images exist
         id: base_exists
         run: |
-          docker manifest inspect gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic-base/oss:${{ needs.checks.outputs.docker_md5 }}-debian
-          echo "exists=$?" >> $GITHUB_OUTPUT
+          if docker manifest inspect gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/dev/nginx-ic-base/oss:${{ needs.checks.outputs.docker_md5 }}-debian; then
+            echo "exists=0" >> $GITHUB_OUTPUT
+          else
+            echo "exists=1" >> $GITHUB_OUTPUT
+          fi
         if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
 
       - name: Rebuild base images

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters-settings:
       - name: if-return
       - name: increment-decrement
       - name: indent-error-flow
-      - name: package-comments
       - name: range
       - name: receiver-naming
       - name: redefines-builtin-id


### PR DESCRIPTION
### Proposed changes

The majority of the packages created in the project do not have comments, they are also not exported as external modules so do not generate godocs.  Removing the package comments lint module.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
