### PR TITLE
remove fips & unused aws images from release

### DIFF
--- a/.github/config/config-plus-gcr-release
+++ b/.github/config/config-plus-gcr-release
@@ -1,8 +1,8 @@
 export TARGET_REGISTRY=gcr.io/f5-gcs-7899-ptg-ingrss-ctlr/release
-declare -a PLUS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine" "-alpine-fips" "-mktpl" "-alpine-mktpl" "-alpine-mktpl-fips")
-declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl" "-ubi-mktpl" "-alpine-fips")
-declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "-alpine-fips")
-declare -a NAP_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl" "-ubi-mktpl")
-declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl" "-ubi-mktpl")
+declare -a PLUS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine" "-mktpl")
+declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl")
+declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi")
+declare -a NAP_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl")
+declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-ubi" "-mktpl")
 declare -a ADDITIONAL_TAGS=("latest" "${ADDITIONAL_TAG}")
 export PUBLISH_OSS=false

--- a/.github/scripts/copy-images.sh
+++ b/.github/scripts/copy-images.sh
@@ -47,9 +47,9 @@ TARGET_NAP_DOS_IMAGE_PREFIX=${TARGET_NAP_DOS_IMAGE_PREFIX:-"nginx-ic-dos/nginx-p
 TARGET_NAP_WAF_DOS_IMAGE_PREFIX=${TARGET_NAP_WAF_DOS_IMAGE_PREFIX:-"nginx-ic-dos-nap/nginx-plus-ingress"}
 
 declare -a OSS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine")
-declare -a PLUS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine" "-alpine-fips")
-declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi" "-alpine-fips")
-declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi" "-alpine-fips")
+declare -a PLUS_TAG_POSTFIX_LIST=("" "-ubi" "-alpine")
+declare -a NAP_WAF_TAG_POSTFIX_LIST=("" "-ubi")
+declare -a NAP_WAFV5_TAG_POSTFIX_LIST=("" "-ubi")
 declare -a NAP_DOS_TAG_POSTFIX_LIST=("" "-ubi")
 declare -a NAP_WAF_DOS_TAG_POSTFIX_LIST=("" "-ubi")
 declare -a ADDITIONAL_TAGS=("latest" "${ADDITIONAL_TAG}")


### PR DESCRIPTION
### Proposed changes

The image patching workflow uses the release configuration from the release branch.  We do not want to try to push fips images, or unused aws images

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
