### PR TITLE
Remove duplicate repo owner and fix smoke test requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -751,13 +751,15 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-22.04
     name: Final CI Results
-    needs: [tag-stable]
+    needs: [tag-stable, smoke-tests]
     steps:
       - run: |
-          result="${{ needs.tag-stable.result }}"
-          if [[ $result == "success" || $result == "skipped" ]]; then
-            exit 0
-          else
+          tagResult="${{ needs.tag-stable.result }}"
+          smokeResult="${{ needs.smoke-tests.result }}"
+          if [[ $tagResult != "success" && $tagResult != "skipped" ]]; then
+            exit 1
+          fi
+          if [[ $smokeResult != "success" && $smokeResult != "skipped" ]]; then
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -413,12 +413,12 @@ jobs:
         run: |
           milestone_number=$(gh api \
             -H "Accept: application/vnd.github.v3+json" \
-            /repos/${{ github.repository_owner }}/${{ github.repository }}/milestones \
+            /repos/${{ github.repository }}/milestones \
             | jq --arg version ${{ inputs.nic_version }} -r \
             '.[] | select(.title == $version) | .number')
           if ! ${{ inputs.dry_run }}
             gh api --method PATCH -H "Accept: application/vnd.github.v3+json" \
-              /repos/${{ github.repository_owner }}/${{ github.repository }}/milestones/${milestone_number} \
+              /repos/${{ github.repository }}/milestones/${milestone_number} \
           else
             echo "Skipping closing Github Release milestone, DRY_RUN"
           fi
@@ -431,7 +431,7 @@ jobs:
           release_id=$(gh api \
             -H "Accept: application/vnd.github.v3+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository_owner }}/${{ github.repository }}/releases \
+            /repos/${{ github.repository }}/releases \
             | jq --arg version ${{ inputs.nic_version }} -r \
             '.[] | select(.name == $version) | .id')
           echo "release_id=${release_id}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Proposed changes

The repository url in the release workflow was being rendered as `nginxinc/nginxinc/kubernetes-ingress`, therefore having duplicate repo owners.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
