### PR TITLE
add permissions for gcr login to base image build

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -16,7 +16,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   checks:
@@ -50,6 +49,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # for scout report
+      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON( needs.checks.outputs.image_matrix_oss ) }}
@@ -113,6 +113,7 @@ jobs:
     needs: checks
     permissions:
       contents: read
+      id-token: write
       pull-requests: write # for scout report
     strategy:
       fail-fast: false
@@ -180,6 +181,7 @@ jobs:
     needs: checks
     permissions:
       contents: read
+      id-token: write
       pull-requests: write # for scout report
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Proposed changes

Allow base image build workflow to login to GCR.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
