### PR TITLE
add image release workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels:
+    - kic-plus
+# Configuration variables in array of strings defined in your repository or
+# organization. `null` means disabling configuration variables check.
+# Empty array means no configuration variable is allowed.
+config-variables: null

--- a/.github/actions/install-skopeo/action.yml
+++ b/.github/actions/install-skopeo/action.yml
@@ -1,0 +1,33 @@
+name: Install Skopeo
+description: Install Skopeo from source on ubuntu runner
+
+inputs:
+  version:
+    description: The Skopeo version to install
+    default: v1.14.2
+    required: false
+  repo:
+    description: The Skopeo repository
+    default: github.com/containers/skopeo
+    required: false
+
+outputs:
+  result:
+    description: Did the installation succeed?
+    value: ${{ steps.result.outputs.result == 0 && true || false }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Skopeo
+      id: result
+      run: |
+          sudo apt-get -y update
+          sudo apt install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config go-md2man
+          sudo mkdir -p $GOPATH/src/${{ inputs.repo }}
+          sudo git clone --depth 1 -b ${{ inputs.version }} https://${{ inputs.repo }} $GOPATH/src/${{ inputs.repo }}
+          pushd $GOPATH/src/${{ inputs.repo }} && sudo make install
+          popd
+          skopeo --version
+          echo "result=$?" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/oss-release.yml
+++ b/.github/workflows/oss-release.yml
@@ -1,0 +1,326 @@
+name: "Release NGINX Ingress Controller OSS Images"
+
+on:
+  workflow_dispatch:
+    inputs:
+      gcr_release_registry:
+        required: true
+        type: boolean
+        default: true
+      ecr_public_registry:
+        required: true
+        type: boolean
+        default: true
+      dockerhub_public_registry:
+        required: true
+        type: boolean
+        default: true
+      quay_public_registry:
+        required: true
+        type: boolean
+        default: true
+      github_public_registry:
+        required: true
+        type: boolean
+        default: true
+      source_tag:
+        required: true
+        type: string
+        default: 'stable'
+      target_tag:
+        required: true
+        type: string
+        default: 'edge'
+      short_target_tag:
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      gcr_release_registry:
+        required: true
+        type: boolean
+        default: true
+      ecr_public_registry:
+        required: true
+        type: boolean
+        default: true
+      dockerhub_public_registry:
+        required: true
+        type: boolean
+        default: true
+      quay_public_registry:
+        required: true
+        type: boolean
+        default: true
+      github_public_registry:
+        required: true
+        type: boolean
+        default: true
+      source_tag:
+        required: true
+        type: string
+        default: 'stable'
+      target_tag:
+        required: true
+        type: string
+        default: 'edge'
+      short_target_tag:
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  release-to-gcr-release-registry:
+    name: Push images to the GCR Release Registry
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ inputs.gcr_release_registry }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcr-auth.outputs.access_token }}
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Publish OSS images
+        run: |
+          export CONFIG_PATH=.github/config/config-oss-gcr-release
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          if [ "${{ inputs.short_target_tag }}" != "" ]; then
+            export ADDITIONAL_TAG=${{ inputs.short_target_tag }}
+          fi
+          .github/scripts/copy-images.sh
+
+  release-oss-to-ecr-public-registry:
+    name: Push OSS images to the AWS Public Registry
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ inputs.ecr_public_registry }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcr-auth.outputs.access_token }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_ROLE_PUBLIC_ECR }}
+
+      - name: Login to Public ECR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: public.ecr.aws
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Publish images
+        run: |
+          export CONFIG_PATH=.github/config/config-oss-ecr
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          if [ "${{ inputs.short_target_tag }}" != "" ]; then
+            export ADDITIONAL_TAG=${{ inputs.short_target_tag }}
+          fi
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          .github/scripts/copy-images.sh
+
+  release-oss-to-dockerhub-public-registry:
+    name: Push OSS images to the DockerHub Public Registry
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ inputs.dockerhub_public_registry }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcr-auth.outputs.access_token }}
+
+      - name: DockerHub Login
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Publish images
+        run: |
+          export CONFIG_PATH=.github/config/config-oss-dockerhub
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          if [ "${{ inputs.short_target_tag }}" != "" ]; then
+            export ADDITIONAL_TAG=${{ inputs.short_target_tag }}
+          fi
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          .github/scripts/copy-images.sh
+
+  release-oss-to-quay-public-registry:
+    name: Push OSS images to the Quay Public Registry
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ inputs.quay_public_registry }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcr-auth.outputs.access_token }}
+
+      - name: Login to Quay.io
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Publish images
+        run: |
+          export CONFIG_PATH=.github/config/config-oss-quay
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          if [ "${{ inputs.short_target_tag }}" != "" ]; then
+            export ADDITIONAL_TAG=${{ inputs.short_target_tag }}
+          fi
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          .github/scripts/copy-images.sh
+
+  release-oss-to-github-public-registry:
+    name: Push OSS images to the GitHub Public Registry
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ inputs.github_public_registry }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcr-auth.outputs.access_token }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Publish images
+        run: |
+          export CONFIG_PATH=.github/config/config-oss-github
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          if [ "${{ inputs.short_target_tag }}" != "" ]; then
+            export ADDITIONAL_TAG=${{ inputs.short_target_tag }}
+          fi
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          .github/scripts/copy-images.sh

--- a/.github/workflows/oss-release.yml
+++ b/.github/workflows/oss-release.yml
@@ -6,33 +6,25 @@ on:
       gcr_release_registry:
         required: true
         type: boolean
-        default: true
       ecr_public_registry:
         required: true
         type: boolean
-        default: true
       dockerhub_public_registry:
         required: true
         type: boolean
-        default: true
       quay_public_registry:
         required: true
         type: boolean
-        default: true
       github_public_registry:
         required: true
         type: boolean
-        default: true
       source_tag:
         required: true
         type: string
-        default: 'stable'
       target_tag:
         required: true
         type: string
-        default: 'edge'
       short_target_tag:
-        required: false
         type: string
         default: ''
       dry_run:
@@ -43,33 +35,25 @@ on:
       gcr_release_registry:
         required: true
         type: boolean
-        default: true
       ecr_public_registry:
         required: true
         type: boolean
-        default: true
       dockerhub_public_registry:
         required: true
         type: boolean
-        default: true
       quay_public_registry:
         required: true
         type: boolean
-        default: true
       github_public_registry:
         required: true
         type: boolean
-        default: true
       source_tag:
         required: true
         type: string
-        default: 'stable'
       target_tag:
         required: true
         type: string
-        default: 'edge'
       short_target_tag:
-        required: false
         type: string
         default: ''
       dry_run:

--- a/.github/workflows/plus-release.yml
+++ b/.github/workflows/plus-release.yml
@@ -6,33 +6,25 @@ on:
       nginx_registry:
         required: true
         type: boolean
-        default: true
       gcr_release_registry:
         required: true
         type: boolean
-        default: true
       gcr_mktpl_registry:
         required: true
         type: boolean
-        default: false
       ecr_mktpl_registry:
         required: true
         type: boolean
-        default: false
       az_mktpl_registry:
         required: true
         type: boolean
-        default: false
       source_tag:
         required: true
         type: string
-        default: 'stable'
       target_tag:
         required: true
         type: string
-        default: 'edge'
       short_target_tag:
-        required: false
         type: string
         default: ''
       dry_run:
@@ -43,33 +35,25 @@ on:
       nginx_registry:
         required: true
         type: boolean
-        default: true
       gcr_release_registry:
         required: true
         type: boolean
-        default: true
       gcr_mktpl_registry:
         required: true
         type: boolean
-        default: false
       ecr_mktpl_registry:
         required: true
         type: boolean
-        default: false
       az_mktpl_registry:
         required: true
         type: boolean
-        default: false
       source_tag:
         required: true
         type: string
-        default: 'stable'
       target_tag:
         required: true
         type: string
-        default: 'edge'
       short_target_tag:
-        required: false
         type: string
         default: ''
       dry_run:

--- a/.github/workflows/plus-release.yml
+++ b/.github/workflows/plus-release.yml
@@ -1,0 +1,325 @@
+name: "Release NGINX Ingress Controller Plus Images"
+
+on:
+  workflow_dispatch:
+    inputs:
+      nginx_registry:
+        required: true
+        type: boolean
+        default: true
+      gcr_release_registry:
+        required: true
+        type: boolean
+        default: true
+      gcr_mktpl_registry:
+        required: true
+        type: boolean
+        default: false
+      ecr_mktpl_registry:
+        required: true
+        type: boolean
+        default: false
+      az_mktpl_registry:
+        required: true
+        type: boolean
+        default: false
+      source_tag:
+        required: true
+        type: string
+        default: 'stable'
+      target_tag:
+        required: true
+        type: string
+        default: 'edge'
+      short_target_tag:
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      nginx_registry:
+        required: true
+        type: boolean
+        default: true
+      gcr_release_registry:
+        required: true
+        type: boolean
+        default: true
+      gcr_mktpl_registry:
+        required: true
+        type: boolean
+        default: false
+      ecr_mktpl_registry:
+        required: true
+        type: boolean
+        default: false
+      az_mktpl_registry:
+        required: true
+        type: boolean
+        default: false
+      source_tag:
+        required: true
+        type: string
+        default: 'stable'
+      target_tag:
+        required: true
+        type: string
+        default: 'edge'
+      short_target_tag:
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  release-to-gcr-release-registry:
+    name: Push images to the GCR Release Registry
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ inputs.gcr_release_registry }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcr-auth.outputs.access_token }}
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Publish Plus images
+        run: |
+          export CONFIG_PATH=.github/config/config-plus-gcr-release
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          if [ "${{ inputs.short_target_tag }}" != "" ]; then
+            export ADDITIONAL_TAG=${{ inputs.short_target_tag }}
+          fi
+          .github/scripts/copy-images.sh
+
+  release-to-nginx-registry:
+    name: Push Plus images to the NGINX Registry
+    runs-on: 'kic-plus'
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ inputs.nginx_registry }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcr-auth.outputs.access_token }}
+
+      - name: Get Id Token
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: idtoken
+        with:
+          script: |
+            let id_token = await core.getIDToken()
+            core.setOutput('id_token', id_token)
+
+      - name: Login to NGINX Registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: docker-mgmt.nginx.com
+          username: ${{ steps.idtoken.outputs.id_token }}
+          password: ${{ github.actor }}
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Publish images
+        run: |
+          export CONFIG_PATH=.github/config/config-plus-nginx
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          if [ "${{ inputs.short_target_tag }}" != "" ]; then
+            export ADDITIONAL_TAG=${{ inputs.short_target_tag }}
+          fi
+          .github/scripts/copy-images.sh
+
+  release-plus-to-gcr-marketplace-registry:
+    name: Push Plus images to the GCR Marketplace Registry
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ inputs.gcr_mktpl_registry }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-priv-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Authenticate to Google Cloud Marketplace
+        id: gcr-mktpl-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY_MKTPL }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT_MKTPL }}
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Publish Plus images
+        run: |
+          export CONFIG_PATH=.github/config/config-plus-gcr-public
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          export SOURCE_OPTS="--src-registry-token ${{ steps.gcr-priv-auth.outputs.access_token }}"
+          export TARGET_OPTS="--dest-registry-token ${{ steps.gcr-mktpl-auth.outputs.access_token }}"
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          if [ "${{ inputs.short_target_tag }}" != "" ]; then
+            export ADDITIONAL_TAG=${{ inputs.short_target_tag }}
+          fi
+          .github/scripts/copy-images.sh
+
+  release-plus-to-ecr-marketplace-registry:
+    name: Push Plus images to the AWS Marketplace Registry
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ inputs.ecr_mktpl_registry }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcr-auth.outputs.access_token }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_ROLE_MARKETPLACE }}
+
+      - name: Login to ECR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: 709825985650.dkr.ecr.us-east-1.amazonaws.com
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Publish images
+        run: |
+          export CONFIG_PATH=.github/config/config-plus-ecr
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          .github/scripts/copy-images.sh
+
+  release-plus-to-azure-marketplace-registry:
+    name: Push Plus images to the Azure Marketplace Registry
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ inputs.az_mktpl_registry }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcr-auth.outputs.access_token }}
+
+      - name: Login to ACR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: nginxmktpl.azurecr.io
+          username: ${{ secrets.AZ_MKTPL_ID }}
+          password: ${{ secrets.AZ_MKTPL_SECRET }}
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Publish images
+        run: |
+          export CONFIG_PATH=.github/config/config-plus-azure
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          .github/scripts/copy-images.sh

--- a/.github/workflows/retag-images.yml
+++ b/.github/workflows/retag-images.yml
@@ -6,11 +6,9 @@ on:
       source_tag:
         required: true
         type: string
-        default: 'build'
       target_tag:
         required: true
         type: string
-        default: 'stable'
       dry_run:
         type: boolean
         default: false
@@ -19,11 +17,9 @@ on:
       source_tag:
         required: true
         type: string
-        default: 'build'
       target_tag:
         required: true
         type: string
-        default: 'stable'
       dry_run:
         type: boolean
         default: false

--- a/.github/workflows/retag-images.yml
+++ b/.github/workflows/retag-images.yml
@@ -1,0 +1,75 @@
+name: "Retag Dev Images"
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_tag:
+        required: true
+        type: string
+        default: 'build'
+      target_tag:
+        required: true
+        type: string
+        default: 'stable'
+      dry_run:
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      source_tag:
+        required: true
+        type: string
+        default: 'build'
+      target_tag:
+        required: true
+        type: string
+        default: 'stable'
+      dry_run:
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  copy-to-gcr-dev-registry:
+    name: Re-tag images in GCR Dev Registry
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Authenticate to Google Cloud
+        id: gcr-auth
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCR_WORKLOAD_IDENTITY }}
+          service_account: ${{ secrets.GCR_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.gcr-auth.outputs.access_token }}
+
+      - name: Install latest skopeo
+        uses: ./.github/actions/install-skopeo
+
+      - name: Retag images
+        run: |
+          export CONFIG_PATH=.github/config/config-gcr-retag
+          export SOURCE_TAG=${{ inputs.source_tag }}
+          export TARGET_TAG=${{ inputs.target_tag }}
+          if ${{ inputs.dry_run }}; then
+            export DRY_RUN=true
+          fi
+          .github/scripts/copy-images.sh


### PR DESCRIPTION
### Proposed changes

These workflows can we called individually or called from other workflows.  They trigger the `copy-images.sh` script with the relevant config for the target registry.

### Examples

oss-release.yml:
```
inputs.gcr_release_registry: true
inputs.ecr_public_registry: true
inputs.dockerhub_public_registry: true
inputs.quay_public_registry: true
inputs.github_public_registry: true
inputs.source_tag: edge
inputs.target_tag: 3.5.0
inputs.short_target_tag: 3.5
inputs.dry_run: false
```

plus-release.yml:
```
inputs.nginx_registry: true
inputs.gcr_release_registry: true
inputs.gcr_mktpl_registry: true
inputs.ecr_mktpl_registry: true
inputs.az_mktpl_registry: true
inputs.source_tag: edge
inputs.target_tag: 3.5.0
inputs.short_target_tag: 3.5
inputs.dry_run: false
```

retag-images.yml:
```
inputs.source_tag: <stable_md5>
inputs.target_tag: edge
inputs.dry_run: false
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
