### PR TITLE
inherit secrets on force image promotion call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,4 +705,5 @@ jobs:
       security-events: write
       pull-requests: write # for scout report
     uses: ./.github/workflows/image-promotion.yml
+    secrets: inherit
     if: ${{ inputs.force && inputs.force || false }}


### PR DESCRIPTION
### Proposed changes

When force building images, the image promotion workflow was failing due to missing secret inheritance 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
