### PR TITLE
Add support for apLogBundle in WAF policy

### DIFF
--- a/config/crd/bases/k8s.nginx.org_policies.yaml
+++ b/config/crd/bases/k8s.nginx.org_policies.yaml
@@ -187,6 +187,8 @@ spec:
                   securityLog:
                     description: SecurityLog defines the security log of a WAF policy.
                     properties:
+                      apLogBundle:
+                        type: string
                       apLogConf:
                         type: string
                       enable:
@@ -198,6 +200,8 @@ spec:
                     items:
                       description: SecurityLog defines the security log of a WAF policy.
                       properties:
+                        apLogBundle:
+                          type: string
                         apLogConf:
                           type: string
                         enable:

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -389,6 +389,8 @@ spec:
                   securityLog:
                     description: SecurityLog defines the security log of a WAF policy.
                     properties:
+                      apLogBundle:
+                        type: string
                       apLogConf:
                         type: string
                       enable:
@@ -400,6 +402,8 @@ spec:
                     items:
                       description: SecurityLog defines the security log of a WAF policy.
                       properties:
+                        apLogBundle:
+                          type: string
                         apLogConf:
                           type: string
                         enable:

--- a/docs/content/configuration/policy-resource.md
+++ b/docs/content/configuration/policy-resource.md
@@ -547,9 +547,11 @@ waf:
 |Field | Description | Type | Required |
 | ---| ---| ---| --- |
 |``enable`` | Enables NGINX App Protect WAF. | ``bool`` | Yes |
-|``apPolicy`` | The [App Protect WAF policy](/nginx-ingress-controller/app-protect/configuration/#app-protect-policies) of the WAF. Accepts an optional namespace. | ``string`` | No |
+|``apPolicy`` | The [App Protect WAF policy](/nginx-ingress-controller/app-protect/configuration/#app-protect-policies) of the WAF. Accepts an optional namespace. Mutually exclusive with ``apBundle``. | ``string`` | No |
+|``apBundle`` | The [App Protect WAF policy bundle](/nginx-ingress-controller/app-protect/configuration/#app-protect-waf-bundles). Mutually exclusive with ``apPolicy``. | ``string`` | No |
 |``securityLog.enable`` | Enables security log. | ``bool`` | No |
-|``securityLog.apLogConf`` | The [App Protect WAF log conf](/nginx-ingress-controller/app-protect/configuration/#app-protect-logs) resource. Accepts an optional namespace. | ``string`` | No |
+|``securityLog.apLogConf`` | The [App Protect WAF log conf](/nginx-ingress-controller/app-protect/configuration/#app-protect-logs) resource. Accepts an optional namespace. Only works with ``apPolicy``. | ``string`` | No |
+|``securityLog.apLogBundle`` | The [App Protect WAF log bundle](/nginx-ingress-controller/app-protect/configuration/#app-protect-waf-bundles) resource. Only works with ``apBundle``. | ``string`` | No |
 |``securityLog.logDest`` | The log destination for the security log. Accepted variables are ``syslog:server=<ip-address &#124; localhost; fqdn>:<port>``, ``stderr``, ``<absolute path to file>``. Default is ``"syslog:server=127.0.0.1:514"``. | ``string`` | No |
 {{% /table %}}
 

--- a/docs/content/configuration/policy-resource.md
+++ b/docs/content/configuration/policy-resource.md
@@ -547,11 +547,11 @@ waf:
 |Field | Description | Type | Required |
 | ---| ---| ---| --- |
 |``enable`` | Enables NGINX App Protect WAF. | ``bool`` | Yes |
-|``apPolicy`` | The [App Protect WAF policy](/nginx-ingress-controller/app-protect/configuration/#app-protect-policies) of the WAF. Accepts an optional namespace. Mutually exclusive with ``apBundle``. | ``string`` | No |
-|``apBundle`` | The [App Protect WAF policy bundle](/nginx-ingress-controller/app-protect/configuration/#app-protect-bundles). Mutually exclusive with ``apPolicy``. | ``string`` | No |
+|``apPolicy`` | The [App Protect WAF policy](/nginx-ingress-controller/installation/integrations/app-protect-waf/configuration/#nginx-app-protect-waf-policies) of the WAF. Accepts an optional namespace. Mutually exclusive with ``apBundle``. | ``string`` | No |
+|``apBundle`` | The [App Protect WAF policy bundle](/nginx-ingress-controller/installation/integrations/app-protect-waf/configuration/#nginx-app-protect-waf-bundles). Mutually exclusive with ``apPolicy``. | ``string`` | No |
 |``securityLog.enable`` | Enables security log. | ``bool`` | No |
-|``securityLog.apLogConf`` | The [App Protect WAF log conf](/nginx-ingress-controller/app-protect/configuration/#app-protect-logs) resource. Accepts an optional namespace. Only works with ``apPolicy``. | ``string`` | No |
-|``securityLog.apLogBundle`` | The [App Protect WAF log bundle](/nginx-ingress-controller/app-protect/configuration/#app-protect-bundles) resource. Only works with ``apBundle``. | ``string`` | No |
+|``securityLog.apLogConf`` | The [App Protect WAF log conf](/nginx-ingress-controller/installation/integrations/app-protect-waf/configuration/#nginx-app-protect-waf-logs) resource. Accepts an optional namespace. Only works with ``apPolicy``. | ``string`` | No |
+|``securityLog.apLogBundle`` | The [App Protect WAF log bundle](/nginx-ingress-controller/installation/integrations/app-protect-waf/configuration/#nginx-app-protect-waf-bundles) resource. Only works with ``apBundle``. | ``string`` | No |
 |``securityLog.logDest`` | The log destination for the security log. Accepted variables are ``syslog:server=<ip-address &#124; localhost; fqdn>:<port>``, ``stderr``, ``<absolute path to file>``. Default is ``"syslog:server=127.0.0.1:514"``. | ``string`` | No |
 {{% /table %}}
 

--- a/docs/content/configuration/policy-resource.md
+++ b/docs/content/configuration/policy-resource.md
@@ -548,10 +548,10 @@ waf:
 | ---| ---| ---| --- |
 |``enable`` | Enables NGINX App Protect WAF. | ``bool`` | Yes |
 |``apPolicy`` | The [App Protect WAF policy](/nginx-ingress-controller/app-protect/configuration/#app-protect-policies) of the WAF. Accepts an optional namespace. Mutually exclusive with ``apBundle``. | ``string`` | No |
-|``apBundle`` | The [App Protect WAF policy bundle](/nginx-ingress-controller/app-protect/configuration/#app-protect-waf-bundles). Mutually exclusive with ``apPolicy``. | ``string`` | No |
+|``apBundle`` | The [App Protect WAF policy bundle](/nginx-ingress-controller/app-protect/configuration/#app-protect-bundles). Mutually exclusive with ``apPolicy``. | ``string`` | No |
 |``securityLog.enable`` | Enables security log. | ``bool`` | No |
 |``securityLog.apLogConf`` | The [App Protect WAF log conf](/nginx-ingress-controller/app-protect/configuration/#app-protect-logs) resource. Accepts an optional namespace. Only works with ``apPolicy``. | ``string`` | No |
-|``securityLog.apLogBundle`` | The [App Protect WAF log bundle](/nginx-ingress-controller/app-protect/configuration/#app-protect-waf-bundles) resource. Only works with ``apBundle``. | ``string`` | No |
+|``securityLog.apLogBundle`` | The [App Protect WAF log bundle](/nginx-ingress-controller/app-protect/configuration/#app-protect-bundles) resource. Only works with ``apBundle``. | ``string`` | No |
 |``securityLog.logDest`` | The log destination for the security log. Accepted variables are ``syslog:server=<ip-address &#124; localhost; fqdn>:<port>``, ``stderr``, ``<absolute path to file>``. Default is ``"syslog:server=127.0.0.1:514"``. | ``string`` | No |
 {{% /table %}}
 

--- a/docs/content/configuration/policy-resource.md
+++ b/docs/content/configuration/policy-resource.md
@@ -547,11 +547,11 @@ waf:
 |Field | Description | Type | Required |
 | ---| ---| ---| --- |
 |``enable`` | Enables NGINX App Protect WAF. | ``bool`` | Yes |
-|``apPolicy`` | The [App Protect WAF policy](/nginx-ingress-controller/installation/integrations/app-protect-waf/configuration/#nginx-app-protect-waf-policies) of the WAF. Accepts an optional namespace. Mutually exclusive with ``apBundle``. | ``string`` | No |
-|``apBundle`` | The [App Protect WAF policy bundle](/nginx-ingress-controller/installation/integrations/app-protect-waf/configuration/#nginx-app-protect-waf-bundles). Mutually exclusive with ``apPolicy``. | ``string`` | No |
+|``apPolicy`` | The [App Protect WAF policy]({{< relref "installation/integrations/app-protect-waf/configuration.md#waf-policies" >}}) of the WAF. Accepts an optional namespace. Mutually exclusive with ``apBundle``. | ``string`` | No |
+|``apBundle`` | The [App Protect WAF policy bundle]({{< relref "installation/integrations/app-protect-waf/configuration.md#waf-bundles" >}}). Mutually exclusive with ``apPolicy``. | ``string`` | No |
 |``securityLog.enable`` | Enables security log. | ``bool`` | No |
-|``securityLog.apLogConf`` | The [App Protect WAF log conf](/nginx-ingress-controller/installation/integrations/app-protect-waf/configuration/#nginx-app-protect-waf-logs) resource. Accepts an optional namespace. Only works with ``apPolicy``. | ``string`` | No |
-|``securityLog.apLogBundle`` | The [App Protect WAF log bundle](/nginx-ingress-controller/installation/integrations/app-protect-waf/configuration/#nginx-app-protect-waf-bundles) resource. Only works with ``apBundle``. | ``string`` | No |
+|``securityLog.apLogConf`` | The [App Protect WAF log conf]({{< relref "installation/integrations/app-protect-waf/configuration.md#waf-logs" >}}) resource. Accepts an optional namespace. Only works with ``apPolicy``. | ``string`` | No |
+|``securityLog.apLogBundle`` | The [App Protect WAF log bundle]({{< relref "installation/integrations/app-protect-waf/configuration.md#waf-bundles" >}}) resource. Only works with ``apBundle``. | ``string`` | No |
 |``securityLog.logDest`` | The log destination for the security log. Accepted variables are ``syslog:server=<ip-address &#124; localhost; fqdn>:<port>``, ``stderr``, ``<absolute path to file>``. Default is ``"syslog:server=127.0.0.1:514"``. | ``string`` | No |
 {{% /table %}}
 

--- a/docs/content/installation/integrations/app-protect-waf/configuration.md
+++ b/docs/content/installation/integrations/app-protect-waf/configuration.md
@@ -212,7 +212,7 @@ You can define App Protect WAF bundles for VirtualServer custom resources by cre
 
 Before applying a policy, a WAF policy bundle must be created, then copied to a volume mounted to `/etc/nginx/waf/bundles`.
 
-{{< note >}} NGINX Ingress Controller does not currently support `securityLogs` for policy bundles. {{< /note >}}
+{{< note >}} NGINX Ingress Controller currently supports `securityLogs` for policy bundles when using `apLogBundle` instead of `apLogConf`. {{< /note >}}
 
 This example show how a policy is configured by referencing a generated WAF Policy Bundle:
 

--- a/docs/content/installation/integrations/app-protect-waf/configuration.md
+++ b/docs/content/installation/integrations/app-protect-waf/configuration.md
@@ -212,7 +212,7 @@ You can define App Protect WAF bundles for VirtualServer custom resources by cre
 
 Before applying a policy, a WAF policy bundle must be created, then copied to a volume mounted to `/etc/nginx/waf/bundles`.
 
-{{< note >}} NGINX Ingress Controller currently supports `securityLogs` for policy bundles when using `apLogBundle` instead of `apLogConf`. {{< /note >}}
+{{< note >}} NGINX Ingress Controller supports `securityLogs` for policy bundles when using `apLogBundle` instead of `apLogConf`. {{< /note >}}
 
 This example shows how a policy is configured by referencing a generated WAF Policy Bundle:
 

--- a/docs/content/installation/integrations/app-protect-waf/configuration.md
+++ b/docs/content/installation/integrations/app-protect-waf/configuration.md
@@ -22,7 +22,7 @@ NGINX App Protect WAF can be enabled and configured for custom resources (Virtua
 - For Ingress resources, apply the [`app-protect` annotations]({{< relref "configuration/ingress-resources/advanced-configuration-with-annotations.md#app-protect" >}}) to each desired resource.
 
 
-## NGINX App Protect WAF Policies
+## NGINX App Protect WAF Policies {#waf-policies}
 
 NGINX App Protect WAF Policies can be created for VirtualServer, VirtualServerRoute, or Ingress resources by creating an `APPolicy` [custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/). There are some caveats:
 
@@ -99,7 +99,7 @@ spec:
 
 Notice that the fields match in name and nesting: NGINX Ingress Controller will transform the YAML into a valid JSON WAF policy config.
 
-## NGINX App Protect WAF Logs
+## NGINX App Protect WAF Logs {#waf-logs}
 
 Configuring
 
@@ -206,7 +206,7 @@ spec:
   tag: Fruits
 ```
 
-## NGINX App Protect WAF Bundles
+## NGINX App Protect WAF Bundles {#waf-bundles}
 
 You can define App Protect WAF bundles for VirtualServer custom resources by creating policy bundles and putting them on a mounted volume accessible from NGINX Ingress Controller.
 

--- a/docs/content/installation/integrations/app-protect-waf/configuration.md
+++ b/docs/content/installation/integrations/app-protect-waf/configuration.md
@@ -240,6 +240,10 @@ spec:
   waf:
     enable: true
     apBundle: "<policy_bundle_name>.tgz"
+    securityLogs:
+    - enable: true
+      apLogBundle: "<log_bundle_name>.tgz"
+      logDest: "syslog:server=syslog-svc.default:514"
 ```
 
 ## OpenAPI Specification in NGINX Ingress Controller

--- a/docs/content/installation/integrations/app-protect-waf/configuration.md
+++ b/docs/content/installation/integrations/app-protect-waf/configuration.md
@@ -212,7 +212,7 @@ You can define App Protect WAF bundles for VirtualServer custom resources by cre
 
 Before applying a policy, a WAF policy bundle must be created, then copied to a volume mounted to `/etc/nginx/waf/bundles`.
 
-{{< note >}} NGINX Ingress Controller supports `securityLogs` for policy bundles when using `apLogBundle` instead of `apLogConf`. {{< /note >}}
+{{< note >}} NGINX Ingress Controller supports `securityLogs` for policy bundles when using `apLogBundle` instead of `apLogConf`. Log bundles must also be copied to a volume mounted to `/etc/nginx/waf/bundles`. {{< /note >}}
 
 This example shows how a policy is configured by referencing a generated WAF Policy Bundle:
 

--- a/docs/content/installation/integrations/app-protect-waf/configuration.md
+++ b/docs/content/installation/integrations/app-protect-waf/configuration.md
@@ -206,7 +206,7 @@ spec:
   tag: Fruits
 ```
 
-## App Protect WAF Bundles
+## NGINX App Protect WAF Bundles
 
 You can define App Protect WAF bundles for VirtualServer custom resources by creating policy bundles and putting them on a mounted volume accessible from NGINX Ingress Controller.
 
@@ -214,7 +214,21 @@ Before applying a policy, a WAF policy bundle must be created, then copied to a 
 
 {{< note >}} NGINX Ingress Controller currently supports `securityLogs` for policy bundles when using `apLogBundle` instead of `apLogConf`. {{< /note >}}
 
-This example show how a policy is configured by referencing a generated WAF Policy Bundle:
+This example shows how a policy is configured by referencing a generated WAF Policy Bundle:
+
+
+```yaml
+apiVersion: k8s.nginx.org/v1
+kind: Policy
+metadata:
+  name: <policy_name>
+spec:
+  waf:
+    enable: true
+    apBundle: "<policy_bundle_name>.tgz"
+```
+
+This example shows the same policy as above but with a log bundle used for :
 
 
 ```yaml

--- a/internal/configs/configurator.go
+++ b/internal/configs/configurator.go
@@ -584,7 +584,7 @@ func (cnf *Configurator) addOrUpdateVirtualServer(virtualServerEx *VirtualServer
 
 	name := getFileNameForVirtualServer(virtualServerEx.VirtualServer)
 
-	vsc := newVirtualServerConfigurator(cnf.cfgParams, cnf.isPlus, cnf.IsResolverConfigured(), cnf.staticCfgParams, cnf.isWildcardEnabled)
+	vsc := newVirtualServerConfigurator(cnf.cfgParams, cnf.isPlus, cnf.IsResolverConfigured(), cnf.staticCfgParams, cnf.isWildcardEnabled, nil)
 	vsCfg, warnings := vsc.GenerateVirtualServerConfig(virtualServerEx, apResources, dosResources)
 	content, err := cnf.templateExecutorV2.ExecuteVirtualServerTemplate(&vsCfg)
 	if err != nil {

--- a/pkg/apis/configuration/v1/types.go
+++ b/pkg/apis/configuration/v1/types.go
@@ -670,7 +670,8 @@ type WAF struct {
 
 // SecurityLog defines the security log of a WAF policy.
 type SecurityLog struct {
-	Enable    bool   `json:"enable"`
-	ApLogConf string `json:"apLogConf"`
-	LogDest   string `json:"logDest"`
+	Enable      bool   `json:"enable"`
+	ApLogConf   string `json:"apLogConf"`
+	ApLogBundle string `json:"apLogBundle"`
+	LogDest     string `json:"logDest"`
 }


### PR DESCRIPTION
### Proposed changes

Add `apLogBundle` field to `securityLogs` to support compiled log configurations. Mutually exclusive with `apLogConf`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
