### PR TITLE
Fix staticcheck linter complains

### DIFF
--- a/internal/k8s/appprotect/app_protect_configuration.go
+++ b/internal/k8s/appprotect/app_protect_configuration.go
@@ -17,10 +17,10 @@ const timeLayout = time.RFC3339
 
 // reasons for invalidity
 const (
-	failedValidationErrorMsg = "Validation Failed"
-	missingUserSigErrorMsg   = "Policy has unsatisfied signature requirements"
+	failedValidationErrorMsg = "validation failed"
+	missingUserSigErrorMsg   = "policy has unsatisfied signature requirements"
 	duplicatedTagsErrorMsg   = "Duplicate tag set"
-	invalidTimestampErrorMsg = "Invalid timestamp"
+	invalidTimestampErrorMsg = "invalid timestamp"
 )
 
 var (
@@ -399,7 +399,7 @@ func (ci *ConfigurationImpl) GetAppResource(kind, key string) (*unstructured.Uns
 			}
 			return nil, fmt.Errorf(obj.ErrorMsg)
 		}
-		return nil, fmt.Errorf("App Protect Policy %s not found", key)
+		return nil, fmt.Errorf("app protect Policy %s not found", key)
 	case LogConfGVK.Kind:
 		if obj, ok := ci.LogConfs[key]; ok {
 			if obj.IsValid {
@@ -407,7 +407,7 @@ func (ci *ConfigurationImpl) GetAppResource(kind, key string) (*unstructured.Uns
 			}
 			return nil, fmt.Errorf(obj.ErrorMsg)
 		}
-		return nil, fmt.Errorf("App Protect LogConf %s not found", key)
+		return nil, fmt.Errorf("app protect LogConf %s not found", key)
 	case UserSigGVK.Kind:
 		if obj, ok := ci.UserSigs[key]; ok {
 			if obj.IsValid {
@@ -415,9 +415,9 @@ func (ci *ConfigurationImpl) GetAppResource(kind, key string) (*unstructured.Uns
 			}
 			return nil, fmt.Errorf(obj.ErrorMsg)
 		}
-		return nil, fmt.Errorf("App Protect UserSig %s not found", key)
+		return nil, fmt.Errorf("app protect UserSig %s not found", key)
 	}
-	return nil, fmt.Errorf("Unknown App Protect resource kind %s", kind)
+	return nil, fmt.Errorf("unknown app protect resource kind %s", kind)
 }
 
 // DeletePolicy deletes an App Protect Policy from App Protect Configuration
@@ -599,14 +599,14 @@ func (fc *FakeConfiguration) GetAppResource(kind, key string) (*unstructured.Uns
 		if obj, ok := fc.Policies[key]; ok {
 			return obj.Obj, nil
 		}
-		return nil, fmt.Errorf("App Protect Policy %s not found", key)
+		return nil, fmt.Errorf("app protect Policy %s not found", key)
 	case LogConfGVK.Kind:
 		if obj, ok := fc.LogConfs[key]; ok {
 			return obj.Obj, nil
 		}
-		return nil, fmt.Errorf("App Protect LogConf %s not found", key)
+		return nil, fmt.Errorf("app protect LogConf %s not found", key)
 	}
-	return nil, fmt.Errorf("Unknown App Protect resource kind %s", kind)
+	return nil, fmt.Errorf("unknown app protect resource kind %s", kind)
 }
 
 // DeletePolicy deletes an App Protect Policy from App Protect Configuration

--- a/internal/k8s/appprotect/app_protect_configuration.go
+++ b/internal/k8s/appprotect/app_protect_configuration.go
@@ -19,7 +19,7 @@ const timeLayout = time.RFC3339
 const (
 	failedValidationErrorMsg = "validation failed"
 	missingUserSigErrorMsg   = "policy has unsatisfied signature requirements"
-	duplicatedTagsErrorMsg   = "Duplicate tag set"
+	duplicatedTagsErrorMsg   = "duplicate tag set"
 	invalidTimestampErrorMsg = "invalid timestamp"
 )
 

--- a/internal/k8s/appprotect/app_protect_configuration_test.go
+++ b/internal/k8s/appprotect/app_protect_configuration_test.go
@@ -854,7 +854,7 @@ func TestAddOrUpdateUserSig(t *testing.T) {
 			expectedProblems: []Problem{
 				{
 					Object:  testUserSigDupTag,
-					Message: "Duplicate tag set",
+					Message: "duplicate tag set",
 					Reason:  "Rejected",
 				},
 			},

--- a/internal/k8s/appprotect/app_protect_configuration_test.go
+++ b/internal/k8s/appprotect/app_protect_configuration_test.go
@@ -107,7 +107,7 @@ func TestCreateAppProtectPolicyEx(t *testing.T) {
 			expectedPolicyEx: &PolicyEx{
 				SignatureReqs: nil,
 				IsValid:       false,
-				ErrorMsg:      "Invalid timestamp",
+				ErrorMsg:      "invalid timestamp",
 			},
 			wantErr: true,
 			msg:     "policy with invalid min timestamp",
@@ -131,7 +131,7 @@ func TestCreateAppProtectPolicyEx(t *testing.T) {
 			expectedPolicyEx: &PolicyEx{
 				SignatureReqs: nil,
 				IsValid:       false,
-				ErrorMsg:      "Invalid timestamp",
+				ErrorMsg:      "invalid timestamp",
 			},
 			wantErr: true,
 			msg:     "policy with invalid max timestamp",
@@ -145,7 +145,7 @@ func TestCreateAppProtectPolicyEx(t *testing.T) {
 			expectedPolicyEx: &PolicyEx{
 				SignatureReqs: nil,
 				IsValid:       false,
-				ErrorMsg:      "Validation Failed",
+				ErrorMsg:      "validation failed",
 			},
 			wantErr: true,
 			msg:     "policy empty spec",
@@ -563,7 +563,7 @@ func TestAddOrUpdatePolicy(t *testing.T) {
 					Resource: &PolicyEx{
 						Obj:      invalidTestPolicy,
 						IsValid:  false,
-						ErrorMsg: "Validation Failed",
+						ErrorMsg: "validation failed",
 					},
 					Op: Delete,
 				},
@@ -584,7 +584,7 @@ func TestAddOrUpdatePolicy(t *testing.T) {
 					Resource: &PolicyEx{
 						Obj:      testPolicyUnsatisfied,
 						IsValid:  false,
-						ErrorMsg: "Policy has unsatisfied signature requirements",
+						ErrorMsg: "policy has unsatisfied signature requirements",
 						SignatureReqs: []SignatureReq{
 							{
 								Tag: "test",
@@ -601,7 +601,7 @@ func TestAddOrUpdatePolicy(t *testing.T) {
 				{
 					Object:  testPolicyUnsatisfied,
 					Reason:  "Rejected",
-					Message: "Policy has unsatisfied signature requirements",
+					Message: "policy has unsatisfied signature requirements",
 				},
 			},
 			msg: "Missing sig reqs",
@@ -671,7 +671,7 @@ func TestAddOrUpdateLogConf(t *testing.T) {
 					Resource: &LogConfEx{
 						Obj:      invalidLogConf,
 						IsValid:  false,
-						ErrorMsg: "Validation Failed",
+						ErrorMsg: "validation failed",
 					},
 					Op: Delete,
 				},
@@ -802,7 +802,7 @@ func TestAddOrUpdateUserSig(t *testing.T) {
 	appProtectConfiguration.Policies["testing/testpolicy"] = &PolicyEx{
 		Obj:      &unstructured.Unstructured{Object: map[string]interface{}{}},
 		IsValid:  false,
-		ErrorMsg: "Policy has unsatisfied signature requirements",
+		ErrorMsg: "policy has unsatisfied signature requirements",
 		SignatureReqs: []SignatureReq{
 			{
 				Tag: "test3",
@@ -839,7 +839,7 @@ func TestAddOrUpdateUserSig(t *testing.T) {
 				{
 					Object:  invalidTestUserSig2,
 					Reason:  "Rejected",
-					Message: "Validation Failed",
+					Message: "validation failed",
 				},
 			},
 			msg: "validation failed",
@@ -870,7 +870,7 @@ func TestAddOrUpdateUserSig(t *testing.T) {
 			expectedProblems: []Problem{
 				{
 					Object:  testUserSig1Invalid,
-					Message: "Validation Failed",
+					Message: "validation failed",
 					Reason:  "Rejected",
 				},
 			},
@@ -1061,7 +1061,7 @@ func TestDeleteUserSig(t *testing.T) {
 			expectedProblems: []Problem{
 				{
 					Reason:  "Rejected",
-					Message: "Policy has unsatisfied signature requirements",
+					Message: "policy has unsatisfied signature requirements",
 					Object: &unstructured.Unstructured{
 						Object: map[string]interface{}{},
 					},
@@ -1107,14 +1107,14 @@ func TestGetAppProtectResource(t *testing.T) {
 			kind:    "APPolicy",
 			key:     "testing/test2",
 			wantErr: true,
-			errMsg:  "Validation Failed",
+			errMsg:  "validation failed",
 			msg:     "Policy, Negative, invalid object",
 		},
 		{
 			kind:    "APPolicy",
 			key:     "testing/test3",
 			wantErr: true,
-			errMsg:  "App Protect Policy testing/test3 not found",
+			errMsg:  "app protect Policy testing/test3 not found",
 			msg:     "Policy, Negative, Object Does not exist",
 		},
 		{
@@ -1127,14 +1127,14 @@ func TestGetAppProtectResource(t *testing.T) {
 			kind:    "APLogConf",
 			key:     "testing/test2",
 			wantErr: true,
-			errMsg:  "Validation Failed",
+			errMsg:  "validation failed",
 			msg:     "LogConf, Negative, invalid object",
 		},
 		{
 			kind:    "APLogConf",
 			key:     "testing/test3",
 			wantErr: true,
-			errMsg:  "App Protect LogConf testing/test3 not found",
+			errMsg:  "app protect LogConf testing/test3 not found",
 			msg:     "LogConf, Negative, Object Does not exist",
 		},
 		{
@@ -1147,31 +1147,31 @@ func TestGetAppProtectResource(t *testing.T) {
 			kind:    "APUserSig",
 			key:     "testing/test2",
 			wantErr: true,
-			errMsg:  "Validation Failed",
+			errMsg:  "validation failed",
 			msg:     "UserSig, Negative, invalid object",
 		},
 		{
 			kind:    "APUserSig",
 			key:     "testing/test3",
 			wantErr: true,
-			errMsg:  "App Protect UserSig testing/test3 not found",
+			errMsg:  "app protect UserSig testing/test3 not found",
 			msg:     "UserSig, Negative, Object Does not exist",
 		},
 		{
 			kind:    "Notreal",
 			key:     "testing/test3",
 			wantErr: true,
-			errMsg:  "Unknown App Protect resource kind Notreal",
+			errMsg:  "unknown app protect resource kind Notreal",
 			msg:     "Invalid kind, Negative",
 		},
 	}
 	appProtectConfiguration := newConfigurationImpl()
 	appProtectConfiguration.Policies["testing/test1"] = &PolicyEx{IsValid: true, Obj: &unstructured.Unstructured{}}
-	appProtectConfiguration.Policies["testing/test2"] = &PolicyEx{IsValid: false, Obj: &unstructured.Unstructured{}, ErrorMsg: "Validation Failed"}
+	appProtectConfiguration.Policies["testing/test2"] = &PolicyEx{IsValid: false, Obj: &unstructured.Unstructured{}, ErrorMsg: "validation failed"}
 	appProtectConfiguration.LogConfs["testing/test1"] = &LogConfEx{IsValid: true, Obj: &unstructured.Unstructured{}}
-	appProtectConfiguration.LogConfs["testing/test2"] = &LogConfEx{IsValid: false, Obj: &unstructured.Unstructured{}, ErrorMsg: "Validation Failed"}
+	appProtectConfiguration.LogConfs["testing/test2"] = &LogConfEx{IsValid: false, Obj: &unstructured.Unstructured{}, ErrorMsg: "validation failed"}
 	appProtectConfiguration.UserSigs["testing/test1"] = &UserSigEx{IsValid: true, Obj: &unstructured.Unstructured{}}
-	appProtectConfiguration.UserSigs["testing/test2"] = &UserSigEx{IsValid: false, Obj: &unstructured.Unstructured{}, ErrorMsg: "Validation Failed"}
+	appProtectConfiguration.UserSigs["testing/test2"] = &UserSigEx{IsValid: false, Obj: &unstructured.Unstructured{}, ErrorMsg: "validation failed"}
 
 	for _, test := range tests {
 		_, err := appProtectConfiguration.GetAppResource(test.kind, test.key)


### PR DESCRIPTION
### Proposed changes

This PR fixes `staticcheck` complains about Go error messages:

```shell
➜  kubernetes-ingress git:(fix/staticcheck-go-errors) ✗ staticcheck internal/k8s/appprotect/*.go
internal/k8s/appprotect/app_protect_configuration.go:293:74: error strings should not be capitalized (ST1005)
internal/k8s/appprotect/app_protect_configuration.go:402:15: error strings should not be capitalized (ST1005)
internal/k8s/appprotect/app_protect_configuration.go:410:15: error strings should not be capitalized (ST1005)
internal/k8s/appprotect/app_protect_configuration.go:418:15: error strings should not be capitalized (ST1005)
internal/k8s/appprotect/app_protect_configuration.go:420:14: error strings should not be capitalized (ST1005)
internal/k8s/appprotect/app_protect_configuration.go:602:15: error strings should not be capitalized (ST1005)
internal/k8s/appprotect/app_protect_configuration.go:607:15: error strings should not be capitalized (ST1005)
internal/k8s/appprotect/app_protect_configuration.go:609:14: error strings should not be capitalized (ST1005)
```


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
