### PR TITLE
Add number of NIC replicas to telemetry data

### DIFF
--- a/charts/nginx-ingress/templates/clusterrole.yaml
+++ b/charts/nginx-ingress/templates/clusterrole.yaml
@@ -56,6 +56,12 @@ rules:
   verbs:
   - list
 - apiGroups:
+  - "apps"
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/charts/nginx-ingress/templates/clusterrole.yaml
+++ b/charts/nginx-ingress/templates/clusterrole.yaml
@@ -59,6 +59,7 @@ rules:
   - "apps"
   resources:
   - replicasets
+  - daemonsets
   verbs:
   - get
 - apiGroups:

--- a/deployments/rbac/rbac.yaml
+++ b/deployments/rbac/rbac.yaml
@@ -15,6 +15,7 @@ rules:
   - "apps"
   resources:
   - replicasets
+  - daemonsets
   verbs:
   - get
 - apiGroups:

--- a/deployments/rbac/rbac.yaml
+++ b/deployments/rbac/rbac.yaml
@@ -12,6 +12,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - "apps"
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - ""
   resources:
   - services

--- a/internal/telemetry/cluster.go
+++ b/internal/telemetry/cluster.go
@@ -29,14 +29,23 @@ func (c *Collector) ReplicaCount(ctx context.Context) (int, error) {
 	if len(podRef) != 1 {
 		return 0, fmt.Errorf("expected pod owner reference to be 1, got %d", len(podRef))
 	}
-	if podRef[0].Kind != "ReplicaSet" {
-		return 0, fmt.Errorf("expected pod owner reference to be ReplicaSet, got %s", pod.OwnerReferences[0].Kind)
+
+	switch podRef[0].Kind {
+	case "ReplicaSet":
+		rs, err := c.Config.K8sClientReader.AppsV1().ReplicaSets(c.Config.PodNSName.Namespace).Get(ctx, podRef[0].Name, metaV1.GetOptions{})
+		if err != nil {
+			return 0, err
+		}
+		return int(*rs.Spec.Replicas), nil
+	case "DaemonSet":
+		ds, err := c.Config.K8sClientReader.AppsV1().DaemonSets(c.Config.PodNSName.Namespace).Get(ctx, podRef[0].Name, metaV1.GetOptions{})
+		if err != nil {
+			return 0, err
+		}
+		return int(ds.Status.CurrentNumberScheduled), nil
+	default:
+		return 0, fmt.Errorf("expected pod owner reference to be ReplicaSet or DeamonSet, got %s", podRef[0].Kind)
 	}
-	rs, err := c.Config.K8sClientReader.AppsV1().ReplicaSets(c.Config.PodNSName.Namespace).Get(ctx, podRef[0].Name, metaV1.GetOptions{})
-	if err != nil {
-		return 0, err
-	}
-	return int(*rs.Spec.Replicas), nil
 }
 
 // ClusterID returns the UID of the kube-system namespace representing cluster id.

--- a/internal/telemetry/cluster.go
+++ b/internal/telemetry/cluster.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +17,26 @@ func (c *Collector) NodeCount(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	return len(nodes.Items), nil
+}
+
+// ReplicaCount returns a number of running NIC replicas.
+func (c *Collector) ReplicaCount(ctx context.Context) (int, error) {
+	pod, err := c.Config.K8sClientReader.CoreV1().Pods(c.Config.PodNSName.Namespace).Get(ctx, c.Config.PodNSName.Name, metaV1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+	podRef := pod.GetOwnerReferences()
+	if len(podRef) != 1 {
+		return 0, fmt.Errorf("expected pod owner reference to be 1, got %d", len(podRef))
+	}
+	if podRef[0].Kind != "ReplicaSet" {
+		return 0, fmt.Errorf("expected pod owner reference to be ReplicaSet, got %s", pod.OwnerReferences[0].Kind)
+	}
+	rs, err := c.Config.K8sClientReader.AppsV1().ReplicaSets(c.Config.PodNSName.Namespace).Get(ctx, podRef[0].Name, metaV1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+	return int(*rs.Spec.Replicas), nil
 }
 
 // ClusterID returns the UID of the kube-system namespace representing cluster id.

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -19,8 +19,10 @@ import (
 	tel "github.com/nginxinc/telemetry-exporter/pkg/telemetry"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
+
 	testClient "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -342,12 +344,16 @@ func TestCountVirtualServers(t *testing.T) {
 		configurator := newConfigurator(t)
 
 		c, err := telemetry.NewCollector(telemetry.CollectorConfig{
-			K8sClientReader: newTestClientset(kubeNS, node1),
+			K8sClientReader: newTestClientset(kubeNS, node1, pod, replica),
 			Configurator:    configurator,
 			Version:         telemetryNICData.ProjectVersion,
 		})
 		if err != nil {
 			t.Fatal(err)
+		}
+		c.Config.PodNSName = types.NamespacedName{
+			Namespace: "nginx-ingress",
+			Name:      "nginx-ingress",
 		}
 
 		for _, vs := range test.virtualServers {
@@ -503,12 +509,16 @@ func TestCountTransportServers(t *testing.T) {
 		configurator := newConfigurator(t)
 
 		c, err := telemetry.NewCollector(telemetry.CollectorConfig{
-			K8sClientReader: newTestClientset(kubeNS, node1),
+			K8sClientReader: newTestClientset(kubeNS, node1, pod, replica),
 			Configurator:    configurator,
 			Version:         telemetryNICData.ProjectVersion,
 		})
 		if err != nil {
 			t.Fatal(err)
+		}
+		c.Config.PodNSName = types.NamespacedName{
+			Namespace: "nginx-ingress",
+			Name:      "nginx-ingress",
 		}
 
 		for _, ts := range test.transportServers {

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -344,7 +344,7 @@ func TestCountVirtualServers(t *testing.T) {
 		configurator := newConfigurator(t)
 
 		c, err := telemetry.NewCollector(telemetry.CollectorConfig{
-			K8sClientReader: newTestClientset(kubeNS, node1, pod, replica),
+			K8sClientReader: newTestClientset(kubeNS, node1, pod1, replica),
 			Configurator:    configurator,
 			Version:         telemetryNICData.ProjectVersion,
 		})
@@ -509,7 +509,7 @@ func TestCountTransportServers(t *testing.T) {
 		configurator := newConfigurator(t)
 
 		c, err := telemetry.NewCollector(telemetry.CollectorConfig{
-			K8sClientReader: newTestClientset(kubeNS, node1, pod, replica),
+			K8sClientReader: newTestClientset(kubeNS, node1, pod1, replica),
 			Configurator:    configurator,
 			Version:         telemetryNICData.ProjectVersion,
 		})

--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -42,4 +42,7 @@ type NICResourceCounts struct {
 	VirtualServerRoutes int64
 	// TransportServers is the number of TransportServers managed by the Ingress Controller.
 	TransportServers int64
+
+	// Replicas is the number of NIC replicas.
+	Replicas int64
 }


### PR DESCRIPTION
### Proposed changes

This PR adds NIC `replica count` information to the telemetry data.


commands
```shell
13187  k scale -n nginx-ingress deployment nginx-ingress --replicas=1
13188  k scale -n nginx-ingress deployment nginx-ingress --replicas=3
13189  k scale -n nginx-ingress deployment nginx-ingress --replicas=6
13190  k scale -n nginx-ingress deployment nginx-ingress --replicas=9
13191  k scale -n nginx-ingress deployment nginx-ingress --replicas=1
```

NIC log:

```shell
I0313 17:37:20.342002       1 collector.go:119] Exported telemetry data: {Data:{ProjectName:NIC ProjectVersion:3.5.0-SNAPSHOT ProjectArchitecture:amd64 ClusterID:c232007d-76bf-48a5-8dc2-60e017467f0f ClusterVersion:v1.29.2 ClusterPlatform:kind InstallationID: ClusterNodeCount:1} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0 Replicas:1}}
I0313 17:37:25.537657       1 collector.go:91] Collecting telemetry data
I0313 17:37:25.555606       1 collector.go:119] Exported telemetry data: {Data:{ProjectName:NIC ProjectVersion:3.5.0-SNAPSHOT ProjectArchitecture:amd64 ClusterID:c232007d-76bf-48a5-8dc2-60e017467f0f ClusterVersion:v1.29.2 ClusterPlatform:kind InstallationID: ClusterNodeCount:1} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0 Replicas:3}}
I0313 17:37:30.664850       1 collector.go:91] Collecting telemetry data
I0313 17:37:30.686694       1 collector.go:119] Exported telemetry data: {Data:{ProjectName:NIC ProjectVersion:3.5.0-SNAPSHOT ProjectArchitecture:amd64 ClusterID:c232007d-76bf-48a5-8dc2-60e017467f0f ClusterVersion:v1.29.2 ClusterPlatform:kind InstallationID: ClusterNodeCount:1} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0 Replicas:3}}
I0313 17:37:35.749217       1 collector.go:91] Collecting telemetry data
I0313 17:37:35.780244       1 collector.go:119] Exported telemetry data: {Data:{ProjectName:NIC ProjectVersion:3.5.0-SNAPSHOT ProjectArchitecture:amd64 ClusterID:c232007d-76bf-48a5-8dc2-60e017467f0f ClusterVersion:v1.29.2 ClusterPlatform:kind InstallationID: ClusterNodeCount:1} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0 Replicas:3}}
I0313 17:37:41.250974       1 collector.go:91] Collecting telemetry data
I0313 17:37:41.281874       1 collector.go:119] Exported telemetry data: {Data:{ProjectName:NIC ProjectVersion:3.5.0-SNAPSHOT ProjectArchitecture:amd64 ClusterID:c232007d-76bf-48a5-8dc2-60e017467f0f ClusterVersion:v1.29.2 ClusterPlatform:kind InstallationID: ClusterNodeCount:1} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0 Replicas:6}}
I0313 17:37:46.482953       1 collector.go:91] Collecting telemetry data
I0313 17:37:46.520021       1 collector.go:119] Exported telemetry data: {Data:{ProjectName:NIC ProjectVersion:3.5.0-SNAPSHOT ProjectArchitecture:amd64 ClusterID:c232007d-76bf-48a5-8dc2-60e017467f0f ClusterVersion:v1.29.2 ClusterPlatform:kind InstallationID: ClusterNodeCount:1} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0 Replicas:6}}
I0313 17:37:51.660169       1 collector.go:91] Collecting telemetry data
I0313 17:37:51.696565       1 collector.go:119] Exported telemetry data: {Data:{ProjectName:NIC ProjectVersion:3.5.0-SNAPSHOT ProjectArchitecture:amd64 ClusterID:c232007d-76bf-48a5-8dc2-60e017467f0f ClusterVersion:v1.29.2 ClusterPlatform:kind InstallationID: ClusterNodeCount:1} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0 Replicas:9}}
I0313 17:37:56.975177       1 collector.go:91] Collecting telemetry data
I0313 17:37:56.980994       1 collector.go:119] Exported telemetry data: {Data:{ProjectName:NIC ProjectVersion:3.5.0-SNAPSHOT ProjectArchitecture:amd64 ClusterID:c232007d-76bf-48a5-8dc2-60e017467f0f ClusterVersion:v1.29.2 ClusterPlatform:kind InstallationID: ClusterNodeCount:1} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0 Replicas:1}}

```



### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
