### PR TITLE
Fix error msg to comply with a Go linter

### DIFF
--- a/internal/k8s/secrets/validation.go
+++ b/internal/k8s/secrets/validation.go
@@ -78,10 +78,10 @@ func ValidateCASecret(secret *api_v1.Secret) error {
 
 	block, _ := pem.Decode(secret.Data[CAKey])
 	if block == nil {
-		return fmt.Errorf("The data field %s must hold a valid CERTIFICATE PEM block", CAKey)
+		return fmt.Errorf("the data field %s must hold a valid CERTIFICATE PEM block", CAKey)
 	}
 	if block.Type != "CERTIFICATE" {
-		return fmt.Errorf("The data field %s must hold a valid CERTIFICATE PEM block, but got '%s'", CAKey, block.Type)
+		return fmt.Errorf("the data field %s must hold a valid CERTIFICATE PEM block, but got '%s'", CAKey, block.Type)
 	}
 
 	_, err := x509.ParseCertificate(block.Bytes)
@@ -112,11 +112,11 @@ func ValidateOIDCSecret(secret *api_v1.Secret) error {
 // ValidateHtpasswdSecret validates the secret. If it is valid, the function returns nil.
 func ValidateHtpasswdSecret(secret *api_v1.Secret) error {
 	if secret.Type != SecretTypeHtpasswd {
-		return fmt.Errorf("Htpasswd secret must be of the type %v", SecretTypeHtpasswd)
+		return fmt.Errorf("htpasswd secret must be of the type %v", SecretTypeHtpasswd)
 	}
 
 	if _, exists := secret.Data[HtpasswdFileKey]; !exists {
-		return fmt.Errorf("Htpasswd secret must have the data field %v", HtpasswdFileKey)
+		return fmt.Errorf("htpasswd secret must have the data field %v", HtpasswdFileKey)
 	}
 
 	// we don't validate the contents of secret.Data[HtpasswdFileKey], because invalid contents will not make NGINX
@@ -149,7 +149,7 @@ func ValidateSecret(secret *api_v1.Secret) error {
 		return ValidateHtpasswdSecret(secret)
 	}
 
-	return fmt.Errorf("Secret is of the unsupported type %v", secret.Type)
+	return fmt.Errorf("secret is of the unsupported type %v", secret.Type)
 }
 
 var clientSecretValueFmtRegexp = regexp.MustCompile(`^([^"$\\\s]|\\[^$])*$`)


### PR DESCRIPTION
### Proposed changes

This PR makes error massages in the `secret` pkg comply with the linter: 


Before:
```shell
➜  kubernetes-ingress git:(main) staticcheck ./...
...
internal/k8s/secrets/validation.go:81:10: error strings should not be capitalized (ST1005)
internal/k8s/secrets/validation.go:84:10: error strings should not be capitalized (ST1005)
internal/k8s/secrets/validation.go:115:10: error strings should not be capitalized (ST1005)
internal/k8s/secrets/validation.go:119:10: error strings should not be capitalized (ST1005)
internal/k8s/secrets/validation.go:152:9: error strings should not be capitalized (ST1005)
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
