### PR TITLE
fix typo in ubi8 image promotion

### DIFF
--- a/.github/config/config-plus-gcr-release
+++ b/.github/config/config-plus-gcr-release
@@ -1,7 +1,7 @@
 export TARGET_REGISTRY=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release
 declare -a PLUS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine" "-mktpl")
-declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "ubi8" "-mktpl")
-declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "ubi8")
+declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "-ubi8" "-mktpl")
+declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "-ubi8")
 declare -a NAP_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl")
 declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl")
 declare -a ADDITIONAL_TAGS=("latest" "${ADDITIONAL_TAG}")

--- a/.github/config/config-plus-nginx
+++ b/.github/config/config-plus-nginx
@@ -1,8 +1,8 @@
 export TARGET_REGISTRY=docker-mgmt.nginx.com
 export TARGET_NAP_WAF_DOS_IMAGE_PREFIX="nginx-ic-nap-dos/nginx-plus-ingress"
 declare -a PLUS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine")
-declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "ubi8")
-declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "ubi8")
+declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "-ubi8")
+declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "-ubi8")
 declare -a NAP_DOS_TAG_POSTFIX_LIST=("" "-ubi")
 declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-ubi")
 export PUBLISH_OSS=false


### PR DESCRIPTION
### Proposed changes

Image promotion was failing due to a typo with the ubi8 image tags

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
