### PR TITLE
Fix manifest CRD documentation

### DIFF
--- a/docs/content/includes/installation/create-custom-resources.md
+++ b/docs/content/includes/installation/create-custom-resources.md
@@ -11,16 +11,16 @@ There are two ways you can install the custom resource definitions:
 1. Using a URL to apply a single CRD yaml file, which we recommend.
 1. Applying your local copy of the CRD yaml files, which requires you to clone the repository.
 
-{{<tabs name="install-crds">}}
-
-{{%tab name="Install CRDs from single YAML"%}}
-
-This single YAML file creates CRDs for the following resources:
+The core custom CRDs are the following:
 
 - [VirtualServer and VirtualServerRoute]({{< relref "configuration/virtualserver-and-virtualserverroute-resources.md" >}})
 - [TransportServer]({{< relref "configuration/transportserver-resource.md" >}})
 - [Policy]({{< relref "configuration/policy-resource.md" >}})
 - [GlobalConfiguration]({{< relref "configuration/global-configuration/globalconfiguration-resource.md" >}})
+
+{{<tabs name="install-crds">}}
+
+{{%tab name="Install CRDs from single YAML"%}}
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/v{{< nic-version >}}/deploy/crds.yaml
@@ -31,13 +31,6 @@ kubectl apply -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/v
 {{%tab name="Install CRDs after cloning the repo"%}}
 
 {{< note >}} If you are installing the CRDs this way, ensure you have first cloned the repository. {{< /note >}}
-
-These YAML files create CRDs for the following resources:
-
-- [VirtualServer and VirtualServerRoute]({{< relref "configuration/virtualserver-and-virtualserverroute-resources.md" >}})
-- [TransportServer]({{< relref "configuration/transportserver-resource.md" >}})
-- [Policy]({{< relref "configuration/policy-resource.md" >}})
-- [GlobalConfiguration]({{< relref "configuration/global-configuration/globalconfiguration-resource.md" >}})
 
 ```shell
 kubectl apply -f config/crd/bases/k8s.nginx.org_virtualservers.yaml

--- a/docs/content/installation/installing-nic/installation-with-manifests.md
+++ b/docs/content/installation/installing-nic/installation-with-manifests.md
@@ -59,72 +59,65 @@ To use App Protect DoS, install the App Protect DoS Arbitrator using the provide
 
 ---
 
-## Create custom resources {#create-custom-resources}
+## Create core custom resources {#create-custom-resources}
 
 {{< include "installation/create-custom-resources.md" >}}
 
-{{<tabs name="install-crds">}}
+### Create optional custom resources
+
+There are optional CRDs that are necessary if you want to use NGINX App Protect WAF or NGINX App Protect DoS.
+
+**NGINX App Protect WAF**:
+- `APPolicy`
+- `APLogConf`
+- `APUserSig`
+
+**NGINX App Protect DoS**:
+- `APDosPolicy`
+- `APDosLogConf`
+- `DosProtectedResource`
+
+{{<tabs name="install-nap-crds">}}
 
 {{%tab name="Install CRDs from single YAML"%}}
 
-### Core custom resource definitions
 
-1. Create CRDs for [VirtualServer and VirtualServerRoute]({{< relref "configuration/virtualserver-and-virtualserverroute-resources.md" >}}), [TransportServer]({{< relref "configuration/transportserver-resource.md" >}}), [Policy]({{< relref "configuration/policy-resource.md" >}}) and [GlobalConfiguration]({{< relref "configuration/global-configuration/globalconfiguration-resource.md" >}}):
+**NGINX App Protect WAF**
 
-    ```shell
-    kubectl apply -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/v{{< nic-version >}}/deploy/crds.yaml
-    ```
+{{<  note >}} This step can be skipped if you are using App Protect WAF module with policy bundles. {{<  /note >}}
 
-### Optional custom resource definitions
+```shell
+kubectl apply -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/v{{< nic-version >}}/deploy/crds-nap-waf.yaml
+```
 
-1. For the NGINX App Protect WAF module, create CRDs for `APPolicy`, `APLogConf` and `APUserSig`:
+**NGINX App Protect DoS**:
 
-    ```shell
-    kubectl apply -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/v{{< nic-version >}}/deploy/crds-nap-waf.yaml
-    ```
-
-2. For the NGINX App Protect DoS module, create CRDs for `APDosPolicy`, `APDosLogConf` and `DosProtectedResource`:
-
-    ```shell
-    kubectl apply -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/v{{< nic-version >}}/deploy/crds-nap-dos.yaml
-    ```
+```shell
+kubectl apply -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/v{{< nic-version >}}/deploy/crds-nap-dos.yaml
+```
 
 {{%/tab%}}
 
 {{%tab name="Install CRDs after cloning the repo"%}}
 
-If you are installing the CRDs this way, ensure that you have first [cloned the repository](#clone-the-repository)
-
-### Core custom resource definitions
-
-1. Create CRDs for [VirtualServer and VirtualServerRoute]({{< relref "configuration/virtualserver-and-virtualserverroute-resources.md" >}}), [TransportServer]({{< relref "configuration/transportserver-resource.md" >}}), [Policy]({{< relref "configuration/policy-resource.md" >}}) and [GlobalConfiguration]({{< relref "configuration/global-configuration/globalconfiguration-resource.md" >}}):
-
-    ```shell
-    kubectl apply -f config/crd/bases/k8s.nginx.org_virtualservers.yaml
-    kubectl apply -f config/crd/bases/k8s.nginx.org_virtualserverroutes.yaml
-    kubectl apply -f config/crd/bases/k8s.nginx.org_transportservers.yaml
-    kubectl apply -f config/crd/bases/k8s.nginx.org_policies.yaml
-    kubectl apply -f config/crd/bases/k8s.nginx.org_globalconfigurations.yaml
-    ```
-### Optional custom resource definitions
+**NGINX App Protect WAF**
 
 {{<  note >}} This step can be skipped if you are using App Protect WAF module with policy bundles. {{<  /note >}}
 
-1. For the NGINX App Protect WAF module, create CRDs for `APPolicy`, `APLogConf` and `APUserSig`:
+```shell
+kubectl apply -f config/crd/bases/appprotect.f5.com_aplogconfs.yaml
+kubectl apply -f config/crd/bases/appprotect.f5.com_appolicies.yaml
+kubectl apply -f config/crd/bases/appprotect.f5.com_apusersigs.yaml
+```
 
-    ```shell
-    kubectl apply -f config/crd/bases/appprotect.f5.com_aplogconfs.yaml
-    kubectl apply -f config/crd/bases/appprotect.f5.com_appolicies.yaml
-    kubectl apply -f config/crd/bases/appprotect.f5.com_apusersigs.yaml
-    ```
+**NGINX App Protect DoS**:
 
-2. For the NGINX App Protect DoS module, create CRDs for `APDosPolicy`, `APDosLogConf` and `DosProtectedResource`:
+```shell
+kubectl apply -f config/crd/bases/appprotectdos.f5.com_apdoslogconfs.yaml
+kubectl apply -f config/crd/bases/appprotectdos.f5.com_apdospolicy.yaml
+kubectl apply -f config/crd/bases/appprotectdos.f5.com_dosprotectedresources.yaml
+```
 
-   ```shell
-   kubectl apply -f config/crd/bases/appprotectdos.f5.com_apdoslogconfs.yaml
-   kubectl apply -f config/crd/bases/appprotectdos.f5.com_apdospolicy.yaml
-   kubectl apply -f config/crd/bases/appprotectdos.f5.com_dosprotectedresources.yaml
-   ```
 {{%/tab%}}
 
 {{</tabs>}}


### PR DESCRIPTION
### Proposed changes

This commit restructures the custom resource section of the Installation with Manifests documentation to remove redundant instructions and more clearly delineate the NAP-specific instructions from the core definitions.

Using includes, a potential furthur improvement for the future would be to fully compartmentalise any NAP WAF or DOS documentation into their "Integration" subsections, removing them from the critical user path.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
