### PR TITLE
add v prefix to github version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,7 +447,7 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/releases \
-            | jq --arg version ${{ inputs.nic_version }} -r \
+            | jq --arg version "v${{ inputs.nic_version }}" -r \
             '.[] | select(.name == $version) | .id')
           echo "release_id=${release_id}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### Proposed changes

The query to get the github release id was missing the `v` prefix

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
