### PR TITLE
Add `dataType` field to generated attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/nginxinc/nginx-plus-go-client v1.2.0
 	github.com/nginxinc/nginx-prometheus-exporter v1.1.0
 	github.com/nginxinc/nginx-service-mesh v1.7.0
-	github.com/nginxinc/telemetry-exporter v0.0.0-20240306143108-e74e64e77cff
+	github.com/nginxinc/telemetry-exporter v0.0.0-20240307135433-a5ecce59bddf
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/common v0.47.0
 	github.com/spiffe/go-spiffe/v2 v2.1.7

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/nginxinc/nginx-prometheus-exporter v1.1.0 h1:Uj+eWKGvUionZc8gWFDnrb3j
 github.com/nginxinc/nginx-prometheus-exporter v1.1.0/go.mod h1:A1Fy5uLQonVGmwLC5xNxBX+vPFgYzBOvPjNRs8msT0k=
 github.com/nginxinc/nginx-service-mesh v1.7.0 h1:oxKr+Jdbxkos10VTy5xF2UHCcmfIhqWNlsOK/zPnZDM=
 github.com/nginxinc/nginx-service-mesh v1.7.0/go.mod h1:8tREM3kSEUGyk8JT8hdCf/9ol2kEo7hLR8b+m5Yd8Fs=
-github.com/nginxinc/telemetry-exporter v0.0.0-20240306143108-e74e64e77cff h1:cSvO6697zceDtW+wlehAA2xOQAipHNR+yTaMnD8F9w4=
-github.com/nginxinc/telemetry-exporter v0.0.0-20240306143108-e74e64e77cff/go.mod h1:rZ+Ohzwv9LJMzxRDPS/dEwXOUPlNrzjoGkICaG9fv0k=
+github.com/nginxinc/telemetry-exporter v0.0.0-20240307135433-a5ecce59bddf h1:PM0o/J1QyRpNCn8C9SI17b5ePuAnLdI1D5B/TV2hneY=
+github.com/nginxinc/telemetry-exporter v0.0.0-20240307135433-a5ecce59bddf/go.mod h1:rZ+Ohzwv9LJMzxRDPS/dEwXOUPlNrzjoGkICaG9fv0k=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=

--- a/internal/telemetry/data.avdl
+++ b/internal/telemetry/data.avdl
@@ -7,43 +7,43 @@
 		/** The time our edge ingested the event */
 		long ingestTime;
 
-		
+
 		/** ProjectName is the name of the project. */
 		string? ProjectName = null;
-		
+
 		/** ProjectVersion is the version of the project. */
 		string? ProjectVersion = null;
-		
+
 		/** ProjectArchitecture is the architecture of the project. For example, "amd64". */
 		string? ProjectArchitecture = null;
-		
+
 		/** ClusterID is the unique id of the Kubernetes cluster where the project is installed.
 It is the UID of the `kube-system` Namespace. */
 		string? ClusterID = null;
-		
+
 		/** ClusterVersion is the Kubernetes version of the cluster. */
 		string? ClusterVersion = null;
-		
+
 		/** ClusterPlatform is the Kubernetes platform of the cluster. */
 		string? ClusterPlatform = null;
-		
+
 		/** InstallationID is the unique id of the project installation in the cluster. */
 		string? InstallationID = null;
-		
+
 		/** ClusterNodeCount is the number of nodes in the cluster. */
 		long? ClusterNodeCount = null;
-		
+
 		/** VirtualServers is the number of VirtualServer resources managed by the Ingress Controller. */
 		long? VirtualServers = null;
-		
+
 		/** VirtualServerRoutes is the number of VirtualServerRoute resources managed by the Ingress Controller. */
 		long? VirtualServerRoutes = null;
-		
+
 		/** TransportServers is the number of TransportServer resources  by the Ingress Controller. */
 		long? TransportServers = null;
-		
+
 		/** Replicas is the number of NIC replicas. */
 		long? Replicas = null;
-		
+
 	}
 }

--- a/internal/telemetry/data.avdl
+++ b/internal/telemetry/data.avdl
@@ -7,40 +7,43 @@
 		/** The time our edge ingested the event */
 		long ingestTime;
 
-
+		
 		/** ProjectName is the name of the project. */
 		string? ProjectName = null;
-
+		
 		/** ProjectVersion is the version of the project. */
 		string? ProjectVersion = null;
-
+		
 		/** ProjectArchitecture is the architecture of the project. For example, "amd64". */
 		string? ProjectArchitecture = null;
-
+		
 		/** ClusterID is the unique id of the Kubernetes cluster where the project is installed.
 It is the UID of the `kube-system` Namespace. */
 		string? ClusterID = null;
-
+		
 		/** ClusterVersion is the Kubernetes version of the cluster. */
 		string? ClusterVersion = null;
-
+		
 		/** ClusterPlatform is the Kubernetes platform of the cluster. */
 		string? ClusterPlatform = null;
-
+		
 		/** InstallationID is the unique id of the project installation in the cluster. */
 		string? InstallationID = null;
-
+		
 		/** ClusterNodeCount is the number of nodes in the cluster. */
 		long? ClusterNodeCount = null;
-
+		
 		/** VirtualServers is the number of VirtualServer resources managed by the Ingress Controller. */
 		long? VirtualServers = null;
-
+		
 		/** VirtualServerRoutes is the number of VirtualServerRoute resources managed by the Ingress Controller. */
 		long? VirtualServerRoutes = null;
-
+		
 		/** TransportServers is the number of TransportServer resources  by the Ingress Controller. */
 		long? TransportServers = null;
-
+		
+		/** Replicas is the number of NIC replicas. */
+		long? Replicas = null;
+		
 	}
 }

--- a/internal/telemetry/data_attributes_generated.go
+++ b/internal/telemetry/data_attributes_generated.go
@@ -12,6 +12,7 @@ import (
 
 func (d *Data) Attributes() []attribute.KeyValue {
 	var attrs []attribute.KeyValue
+	attrs = append(attrs, attribute.String("dataType", "nic-product-telemetry"))
 
 	attrs = append(attrs, d.Data.Attributes()...)
 	attrs = append(attrs, d.NICResourceCounts.Attributes()...)

--- a/internal/telemetry/nicresourcecounts_attributes_generated.go
+++ b/internal/telemetry/nicresourcecounts_attributes_generated.go
@@ -16,6 +16,7 @@ func (d *NICResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("VirtualServers", d.VirtualServers))
 	attrs = append(attrs, attribute.Int64("VirtualServerRoutes", d.VirtualServerRoutes))
 	attrs = append(attrs, attribute.Int64("TransportServers", d.TransportServers))
+	attrs = append(attrs, attribute.Int64("Replicas", d.Replicas))
 
 	return attrs
 }


### PR DESCRIPTION
### Proposed changes

Update telemetry-exporter dependency and re-generated attributes and schema.

Ran `make
 telemetry-schema` to re-generate all the required files

```console
make telemetry-schema

go generate internal/telemetry/exporter.go
go: downloading github.com/nginxinc/telemetry-exporter v0.0.0-20240307135433-a5ecce59bddf
Successfully parsed struct Data
Generating code
Generating scheme
Successfully parsed struct NICResourceCounts
Generating code
gofumpt -w internal/telemetry/*_generated.go
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
