### PR TITLE
remove cert-gen script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,6 @@ telemetry-schema: ## Generate the telemetry Schema
 	go generate internal/telemetry/exporter.go
 	gofumpt -w internal/telemetry/*_generated.go
 
-.PHONY: certificate-and-key
-certificate-and-key: ## Create default cert and key
-	./build/generate_default_cert_and_key.sh
-
 .PHONY: build
 build: ## Build Ingress Controller binary
 	@docker -v || (code=$$?; printf "\033[0;31mError\033[0m: there was a problem with Docker\n"; exit $$code)

--- a/build/generate_default_cert_and_key.sh
+++ b/build/generate_default_cert_and_key.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout default.key -out default.crt -subj "/CN=NGINXIngressController"
-cat default.key default.crt >default.pem
-rm default.key default.crt

--- a/docs/content/installation/building-nginx-ingress-controller.md
+++ b/docs/content/installation/building-nginx-ingress-controller.md
@@ -165,7 +165,6 @@ A few other useful targets:
 | _push_                              | Pushes the built image to the Docker registry. Configures with `PREFIX` and `TAG`.  |
 | _all_                               | Runs `test`, `lint`, `verify-codegen`, `update-crds`, and `debian-image`. Stops and reports an error if any of these targets fail.  |
 | _test_                              | Runs unit tests.  |
-| _certificate-and-key_               | NGINX Ingress Controller requires a certificate and key for the default HTTP/HTTPS server. You have several options: <ul><li>Reference them in a TLS Secret in a command-line argument to NGINX Ingress Controller.</li><li>Add them to the image in in a file in PEM format as `/etc/nginx/secrets/default`.</li><li>Generate a self-signed certificate and key with this target.</li></ul>Note, you must include the `ADD` instruction in your Dockerfile to copy the cert and key to the image. |
 {{</bootstrap-table>}}
 
 ### Makefile variables you can customize {#makefile-variables}


### PR DESCRIPTION
### Proposed changes

- Remove default crt-key gen script, refer: https://github.com/nginxinc/kubernetes-ingress/pull/3302

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
