### PR TITLE
always load njs module in OSS and Plus

### DIFF
--- a/internal/configs/version1/nginx-plus.tmpl
+++ b/internal/configs/version1/nginx-plus.tmpl
@@ -27,9 +27,7 @@ load_module modules/ngx_fips_check_module.so;
 {{$value}}{{end}}
 {{- end}}
 
-{{- if .OIDC}}
 load_module modules/ngx_http_js_module.so;
-{{- end}}
 
 events {
     worker_connections  {{.WorkerConnections}};

--- a/internal/configs/version1/nginx.tmpl
+++ b/internal/configs/version1/nginx.tmpl
@@ -20,6 +20,8 @@ load_module modules/ngx_http_opentracing_module.so;
 {{$value}}{{end}}
 {{- end}}
 
+load_module modules/ngx_http_js_module.so;
+
 events {
     worker_connections  {{.WorkerConnections}};
 }


### PR DESCRIPTION
### Proposed changes

Always loads `modules/ngx_http_js_module.so` even without the oidc flag because this module is also useful for other use cases that utilise njs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
