### PR TITLE
Update telemetry data types from `int` to `int64`

### DIFF
--- a/internal/telemetry/cluster.go
+++ b/internal/telemetry/cluster.go
@@ -8,12 +8,12 @@ import (
 
 // NodeCount returns the total number of nodes in the cluster.
 // It returns an error if the underlying k8s API client errors.
-func (c *Collector) NodeCount(ctx context.Context) (int, error) {
+func (c *Collector) NodeCount(ctx context.Context) (int64, error) {
 	nodes, err := c.Config.K8sClientReader.CoreV1().Nodes().List(ctx, metaV1.ListOptions{})
 	if err != nil {
 		return 0, err
 	}
-	return len(nodes.Items), nil
+	return int64(len(nodes.Items)), nil
 }
 
 // ClusterID returns the UID of the kube-system namespace representing cluster id.

--- a/internal/telemetry/cluster_test.go
+++ b/internal/telemetry/cluster_test.go
@@ -19,7 +19,7 @@ func TestNodeCountInAClusterWithThreeNodes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := 3
+	var want int64 = 3
 	if want != got {
 		t.Errorf("want %v, got %v", want, got)
 	}
@@ -33,7 +33,7 @@ func TestNodeCountInAClusterWithOneNode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := 1
+	var want int64 = 1
 	if want != got {
 		t.Errorf("want %v, got %v", want, got)
 	}

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -108,25 +108,21 @@ func (c *Collector) BuildReport(ctx context.Context) (Data, error) {
 	var err error
 
 	if c.Config.Configurator != nil {
-		d.NICResourceCounts.VirtualServers, d.NICResourceCounts.VirtualServerRoutes = c.Config.Configurator.GetVirtualServerCounts()
-		d.NICResourceCounts.TransportServers = c.Config.Configurator.GetTransportServerCounts()
+		vsCount, vsrCount := c.Config.Configurator.GetVirtualServerCounts()
+		d.VirtualServers, d.VirtualServerRoutes = int64(vsCount), int64(vsrCount)
+		d.TransportServers = int64(c.Config.Configurator.GetTransportServerCounts())
 	}
-	nc, err := c.NodeCount(ctx)
-	if err != nil {
+
+	if d.NodeCount, err = c.NodeCount(ctx); err != nil {
 		glog.Errorf("Error collecting telemetry data: Nodes: %v", err)
 	}
-	d.NodeCount = nc
 
-	cID, err := c.ClusterID(ctx)
-	if err != nil {
+	if d.ClusterID, err = c.ClusterID(ctx); err != nil {
 		glog.Errorf("Error collecting telemetry data: ClusterID: %v", err)
 	}
-	d.ClusterID = cID
 
-	k8s, err := c.K8sVersion()
-	if err != nil {
+	if d.K8sVersion, err = c.K8sVersion(); err != nil {
 		glog.Errorf("Error collecting telemetry data: K8s Version: %v", err)
 	}
-	d.K8sVersion = k8s
 	return d, err
 }

--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -27,12 +27,12 @@ func (e *StdoutExporter) Export(_ context.Context, data Data) error {
 
 // Data holds collected telemetry data.
 type Data struct {
-	ProjectMeta       ProjectMeta
-	NICResourceCounts NICResourceCounts
-	NodeCount         int
-	ClusterID         string
-	K8sVersion        string
-	Arch              string
+	ProjectMeta
+	NICResourceCounts
+	NodeCount  int64
+	ClusterID  string
+	K8sVersion string
+	Arch       string
 }
 
 // ProjectMeta holds metadata for the project.
@@ -43,9 +43,9 @@ type ProjectMeta struct {
 
 // NICResourceCounts holds a count of NIC specific resource.
 type NICResourceCounts struct {
-	VirtualServers      int
-	VirtualServerRoutes int
-	TransportServers    int
+	VirtualServers      int64
+	VirtualServerRoutes int64
+	TransportServers    int64
 }
 
 // Attributes is a placeholder function.


### PR DESCRIPTION
### Proposed changes

This PR updates any of our `int` data types used for telemetry to `int64`
This is to ensure we use the correct go-lang data type that is compatible with the AVRO `long` data type
[Docs on the details of the AVRO primitives](https://avro.apache.org/docs/1.11.1/specification/#primitive-types)

#### Additional changes
- `ProjectMeta` and `NICResourceCounts` are now embedded. This will need to be done when we are generating the schema.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
