### PR TITLE
Communicate clearly func intent

### DIFF
--- a/cmd/nginx-ingress/flags.go
+++ b/cmd/nginx-ingress/flags.go
@@ -221,7 +221,7 @@ func parseFlags() {
 		os.Exit(0)
 	}
 
-	initialChecks()
+	mustValidateInitialChecks()
 
 	validateWatchedNamespaces()
 
@@ -295,7 +295,7 @@ func parseFlags() {
 	}
 }
 
-func initialChecks() {
+func mustValidateInitialChecks() {
 	err := flag.Lookup("logtostderr").Value.Set("true")
 	if err != nil {
 		glog.Fatalf("Error setting logtostderr to true: %v", err)


### PR DESCRIPTION
### Proposed changes

After merging this PR func names will communicate intent to the reader. 
The naming convention follows the Go pattern of using the `must` (or `Must`) prefixes for functions that either internally call `panic` or make the program exit (`os.Exit`).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
