### PR TITLE
assign write permissions when publishing ghcr images

### DIFF
--- a/.github/workflows/oss-release.yml
+++ b/.github/workflows/oss-release.yml
@@ -266,6 +266,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     if: ${{ inputs.github_public_registry }}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
### Proposed changes

Publishing GHCR images was failing in the Image update workflow.  This PR assigns the job package write permissions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
