### PR TITLE
Collect usage of GlobalConfiguration resources

### DIFF
--- a/docs/content/overview/product-telemetry.md
+++ b/docs/content/overview/product-telemetry.md
@@ -34,7 +34,8 @@ These are the data points collected and reported by NGINX Ingress Controller:
 - **TransportServers** The number of TransportServer resources managed by NGINX Ingress Controller.
 - **Replicas** Number of Deployment replicas, or Daemonset instances.
 - **Secrets** Number of Secret resources managed by NGINX Ingress Controller.
-- **Ingress Count** Number of Ingresses.
+- **Ingress Count** The number of Ingress resources managed by the NGINX Ingress Controller.
+- **GlobalConfiguration** Represents the use of a GlobalConfiguration resource.
 
 
 ## Opt out

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -360,12 +360,12 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 			glog.Fatalf("failed to initialize telemetry exporter: %v", err)
 		}
 		collectorConfig := telemetry.CollectorConfig{
-			K8sClientReader:       input.KubeClient,
-			CustomK8sClientReader: input.ConfClient,
-			Period:                24 * time.Hour,
-			Configurator:          lbc.configurator,
-			SecretStore:           lbc.secretStore,
-			Version:               input.NICVersion,
+			Period:              24 * time.Hour,
+			K8sClientReader:     input.KubeClient,
+			Version:             input.NICVersion,
+			GlobalConfiguration: lbc.watchGlobalConfiguration,
+			Configurator:        lbc.configurator,
+			SecretStore:         lbc.secretStore,
 			PodNSName: types.NamespacedName{
 				Namespace: os.Getenv("POD_NAMESPACE"),
 				Name:      os.Getenv("POD_NAME"),

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -355,7 +355,7 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 		exporterCfg := telemetry.ExporterCfg{
 			Endpoint: input.TelemetryReportingEndpoint,
 		}
-		
+
 		exporter, err := telemetry.NewExporter(exporterCfg)
 		if err != nil {
 			glog.Fatalf("failed to initialize telemetry exporter: %v", err)

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -355,9 +355,7 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 		exporterCfg := telemetry.ExporterCfg{
 			Endpoint: input.TelemetryReportingEndpoint,
 		}
-
-		glog.V(3).Infof("Telemetry Endpoint: %s", input.TelemetryReportingEndpoint)
-
+		
 		exporter, err := telemetry.NewExporter(exporterCfg)
 		if err != nil {
 			glog.Fatalf("failed to initialize telemetry exporter: %v", err)

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/nginxinc/kubernetes-ingress/internal/configs"
 
-	k8s_nginx "github.com/nginxinc/kubernetes-ingress/pkg/client/clientset/versioned"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -47,23 +46,23 @@ type Collector struct {
 
 // CollectorConfig contains configuration options for a Collector
 type CollectorConfig struct {
-	// K8sClientReader is a kubernetes client.
-	K8sClientReader kubernetes.Interface
-
-	// CustomK8sClientReader is a kubernetes client for our CRDs.
-	// Note: May not need this client.
-	CustomK8sClientReader k8s_nginx.Interface
-
 	// Period to collect telemetry
 	Period time.Duration
 
+	// K8sClientReader is a kubernetes client.
+	K8sClientReader kubernetes.Interface
+
+	// Version represents NIC version.
+	Version string
+
+	// GlobalConfiguration represents the use of a GlobalConfiguration resource.
+	GlobalConfiguration bool
+
+	// Configurator is a struct for configuring NGINX.
 	Configurator *configs.Configurator
 
 	// SecretStore for access to secrets managed by NIC.
 	SecretStore secrets.SecretStore
-
-	// Version represents NIC version.
-	Version string
 
 	// PodNSName represents NIC Pod's NamespacedName.
 	PodNSName types.NamespacedName
@@ -117,6 +116,7 @@ func (c *Collector) Collect(ctx context.Context) {
 			Replicas:            int64(report.NICReplicaCount),
 			Secrets:             int64(report.Secrets),
 			Ingresses:           int64(report.IngressCount),
+			GlobalConfiguration: report.GlobalConfiguration,
 		},
 	}
 
@@ -145,6 +145,7 @@ type Report struct {
 	TransportServers    int
 	Secrets             int
 	IngressCount        int
+	GlobalConfiguration bool
 }
 
 // BuildReport takes context, collects telemetry data and builds the report.
@@ -188,7 +189,7 @@ func (c *Collector) BuildReport(ctx context.Context) (Report, error) {
 		glog.Errorf("Error collecting telemetry data: InstallationID: %v", err)
 	}
 
-	secrets, err := c.Secrets()
+	secretCount, err := c.Secrets()
 	if err != nil {
 		glog.Errorf("Error collecting telemetry data: Secrets: %v", err)
 	}
@@ -207,7 +208,8 @@ func (c *Collector) BuildReport(ctx context.Context) (Report, error) {
 		VirtualServers:      vsCount,
 		VirtualServerRoutes: vsrCount,
 		TransportServers:    tsCount,
-		Secrets:             secrets,
+		Secrets:             secretCount,
 		IngressCount:        ingressCount,
+		GlobalConfiguration: c.Config.GlobalConfiguration,
 	}, err
 }

--- a/internal/telemetry/data.avdl
+++ b/internal/telemetry/data.avdl
@@ -7,52 +7,52 @@
 		/** The time our edge ingested the event */
 		long ingestTime;
 
-		
+
 		/** ProjectName is the name of the project. */
 		string? ProjectName = null;
-		
+
 		/** ProjectVersion is the version of the project. */
 		string? ProjectVersion = null;
-		
+
 		/** ProjectArchitecture is the architecture of the project. For example, "amd64". */
 		string? ProjectArchitecture = null;
-		
+
 		/** ClusterID is the unique id of the Kubernetes cluster where the project is installed.
 It is the UID of the `kube-system` Namespace. */
 		string? ClusterID = null;
-		
+
 		/** ClusterVersion is the Kubernetes version of the cluster. */
 		string? ClusterVersion = null;
-		
+
 		/** ClusterPlatform is the Kubernetes platform of the cluster. */
 		string? ClusterPlatform = null;
-		
+
 		/** InstallationID is the unique id of the project installation in the cluster. */
 		string? InstallationID = null;
-		
+
 		/** ClusterNodeCount is the number of nodes in the cluster. */
 		long? ClusterNodeCount = null;
-		
+
 		/** VirtualServers is the number of VirtualServer resources managed by the Ingress Controller. */
 		long? VirtualServers = null;
-		
+
 		/** VirtualServerRoutes is the number of VirtualServerRoute resources managed by the Ingress Controller. */
 		long? VirtualServerRoutes = null;
-		
+
 		/** TransportServers is the number of TransportServer resources managed by the Ingress Controller. */
 		long? TransportServers = null;
-		
+
 		/** Replicas is the number of NIC replicas. */
 		long? Replicas = null;
-		
+
 		/** Secrets is the number of Secret resources managed by the Ingress Controller. */
 		long? Secrets = null;
-		
+
 		/** Ingresses is the number of Ingresses. */
 		long? Ingresses = null;
-		
+
 		/** GlobalConfiguration indicates if a GlobalConfiguration resource is used. */
 		boolean? GlobalConfiguration = null;
-		
+
 	}
 }

--- a/internal/telemetry/data.avdl
+++ b/internal/telemetry/data.avdl
@@ -7,49 +7,52 @@
 		/** The time our edge ingested the event */
 		long ingestTime;
 
-
+		
 		/** ProjectName is the name of the project. */
 		string? ProjectName = null;
-
+		
 		/** ProjectVersion is the version of the project. */
 		string? ProjectVersion = null;
-
+		
 		/** ProjectArchitecture is the architecture of the project. For example, "amd64". */
 		string? ProjectArchitecture = null;
-
+		
 		/** ClusterID is the unique id of the Kubernetes cluster where the project is installed.
 It is the UID of the `kube-system` Namespace. */
 		string? ClusterID = null;
-
+		
 		/** ClusterVersion is the Kubernetes version of the cluster. */
 		string? ClusterVersion = null;
-
+		
 		/** ClusterPlatform is the Kubernetes platform of the cluster. */
 		string? ClusterPlatform = null;
-
+		
 		/** InstallationID is the unique id of the project installation in the cluster. */
 		string? InstallationID = null;
-
+		
 		/** ClusterNodeCount is the number of nodes in the cluster. */
 		long? ClusterNodeCount = null;
-
+		
 		/** VirtualServers is the number of VirtualServer resources managed by the Ingress Controller. */
 		long? VirtualServers = null;
-
+		
 		/** VirtualServerRoutes is the number of VirtualServerRoute resources managed by the Ingress Controller. */
 		long? VirtualServerRoutes = null;
-
+		
 		/** TransportServers is the number of TransportServer resources managed by the Ingress Controller. */
 		long? TransportServers = null;
-
+		
 		/** Replicas is the number of NIC replicas. */
 		long? Replicas = null;
-
+		
 		/** Secrets is the number of Secret resources managed by the Ingress Controller. */
 		long? Secrets = null;
-
+		
 		/** Ingresses is the number of Ingresses. */
 		long? Ingresses = null;
-
+		
+		/** GlobalConfiguration indicates if a GlobalConfiguration resource is used. */
+		boolean? GlobalConfiguration = null;
+		
 	}
 }

--- a/internal/telemetry/data.avdl
+++ b/internal/telemetry/data.avdl
@@ -7,58 +7,58 @@
 		/** The time our edge ingested the event */
 		long ingestTime;
 
-		
+
 		/** ProjectName is the name of the project. */
 		string? ProjectName = null;
-		
+
 		/** ProjectVersion is the version of the project. */
 		string? ProjectVersion = null;
-		
+
 		/** ProjectArchitecture is the architecture of the project. For example, "amd64". */
 		string? ProjectArchitecture = null;
-		
+
 		/** ClusterID is the unique id of the Kubernetes cluster where the project is installed.
 It is the UID of the `kube-system` Namespace. */
 		string? ClusterID = null;
-		
+
 		/** ClusterVersion is the Kubernetes version of the cluster. */
 		string? ClusterVersion = null;
-		
+
 		/** ClusterPlatform is the Kubernetes platform of the cluster. */
 		string? ClusterPlatform = null;
-		
+
 		/** InstallationID is the unique id of the project installation in the cluster. */
 		string? InstallationID = null;
-		
+
 		/** ClusterNodeCount is the number of nodes in the cluster. */
 		long? ClusterNodeCount = null;
-		
+
 		/** VirtualServers is the number of VirtualServer resources managed by the Ingress Controller. */
 		long? VirtualServers = null;
-		
+
 		/** VirtualServerRoutes is the number of VirtualServerRoute resources managed by the Ingress Controller. */
 		long? VirtualServerRoutes = null;
-		
+
 		/** TransportServers is the number of TransportServer resources managed by the Ingress Controller. */
 		long? TransportServers = null;
-		
+
 		/** Replicas is the number of NIC replicas. */
 		long? Replicas = null;
-		
+
 		/** Secrets is the number of Secret resources managed by the Ingress Controller. */
 		long? Secrets = null;
-		
+
 		/** Services is the number of services referenced by NGINX Ingress Controller in the cluster */
 		long? Services = null;
-		
+
 		/** Ingresses is the number of Ingress resources managed by the NGINX Ingress Controller. */
 		long? Ingresses = null;
-		
+
 		/** IngressClasses is the number of Ingress Classes. */
 		long? IngressClasses = null;
-		
+
 		/** GlobalConfiguration indicates if a GlobalConfiguration resource is used. */
 		boolean? GlobalConfiguration = null;
-		
+
 	}
 }

--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -74,4 +74,6 @@ type NICResourceCounts struct {
 	Secrets int64
 	// Ingresses is the number of Ingresses.
 	Ingresses int64
+	// GlobalConfiguration indicates if a GlobalConfiguration resource is used.
+	GlobalConfiguration bool
 }

--- a/internal/telemetry/nicresourcecounts_attributes_generated.go
+++ b/internal/telemetry/nicresourcecounts_attributes_generated.go
@@ -19,6 +19,7 @@ func (d *NICResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("Replicas", d.Replicas))
 	attrs = append(attrs, attribute.Int64("Secrets", d.Secrets))
 	attrs = append(attrs, attribute.Int64("Ingresses", d.Ingresses))
+	attrs = append(attrs, attribute.Bool("GlobalConfiguration", d.GlobalConfiguration))
 
 	return attrs
 }


### PR DESCRIPTION
### Proposed changes

Resolves https://github.com/nginxinc/kubernetes-ingress/issues/5141

Updates telemetry to collect the usage of a GlobalConfiguration resource.
Since a single install of the Ingress Controller can only have one GlobalConfiguration resource, this is set as either `true` or `false` instead of being a count

Example data:
```bash
{
  Data: {
    ProjectName:NIC 
    ProjectVersion:3.6.0-SNAPSHOT
    ...
  }
  NICResourceCounts: { 
    ...
    GlobalConfiguration:false
  }
}
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
