### PR TITLE
Cherrypick: Add support for named ports in ingresses which use-cluster-ip (#5456)

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -2968,6 +2968,14 @@ func (lbc *LoadBalancerController) createIngressEx(ing *networking.Ingress, vali
 		}
 
 		if svc != nil && !external && hasUseClusterIP {
+			if ing.Spec.DefaultBackend.Service.Port.Number == 0 {
+				for _, port := range svc.Spec.Ports {
+					if port.Name == ing.Spec.DefaultBackend.Service.Port.Name {
+						ing.Spec.DefaultBackend.Service.Port.Number = port.Port
+						break
+					}
+				}
+			}
 			endps = []string{ipv6SafeAddrPort(svc.Spec.ClusterIP, ing.Spec.DefaultBackend.Service.Port.Number)}
 		} else {
 			endps = getIPAddressesFromEndpoints(podEndps)
@@ -3028,6 +3036,14 @@ func (lbc *LoadBalancerController) createIngressEx(ing *networking.Ingress, vali
 			}
 
 			if svc != nil && !external && hasUseClusterIP {
+				if path.Backend.Service.Port.Number == 0 {
+					for _, port := range svc.Spec.Ports {
+						if port.Name == path.Backend.Service.Port.Name {
+							path.Backend.Service.Port.Number = port.Port
+							break
+						}
+					}
+				}
 				endps = []string{ipv6SafeAddrPort(svc.Spec.ClusterIP, path.Backend.Service.Port.Number)}
 			} else {
 				endps = getIPAddressesFromEndpoints(podEndps)


### PR DESCRIPTION
### Proposed changes
Cherry pick: 3b7340b91d0f910d5e8cb6e40d9b9fc781a62995


Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to
that issue here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
