### PR TITLE
Wait before assertion in weight changes dynamic reload test

### DIFF
--- a/tests/suite/test_v_s_route_weight_changes_dynamic_reload_many_splits.py
+++ b/tests/suite/test_v_s_route_weight_changes_dynamic_reload_many_splits.py
@@ -175,9 +175,9 @@ class TestVSRWeightChangesDynamicReloadManySplits:
         print("Step 3: Verify hitting the other backend.")
         ensure_response_from_backend(backends32_url, vsr_weight_changes_dynamic_reload_many_splits_setup.vs_host)
         wait_and_assert_status_code(200, backends32_url, vsr_weight_changes_dynamic_reload_many_splits_setup.vs_host)
+        wait_before_test(1)
         resp = requests.get(
             backends32_url,
             headers={"host": vsr_weight_changes_dynamic_reload_many_splits_setup.vs_host},
         )
-        wait_before_test(1)
         assert "backend2" in resp.text

--- a/tests/suite/test_v_s_route_weight_changes_dynamic_reload_many_splits.py
+++ b/tests/suite/test_v_s_route_weight_changes_dynamic_reload_many_splits.py
@@ -179,4 +179,5 @@ class TestVSRWeightChangesDynamicReloadManySplits:
             backends32_url,
             headers={"host": vsr_weight_changes_dynamic_reload_many_splits_setup.vs_host},
         )
+        wait_before_test(1)
         assert "backend2" in resp.text


### PR DESCRIPTION
### Proposed changes

Weight changes without reload is almost instant, but still may take some time to complete. Prior before was to test for a change in the backends immediately after applying the config, this leaves 1 second.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
