### PR TITLE
Bump Go version - fix vulnerability in the std lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginxinc/kubernetes-ingress
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.22


### PR DESCRIPTION
### Proposed changes

This PR bumps Go version to 1.22.5. It fixes [GO-2024-2963](https://pkg.go.dev/vuln/GO-2024-2963) vulnerability.

```shell
➜  kubernetes-ingress git:(chore/vuln-fix) ✗ govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2024-2963
    Denial of service due to improper 100-continue handling in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2963
  Standard library
    Found in: net/http@go1.22.4
    Fixed in: net/http@go1.22.5
    Example traces found:
      #1: internal/nginx/verify.go:48:26: nginx.verifyClient.GetConfigVersion calls http.Client.Do

Your code is affected by 1 vulnerability from the Go standard library.
This scan found no other vulnerabilities in packages you import or modules you
require.
```

After the change:

```shell
➜  kubernetes-ingress git:(chore/vuln-fix) govulncheck -show verbose,version ./...
Go: go1.22.5
Scanner: govulncheck@v1.1.2
DB: https://vuln.go.dev
DB updated: 2024-07-02 20:11:00 +0000 UTC

Scanning your code and 1073 packages across 100 dependent modules for known vulnerabilities...

Fetching vulnerabilities from the database...

Checking the code against the vulnerabilities...

No vulnerabilities found.
```



### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
