### PR TITLE
Add Ingress Classes to Telemetry data

### DIFF
--- a/charts/nginx-ingress/templates/clusterrole.yaml
+++ b/charts/nginx-ingress/templates/clusterrole.yaml
@@ -68,6 +68,7 @@ rules:
   - ingressclasses
   verbs:
   - get
+  - list
 {{- if .Values.controller.reportIngressStatus.enable }}
 - apiGroups:
   - networking.k8s.io

--- a/deployments/rbac/rbac.yaml
+++ b/deployments/rbac/rbac.yaml
@@ -127,6 +127,7 @@ rules:
   - ingressclasses
   verbs:
   - get
+  - list
 - apiGroups:
     - cis.f5.com
   resources:

--- a/docs/content/overview/product-telemetry.md
+++ b/docs/content/overview/product-telemetry.md
@@ -35,6 +35,7 @@ These are the data points collected and reported by NGINX Ingress Controller:
 - **Replicas** Number of Deployment replicas, or Daemonset instances.
 - **Secrets** Number of Secret resources managed by NGINX Ingress Controller.
 - **Ingress Count** Number of Ingresses.
+- **Ingress Classes** Number of Ingress Classes.
 
 
 ## Opt out

--- a/internal/telemetry/cluster.go
+++ b/internal/telemetry/cluster.go
@@ -136,6 +136,15 @@ func (c *Collector) IngressCount() int {
 	return total
 }
 
+// IngressClassCount returns number of Ingress Classes.
+func (c *Collector) IngressClassCount(ctx context.Context) (int, error) {
+	ic, err := c.Config.K8sClientReader.NetworkingV1().IngressClasses().List(ctx, metaV1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+	return len(ic.Items), nil
+}
+
 // lookupPlatform takes a string representing a K8s PlatformID
 // retrieved from a cluster node and returns a string
 // representing the platform name.

--- a/internal/telemetry/cluster_test.go
+++ b/internal/telemetry/cluster_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/nginxinc/kubernetes-ingress/internal/telemetry"
 	appsV1 "k8s.io/api/apps/v1"
 	apiCoreV1 "k8s.io/api/core/v1"
+	networkingV1 "k8s.io/api/networking/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -911,5 +913,28 @@ var (
 		},
 		Type: apiCoreV1.SecretTypeTLS,
 		Data: map[string][]byte{},
+	}
+)
+
+// IngressClass for testing.
+var (
+	ingressClassList = &networkingV1.IngressClassList{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		ListMeta: metaV1.ListMeta{},
+		Items: []networkingV1.IngressClass{
+			{
+				TypeMeta: metaV1.TypeMeta{
+					Kind:       "IngressClass",
+					APIVersion: "networking.k8s.io/v1",
+				},
+				ObjectMeta: metaV1.ObjectMeta{},
+				Spec: networkingV1.IngressClassSpec{
+					Controller: "nginx.org/ingress-controller",
+				},
+			},
+		},
 	}
 )

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -117,6 +117,7 @@ func (c *Collector) Collect(ctx context.Context) {
 			Replicas:            int64(report.NICReplicaCount),
 			Secrets:             int64(report.Secrets),
 			Ingresses:           int64(report.IngressCount),
+			IngressClasses:      int64(report.IngressClassCount),
 		},
 	}
 
@@ -145,6 +146,7 @@ type Report struct {
 	TransportServers    int
 	Secrets             int
 	IngressCount        int
+	IngressClassCount   int
 }
 
 // BuildReport takes context, collects telemetry data and builds the report.
@@ -193,6 +195,10 @@ func (c *Collector) BuildReport(ctx context.Context) (Report, error) {
 		glog.Errorf("Error collecting telemetry data: Secrets: %v", err)
 	}
 	ingressCount := c.IngressCount()
+	ingressClassCount, err := c.IngressClassCount(ctx)
+	if err != nil {
+		glog.Errorf("Error collecting telemetry data: Ingress Classes: %v", err)
+	}
 
 	return Report{
 		Name:                "NIC",
@@ -209,5 +215,6 @@ func (c *Collector) BuildReport(ctx context.Context) (Report, error) {
 		TransportServers:    tsCount,
 		Secrets:             secrets,
 		IngressCount:        ingressCount,
+		IngressClassCount:   ingressClassCount,
 	}, err
 }

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -763,6 +763,101 @@ func TestCountSecretsAddTwoSecretsAndDeleteOne(t *testing.T) {
 	}
 }
 
+func TestIngressClassCountReportsNoIngressClasses(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	exp := &telemetry.StdoutExporter{Endpoint: buf}
+
+	cfg := telemetry.CollectorConfig{
+		Configurator:    newConfigurator(t),
+		K8sClientReader: newTestClientset(node1, kubeNS),
+		Version:         telemetryNICData.ProjectVersion,
+	}
+
+	c, err := telemetry.NewCollector(cfg, telemetry.WithExporter(exp))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Collect(context.Background())
+
+	telData := tel.Data{
+		ProjectName:         telemetryNICData.ProjectName,
+		ProjectVersion:      telemetryNICData.ProjectVersion,
+		ProjectArchitecture: telemetryNICData.ProjectArchitecture,
+		ClusterNodeCount:    1,
+		ClusterID:           telemetryNICData.ClusterID,
+		ClusterVersion:      telemetryNICData.ClusterVersion,
+		ClusterPlatform:     "other",
+	}
+
+	nicResourceCounts := telemetry.NICResourceCounts{
+		VirtualServers:      0,
+		VirtualServerRoutes: 0,
+		TransportServers:    0,
+		Ingresses:           0,
+		IngressClasses:      0,
+	}
+
+	td := telemetry.Data{
+		telData,
+		nicResourceCounts,
+	}
+
+	want := fmt.Sprintf("%+v", &td)
+	got := buf.String()
+	if !cmp.Equal(want, got) {
+		t.Error(cmp.Diff(want, got))
+	}
+}
+
+func TestIngressClassCountReportsIngressClasses(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	exp := &telemetry.StdoutExporter{Endpoint: buf}
+
+	cfg := telemetry.CollectorConfig{
+		Configurator:    newConfigurator(t),
+		K8sClientReader: newTestClientset(node1, kubeNS, ingressClassList),
+		Version:         telemetryNICData.ProjectVersion,
+	}
+
+	c, err := telemetry.NewCollector(cfg, telemetry.WithExporter(exp))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Collect(context.Background())
+
+	telData := tel.Data{
+		ProjectName:         telemetryNICData.ProjectName,
+		ProjectVersion:      telemetryNICData.ProjectVersion,
+		ProjectArchitecture: telemetryNICData.ProjectArchitecture,
+		ClusterNodeCount:    1,
+		ClusterID:           telemetryNICData.ClusterID,
+		ClusterVersion:      telemetryNICData.ClusterVersion,
+		ClusterPlatform:     "other",
+	}
+
+	nicResourceCounts := telemetry.NICResourceCounts{
+		VirtualServers:      0,
+		VirtualServerRoutes: 0,
+		TransportServers:    0,
+		Ingresses:           0,
+		IngressClasses:      1,
+	}
+
+	td := telemetry.Data{
+		telData,
+		nicResourceCounts,
+	}
+
+	want := fmt.Sprintf("%+v", &td)
+	got := buf.String()
+	if !cmp.Equal(want, got) {
+		t.Error(cmp.Diff(want, got))
+	}
+}
+
 func createCafeIngressEx() configs.IngressEx {
 	cafeIngress := networkingV1.Ingress{
 		ObjectMeta: metaV1.ObjectMeta{

--- a/internal/telemetry/data.avdl
+++ b/internal/telemetry/data.avdl
@@ -51,5 +51,8 @@ It is the UID of the `kube-system` Namespace. */
 		/** Ingresses is the number of Ingresses. */
 		long? Ingresses = null;
 
+		/** IngressClasses is the number of Ingress Classes. */
+		long? IngressClasses = null;
+
 	}
 }

--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -22,7 +22,10 @@ type StdoutExporter struct {
 
 // Export takes context and trace data and writes to the endpoint.
 func (e *StdoutExporter) Export(_ context.Context, data tel.Exportable) error {
-	fmt.Fprintf(e.Endpoint, "%+v", data)
+	_, err := fmt.Fprintf(e.Endpoint, "%+v", data)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -74,4 +77,6 @@ type NICResourceCounts struct {
 	Secrets int64
 	// Ingresses is the number of Ingresses.
 	Ingresses int64
+	// IngressClasses is the number of Ingress Classes.
+	IngressClasses int64
 }

--- a/internal/telemetry/nicresourcecounts_attributes_generated.go
+++ b/internal/telemetry/nicresourcecounts_attributes_generated.go
@@ -19,6 +19,7 @@ func (d *NICResourceCounts) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.Int64("Replicas", d.Replicas))
 	attrs = append(attrs, attribute.Int64("Secrets", d.Secrets))
 	attrs = append(attrs, attribute.Int64("Ingresses", d.Ingresses))
+	attrs = append(attrs, attribute.Int64("IngressClasses", d.IngressClasses))
 
 	return attrs
 }


### PR DESCRIPTION
### Proposed changes

Add Ingress Classes to telemetry data payload.

log:
```shell
I0417 14:02:48.994112       1 collector.go:128] Telemetry data collected: {Data:{ProjectName:NIC ProjectVersion:3.6.0-SNAPSHOT ProjectArchitecture:amd64 ClusterID:41611749-00ad-4f54-8e95-ea6400abe4bc ClusterVersion:v1.29.2 ClusterPlatform:kind InstallationID:6fb6c436-3086-48be-a650-b9a4b25b510a ClusterNodeCount:1} NICResourceCounts:{VirtualServers:0 VirtualServerRoutes:0 TransportServers:0 Replicas:1 Secrets:2 Ingresses:1 IngressClasses:1}}
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
