### PR TITLE
values: auto-generate leaderElectionLockName by default

### DIFF
--- a/charts/nginx-ingress/templates/controller-role.yaml
+++ b/charts/nginx-ingress/templates/controller-role.yaml
@@ -43,7 +43,7 @@ rules:
   resources:
   - leases
   resourceNames:
-  - {{ .Values.controller.reportIngressStatus.leaderElectionLockName }}
+  - {{ include "nginx-ingress.leaderElectionName" . }}
   verbs:
   - get
   - update

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -442,7 +442,7 @@ controller:
     enableLeaderElection: true
 
     ## Specifies the name to be used as the lock for leader election. controller.reportIngressStatus.enableLeaderElection must be set to true.
-    leaderElectionLockName: "nginx-ingress-leader"
+    leaderElectionLockName: ""
 
     ## The annotations of the leader election configmap.
     annotations: {}


### PR DESCRIPTION
The README claims that it's auto-generated today, but it's actually hard-coded. This PR fixes #5389 by changing it to use an empty string by default, thereby allowing the `nginx-ingress.leaderElectionName` helper to take care of auto-generating it.