### PR TITLE
Fix false-positive code scanning issue

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -3111,14 +3111,14 @@ func (lbc *LoadBalancerController) createVirtualServerEx(virtualServer *conf_v1.
 	}
 
 	if virtualServer.Spec.TLS != nil && virtualServer.Spec.TLS.Secret != "" {
-		secretKey := virtualServer.Namespace + "/" + virtualServer.Spec.TLS.Secret
+		scrtKey := virtualServer.Namespace + "/" + virtualServer.Spec.TLS.Secret
 
-		secretRef := lbc.secretStore.GetSecret(secretKey)
-		if secretRef.Error != nil {
-			glog.Warningf("Error trying to get the secret %v for VirtualServer %v: %v", secretKey, virtualServer.Name, secretRef.Error)
+		scrtRef := lbc.secretStore.GetSecret(scrtKey)
+		if scrtRef.Error != nil {
+			glog.Warningf("Error trying to get the secret %v for VirtualServer %v: %v", scrtKey, virtualServer.Name, scrtRef.Error)
 		}
 
-		virtualServerEx.SecretRefs[secretKey] = secretRef
+		virtualServerEx.SecretRefs[scrtKey] = scrtRef
 	}
 
 	policies, policyErrors := lbc.getPolicies(virtualServer.Spec.Policies, virtualServer.Namespace)
@@ -3717,17 +3717,17 @@ func (lbc *LoadBalancerController) createTransportServerEx(transportServer *conf
 		}
 	}
 
-	secretRefs := make(map[string]*secrets.SecretReference)
+	scrtRefs := make(map[string]*secrets.SecretReference)
 
 	if transportServer.Spec.TLS != nil && transportServer.Spec.TLS.Secret != "" {
-		secretKey := transportServer.Namespace + "/" + transportServer.Spec.TLS.Secret
+		scrtKey := transportServer.Namespace + "/" + transportServer.Spec.TLS.Secret
 
-		secretRef := lbc.secretStore.GetSecret(secretKey)
-		if secretRef.Error != nil {
-			glog.Warningf("Error trying to get the secret %v for TransportServer %v: %v", secretKey, transportServer.Name, secretRef.Error)
+		scrtRef := lbc.secretStore.GetSecret(scrtKey)
+		if scrtRef.Error != nil {
+			glog.Warningf("Error trying to get the secret %v for TransportServer %v: %v", scrtKey, transportServer.Name, scrtRef.Error)
 		}
 
-		secretRefs[secretKey] = secretRef
+		scrtRefs[scrtKey] = scrtRef
 	}
 
 	return &configs.TransportServerEx{
@@ -3737,7 +3737,7 @@ func (lbc *LoadBalancerController) createTransportServerEx(transportServer *conf
 		PodsByIP:         podsByIP,
 		ExternalNameSvcs: externalNameSvcs,
 		DisableIPV6:      disableIPV6,
-		SecretRefs:       secretRefs,
+		SecretRefs:       scrtRefs,
 	}
 }
 


### PR DESCRIPTION
### Proposed changes

This PR if merged it will fix false-positive code scanning issues. The var names with prefixes "secret" are recognised by the scanner as a secrets (passed to logs).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
