### PR TITLE
Don't log errors for not implemented grpc metrics

### DIFF
--- a/internal/metrics/collectors/latency.go
+++ b/internal/metrics/collectors/latency.go
@@ -181,6 +181,17 @@ func (l *LatencyMetricsCollector) RecordLatency(syslogMsg string) {
 		glog.V(3).Infof("could not parse syslog message: %v", err)
 		return
 	}
+
+	// Upstream for gRPC service is not implemented yet.
+	// This is a temp solution to avoid spamming error logs.
+	// Ref:
+	// https://github.com/nginxinc/kubernetes-ingress/issues/5010
+	// https://github.com/nginxinc/kubernetes-ingress/issues/6124
+	if lm.Upstream == "-" {
+		glog.V(3).Infof("latency metrics for gRPC upstreams: %v", lm)
+		return
+	}
+
 	labelValues, err := l.createLatencyLabelValues(lm)
 	if err != nil {
 		glog.Errorf("cannot record latency for upstream %s and server %s: %v", lm.Upstream, lm.Server, err)


### PR DESCRIPTION
### Proposed changes

This PR introduces a temp fix for [gRPC latency metrics errors issue](https://github.com/nginxinc/kubernetes-ingress/issues/5010).

Error log messages are not emitted, instead a log message in a debug mode:

example request:
```shell
10.244.0.1 - - [02/Aug/2024:10:32:32 +0000] "POST /helloworld.Greeter/SayHello HTTP/2.0" 200 13 "-" "grpcurl/dev-build (no version set) grpc-go/1.61.0" "-"
```
log message in a debug mode (`-v=3`)
```
I20240802 10:32:32.615314       1 latency.go:191] latency metrics: {- 10.244.0.21:50051 200 0.032}
``` 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
