### PR TITLE
NGINX App Protect DoS references added

### DIFF
--- a/docs/content/installation/installing-nic/installation-with-manifests.md
+++ b/docs/content/installation/installing-nic/installation-with-manifests.md
@@ -37,6 +37,10 @@ For example, if you want to use version 3.5.0, the command would be `git clone h
 
 This guide assumes you are using the latest release.
 
+### App Protect DoS
+
+To use App Protect DoS, install the App Protect DoS Arbitrator using the provided manifests in the same namespace as the NGINX Ingress Controller. If you install multiple NGINX Ingress Controllers in the same namespace, they will need to share the same Arbitrator because there can only be one Arbitrator in a single namespace.
+
 ---
 
 ## Set up role-based access control (RBAC) {#configure-rbac}

--- a/docs/content/installation/nic-images/pulling-ingress-controller-image.md
+++ b/docs/content/installation/nic-images/pulling-ingress-controller-image.md
@@ -60,7 +60,7 @@ To pull an image, follow these steps. Replace `<version-tag>` with the specific 
    docker pull private-registry.nginx.com/nginx-ic-dos/nginx-plus-ingress:<version-tag>
    ```
 
-- For NGINX Plus Ingress Controller with NGINX App Protect WAF and DoS, run:
+- For NGINX Plus Ingress Controller with NGINX App Protect WAF and NGINX App Protect DoS, run:
 
    ```shell
    docker pull private-registry.nginx.com/nginx-ic-nap-dos/nginx-plus-ingress:<version-tag>


### PR DESCRIPTION
### Proposed changes

Added missing reference to NGINX Ingress Controller with both NGINX App Protect WAF and NGINX App Protect DoS image

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
