### PR TITLE
Set reporting endpoint in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ TARGET                        ?= local ## The target of the build. Possible valu
 override DOCKER_BUILD_OPTIONS += --build-arg IC_VERSION=$(VERSION) ## The options for the docker build command. For example, --pull
 ARCH                          ?= amd64 ## The architecture of the image or binary. For example: amd64, arm64, ppc64le, s390x. Not all architectures are supported for all targets
 GOOS                          ?= linux ## The OS of the binary. For example linux, darwin
-NGINX_AGENT					  ?= true
-TELEMETRY_ENDPOINT 			  ?= oss.edge.df.f5.com:443
+NGINX_AGENT                   ?= true
+TELEMETRY_ENDPOINT            ?= oss.edge.df.f5.com:443
 
 # Additional flags added here can be accessed in main.go.
 # e.g. `main.version` maps to `var version` in main.go

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,7 @@ GIT_TAG = $(shell git tag --sort=-version:refname | head -n1 || echo untagged)
 VERSION = $(VER)-SNAPSHOT
 PLUS_ARGS = --secret id=nginx-repo.crt,src=nginx-repo.crt --secret id=nginx-repo.key,src=nginx-repo.key
 
-# Additional flags added here can be accessed in main.go.
-# e.g. `main.version` maps to `var version` in main.go
-GO_LINKER_FLAGS_VARS = -X main.version=${VERSION}
-GO_LINKER_FLAGS_OPTIONS = -s -w
-GO_LINKER_FLAGS = $(GO_LINKER_FLAGS_OPTIONS) $(GO_LINKER_FLAGS_VARS)
-DEBUG_GO_LINKER_FLAGS = $(GO_LINKER_FLAGS_VARS)
-DEBUG_GO_GC_FLAGS = all=-N -l
-
-# variables that can be overridden by the user
+# Variables that can be overridden
 PREFIX                        ?= nginx/nginx-ingress ## The name of the image. For example, nginx/nginx-ingress
 TAG                           ?= $(VERSION:v%=%) ## The tag of the image. For example, 2.0.0
 TARGET                        ?= local ## The target of the build. Possible values: local, container and download
@@ -20,6 +12,15 @@ override DOCKER_BUILD_OPTIONS += --build-arg IC_VERSION=$(VERSION) ## The option
 ARCH                          ?= amd64 ## The architecture of the image or binary. For example: amd64, arm64, ppc64le, s390x. Not all architectures are supported for all targets
 GOOS                          ?= linux ## The OS of the binary. For example linux, darwin
 NGINX_AGENT					  ?= true
+TELEMETRY_ENDPOINT 			  ?= oss.edge.df.f5.com:443
+
+# Additional flags added here can be accessed in main.go.
+# e.g. `main.version` maps to `var version` in main.go
+GO_LINKER_FLAGS_VARS = -X main.version=${VERSION} -X main.telemetryEndpoint=${TELEMETRY_ENDPOINT}
+GO_LINKER_FLAGS_OPTIONS = -s -w
+GO_LINKER_FLAGS = $(GO_LINKER_FLAGS_OPTIONS) $(GO_LINKER_FLAGS_VARS)
+DEBUG_GO_LINKER_FLAGS = $(GO_LINKER_FLAGS_VARS)
+DEBUG_GO_GC_FLAGS = all=-N -l
 
 # final docker build command
 DOCKER_CMD = docker build --platform linux/$(strip $(ARCH)) $(strip $(DOCKER_BUILD_OPTIONS)) --target $(strip $(TARGET)) -f build/Dockerfile -t $(strip $(PREFIX)):$(strip $(TAG)) .

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -42,7 +42,8 @@ import (
 
 // Injected during build
 var (
-	version string
+	version           string
+	telemetryEndpoint string
 )
 
 const (
@@ -212,6 +213,7 @@ func main() {
 		IsIPV6Disabled:               *disableIPV6,
 		WatchNamespaceLabel:          *watchNamespaceLabel,
 		EnableTelemetryReporting:     *enableTelemetryReporting,
+		TelemetryReportingEndpoint:   telemetryEndpoint,
 		NICVersion:                   version,
 		DynamicWeightChangesReload:   *enableDynamicWeightChangesReload,
 	}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -214,6 +214,7 @@ type NewLoadBalancerControllerInput struct {
 	IsIPV6Disabled               bool
 	WatchNamespaceLabel          string
 	EnableTelemetryReporting     bool
+	TelemetryReportingEndpoint   string
 	NICVersion                   string
 	DynamicWeightChangesReload   bool
 }
@@ -352,8 +353,10 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 	// NIC Telemetry Reporting
 	if input.EnableTelemetryReporting {
 		exporterCfg := telemetry.ExporterCfg{
-			Endpoint: "oss.edge.df.f5.com:443",
+			Endpoint: input.TelemetryReportingEndpoint,
 		}
+
+		glog.V(3).Infof("Telemetry Endpoint: %s", input.TelemetryReportingEndpoint)
 
 		exporter, err := telemetry.NewExporter(exporterCfg)
 		if err != nil {


### PR DESCRIPTION
### Proposed changes

Allows the reporting endpoint to be set asa build argument.
This is useful in development scenarios where we don't want to send data to the production endpoint

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
