### PR TITLE
Remove unused var

### DIFF
--- a/internal/telemetry/cluster_test.go
+++ b/internal/telemetry/cluster_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/nginxinc/kubernetes-ingress/internal/telemetry"
 	appsV1 "k8s.io/api/apps/v1"
 	apiCoreV1 "k8s.io/api/core/v1"
-	networkingV1 "k8s.io/api/networking/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -913,28 +912,5 @@ var (
 		},
 		Type: apiCoreV1.SecretTypeTLS,
 		Data: map[string][]byte{},
-	}
-)
-
-// IngressClass for testing.
-var (
-	ingressClassList = &networkingV1.IngressClassList{
-		TypeMeta: metaV1.TypeMeta{
-			Kind:       "List",
-			APIVersion: "v1",
-		},
-		ListMeta: metaV1.ListMeta{},
-		Items: []networkingV1.IngressClass{
-			{
-				TypeMeta: metaV1.TypeMeta{
-					Kind:       "IngressClass",
-					APIVersion: "networking.k8s.io/v1",
-				},
-				ObjectMeta: metaV1.ObjectMeta{},
-				Spec: networkingV1.IngressClassSpec{
-					Controller: "nginx.org/ingress-controller",
-				},
-			},
-		},
 	}
 )


### PR DESCRIPTION
### Proposed changes

This PR makes `staticcheck` happy by removing unused var in the telemetry package.

```shell
➜  kubernetes-ingress git:(test/fix-staticcheck) ✗ staticcheck ./internal/telemetry/*.go
internal/telemetry/cluster_test.go:921:2: var ingressClassList is unused (U1000)
```


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
