### PR TITLE
Cherrypick: Don't reload when `use-cluster-ip` endpoints update

### DIFF
--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -534,34 +534,21 @@ func createUpstream(ingEx *IngressEx, name string, backend *networking.IngressBa
 			endps = []string{}
 		}
 
-		if cfg.UseClusterIP {
-			fqdn := fmt.Sprintf("%s.%s.svc.cluster.local:%d", backend.Service.Name, ingEx.Ingress.Namespace, backend.Service.Port.Number)
+		for _, endp := range endps {
 			upsServers = append(upsServers, version1.UpstreamServer{
-				Address:     fqdn,
+				Address:     endp,
 				MaxFails:    cfg.MaxFails,
 				MaxConns:    cfg.MaxConns,
 				FailTimeout: cfg.FailTimeout,
 				SlowStart:   cfg.SlowStart,
 				Resolve:     isExternalNameSvc,
 			})
+		}
+		if len(upsServers) > 0 {
+			sort.Slice(upsServers, func(i, j int) bool {
+				return upsServers[i].Address < upsServers[j].Address
+			})
 			ups.UpstreamServers = upsServers
-		} else {
-			for _, endp := range endps {
-				upsServers = append(upsServers, version1.UpstreamServer{
-					Address:     endp,
-					MaxFails:    cfg.MaxFails,
-					MaxConns:    cfg.MaxConns,
-					FailTimeout: cfg.FailTimeout,
-					SlowStart:   cfg.SlowStart,
-					Resolve:     isExternalNameSvc,
-				})
-			}
-			if len(upsServers) > 0 {
-				sort.Slice(upsServers, func(i, j int) bool {
-					return upsServers[i].Address < upsServers[j].Address
-				})
-				ups.UpstreamServers = upsServers
-			}
 		}
 	}
 

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -700,7 +700,7 @@ func createExpectedConfigForMergeableCafeIngressWithUseClusterIP() version1.Ingr
 		UpstreamZoneSize: upstreamZoneSize,
 		UpstreamServers: []version1.UpstreamServer{
 			{
-				Address:     "coffee-svc.default.svc.cluster.local:80",
+				Address:     "10.0.0.1:80",
 				MaxFails:    1,
 				MaxConns:    0,
 				FailTimeout: "10s",
@@ -803,7 +803,7 @@ func createExpectedConfigForCafeIngressWithUseClusterIP() version1.IngressNginxC
 		UpstreamZoneSize: upstreamZoneSize,
 		UpstreamServers: []version1.UpstreamServer{
 			{
-				Address:     "coffee-svc.default.svc.cluster.local:80",
+				Address:     "10.0.0.1:80",
 				MaxFails:    1,
 				MaxConns:    0,
 				FailTimeout: "10s",
@@ -817,7 +817,7 @@ func createExpectedConfigForCafeIngressWithUseClusterIP() version1.IngressNginxC
 		UpstreamZoneSize: upstreamZoneSize,
 		UpstreamServers: []version1.UpstreamServer{
 			{
-				Address:     "tea-svc.default.svc.cluster.local:80",
+				Address:     "10.0.0.2:80",
 				MaxFails:    1,
 				MaxConns:    0,
 				FailTimeout: "10s",

--- a/tests/data/use-cluster-ip/ingress/mergeable/minion-ingress.yaml
+++ b/tests/data/use-cluster-ip/ingress/mergeable/minion-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: use-cluster-ip-ingress-minion
+  annotations:
+    nginx.org/use-cluster-ip: "true"
+    nginx.org/mergeable-ingress-type: "minion"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: use-cluster-ip.example.com
+    http:
+      paths:
+      - path: /backend1
+        pathType: Prefix
+        backend:
+          service:
+            name: backend1-svc
+            port:
+              number: 80

--- a/tests/data/use-cluster-ip/ingress/mergeable/use-cluster-ip-ingress.yaml
+++ b/tests/data/use-cluster-ip/ingress/mergeable/use-cluster-ip-ingress.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.org/mergeable-ingress-type: "master"
+  name: use-cluster-ip-ingress-master
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: use-cluster-ip.example.com

--- a/tests/data/use-cluster-ip/ingress/standard/use-cluster-ip-ingress.yaml
+++ b/tests/data/use-cluster-ip/ingress/standard/use-cluster-ip-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.org/use-cluster-ip: "true"
+  name: use-cluster-ip-ingress
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: use-cluster-ip.example.com
+    http:
+      paths:
+      - path: /backend1
+        pathType: Prefix
+        backend:
+          service:
+            name: backend1-svc
+            port:
+              number: 80

--- a/tests/data/virtual-server-use-cluster-ip/standard/virtual-server.yaml
+++ b/tests/data/virtual-server-use-cluster-ip/standard/virtual-server.yaml
@@ -1,0 +1,21 @@
+apiVersion: k8s.nginx.org/v1
+kind: VirtualServer
+metadata:
+  name: virtual-server
+spec:
+  host: virtual-server.example.com
+  upstreams:
+  - name: backend1
+    service: backend1-svc
+    port: 80
+    use-cluster-ip: true
+  - name: backend2
+    service: backend2-svc
+    port: 80
+  routes:
+  - path: "/backend1"
+    action:
+      pass: backend1
+  - path: "/backend2"
+    action:
+      pass: backend2

--- a/tests/suite/test_use_cluster_ip.py
+++ b/tests/suite/test_use_cluster_ip.py
@@ -1,0 +1,104 @@
+import pytest
+from settings import TEST_DATA
+from suite.utils.resources_utils import (
+    create_example_app,
+    create_ingress_from_yaml,
+    create_secret_from_yaml,
+    delete_common_app,
+    delete_items_from_yaml,
+    delete_secret,
+    ensure_connection_to_public_endpoint,
+    get_reload_count,
+    replace_secret,
+    scale_deployment,
+    wait_before_test,
+)
+from suite.utils.yaml_utils import get_first_ingress_host_from_yaml, get_name_from_yaml
+
+from tests.suite.utils.custom_assertions import assert_pods_scaled_to_count
+
+
+class UseClusterIPSetup:
+    def __init__(self, ingress_host, metrics_url):
+        self.ingress_host = ingress_host
+        self.metrics_url = metrics_url
+
+
+@pytest.fixture(scope="class")
+def use_cluster_ip_setup(
+    request,
+    kube_apis,
+    ingress_controller_prerequisites,
+    ingress_controller_endpoint,
+    ingress_controller,
+    test_namespace,
+) -> UseClusterIPSetup:
+    print("------------------------- Deploy use-cluster-ip setup -----------------------------------")
+
+    test_data_path = f"{TEST_DATA}/use-cluster-ip/ingress"
+    metrics_url = f"http://{ingress_controller_endpoint.public_ip}:{ingress_controller_endpoint.metrics_port}/metrics"
+
+    ingress_path = f"{test_data_path}/{request.param}/use-cluster-ip-ingress.yaml"
+    create_ingress_from_yaml(kube_apis.networking_v1, test_namespace, ingress_path)
+    if request.param == "mergeable":
+        create_ingress_from_yaml(
+            kube_apis.networking_v1, test_namespace, f"{test_data_path}/{request.param}/minion-ingress.yaml"
+        )
+    create_example_app(kube_apis, "simple", test_namespace)
+
+    wait_before_test(1)
+
+    ingress_host = get_first_ingress_host_from_yaml(ingress_path)
+
+    ensure_connection_to_public_endpoint(
+        ingress_controller_endpoint.public_ip, ingress_controller_endpoint.port, ingress_controller_endpoint.port_ssl
+    )
+
+    def fin():
+        if request.config.getoption("--skip-fixture-teardown") == "no":
+            print("Clean up use-cluster-ip setup")
+            delete_items_from_yaml(kube_apis, ingress_path, test_namespace)
+            delete_common_app(kube_apis, "simple", test_namespace)
+            if request.param == "mergeable":
+                delete_items_from_yaml(
+                    kube_apis,
+                    f"{test_data_path}/{request.param}/minion-ingress.yaml",
+                    test_namespace,
+                )
+
+    request.addfinalizer(fin)
+
+    return UseClusterIPSetup(
+        ingress_host,
+        metrics_url,
+    )
+
+
+@pytest.mark.ingresses
+@pytest.mark.parametrize(
+    "ingress_controller, use_cluster_ip_setup",
+    [
+        pytest.param({"extra_args": ["-enable-prometheus-metrics"]}, "standard"),
+        pytest.param({"extra_args": ["-enable-prometheus-metrics"]}, "mergeable"),
+    ],
+    indirect=True,
+)
+class TestIngressUseClusterIPReloads:
+    def test_ingress_use_cluster_ip_reloads(
+        self, kube_apis, ingress_controller_endpoint, test_namespace, use_cluster_ip_setup
+    ):
+        print("Step 1: get initial reload count")
+        initial_reload_count = get_reload_count(use_cluster_ip_setup.metrics_url)
+
+        print("Step 2: scale the deployment down")
+        scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "backend1", test_namespace, 1)
+        assert_pods_scaled_to_count(kube_apis.apps_v1_api, kube_apis.v1, "backend1", test_namespace, 1)
+
+        print("Step 3: scale the deployment up")
+        scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "backend1", test_namespace, 4)
+        assert_pods_scaled_to_count(kube_apis.apps_v1_api, kube_apis.v1, "backend1", test_namespace, 4)
+
+        print("Step 4: get reload count after scaling")
+        reload_count_after_scaling = get_reload_count(use_cluster_ip_setup.metrics_url)
+
+        assert reload_count_after_scaling == initial_reload_count, "Expected: no new reloads"

--- a/tests/suite/test_virtual_server_use_cluster_ip_reloads.py
+++ b/tests/suite/test_virtual_server_use_cluster_ip_reloads.py
@@ -1,0 +1,48 @@
+import pytest
+from suite.utils.resources_utils import (
+    get_reload_count,
+    scale_deployment,
+    wait_before_test,
+    wait_until_all_pods_are_ready,
+)
+
+from tests.suite.utils.custom_assertions import assert_pods_scaled_to_count
+
+
+@pytest.mark.vs
+@pytest.mark.parametrize(
+    "crd_ingress_controller, virtual_server_setup",
+    [
+        (
+            {
+                "type": "complete",
+                "extra_args": [
+                    "-enable-custom-resources",
+                    "-enable-prometheus-metrics",
+                ],
+            },
+            {"example": "virtual-server-use-cluster-ip", "app_type": "simple"},
+        )
+    ],
+    indirect=True,
+)
+class TestVSUseClusterIP:
+    def test_use_cluster_ip_reloads(
+        self, kube_apis, ingress_controller_endpoint, crd_ingress_controller, virtual_server_setup
+    ):
+        wait_until_all_pods_are_ready(kube_apis.v1, virtual_server_setup.namespace)
+        print("Step 1: get initial reload count")
+        initial_reload_count = get_reload_count(virtual_server_setup.metrics_url)
+
+        print("Step 2: scale the deployment down")
+        scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "backend1", virtual_server_setup.namespace, 1)
+        assert_pods_scaled_to_count(kube_apis.apps_v1_api, kube_apis.v1, "backend1", virtual_server_setup.namespace, 1)
+
+        print("Step 3: scale the deployment up")
+        scale_deployment(kube_apis.v1, kube_apis.apps_v1_api, "backend1", virtual_server_setup.namespace, 4)
+        assert_pods_scaled_to_count(kube_apis.apps_v1_api, kube_apis.v1, "backend1", virtual_server_setup.namespace, 4)
+
+        print("Step 4: get reload count after scaling")
+        reload_count_after_scaling = get_reload_count(virtual_server_setup.metrics_url)
+
+        assert reload_count_after_scaling == initial_reload_count, "Expected: no new reloads"


### PR DESCRIPTION
sha: 0095bc3a4b6682672918cdfa19150881b7473033
…ngress `use-cluster-ip` implementation to use the cluster ip instead of the fqdn (#5318)

* change use-cluster-ip implementation to use the cluster ip instead of fqdn, don't relaod when use-cluster-ip endpoints update

* Update controller.go

* Fix vs use cluster ip test

* move assert function to custom_assertions.py

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to
that issue here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
