### PR TITLE
move mounted code to fix /tmp file permissions

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -538,11 +538,12 @@ ARG NAP_MODULES=none
 
 ENV BUILD_OS=${BUILD_OS}
 
-RUN --mount=type=bind,target=/tmp \
+RUN --mount=type=bind,target=/code \
 	--mount=type=bind,from=nginx-files,src=common.sh,target=/usr/local/bin/common.sh \
 	--mount=type=bind,from=nginx-files,src=patch-os.sh,target=/usr/local/bin/patch-os.sh \
-	patch-os.sh \
-	&& common.sh
+	ls -al /tmp \
+	&& /usr/local/bin/patch-os.sh \
+	&& /usr/local/bin/common.sh
 
 EXPOSE 80 443
 

--- a/build/scripts/common.sh
+++ b/build/scripts/common.sh
@@ -5,20 +5,20 @@ set -e
 PLUS=""
 if [ -z "${BUILD_OS##*plus*}" ]; then
     mkdir -p /etc/nginx/oidc/
-    cp -a /tmp/internal/configs/oidc/* /etc/nginx/oidc/
+    cp -a /code/internal/configs/oidc/* /etc/nginx/oidc/
     mkdir -p /etc/nginx/state_files/
     PLUS=-plus
 fi
 
-mkdir -p /etc/nginx/njs/ && cp -a /tmp/internal/configs/njs/* /etc/nginx/njs/
+mkdir -p /etc/nginx/njs/ && cp -a /code/internal/configs/njs/* /etc/nginx/njs/
 mkdir -p /var/lib/nginx /etc/nginx/secrets /etc/nginx/stream-conf.d
 setcap 'cap_net_bind_service=+eip' /usr/sbin/nginx 'cap_net_bind_service=+eip' /usr/sbin/nginx-debug
 setcap -v 'cap_net_bind_service=+eip' /usr/sbin/nginx 'cap_net_bind_service=+eip' /usr/sbin/nginx-debug
 
-cp -a /tmp/internal/configs/version1/nginx$PLUS.ingress.tmpl \
-    /tmp/internal/configs/version1/nginx$PLUS.tmpl \
-	/tmp/internal/configs/version2/nginx$PLUS.virtualserver.tmpl \
-    /tmp/internal/configs/version2/nginx$PLUS.transportserver.tmpl \
+cp -a /code/internal/configs/version1/nginx$PLUS.ingress.tmpl \
+    /code/internal/configs/version1/nginx$PLUS.tmpl \
+	/code/internal/configs/version2/nginx$PLUS.virtualserver.tmpl \
+    /code/internal/configs/version2/nginx$PLUS.transportserver.tmpl \
     /
 
 chown -R 101:0 /etc/nginx /var/cache/nginx /var/lib/nginx /var/log/nginx /*.tmpl


### PR DESCRIPTION
### Proposed changes

The OS patching on base image generation was silently failing due to a permissions errors on the `/tmp` file system
```
#124 [linux/arm64 common 1/1] RUN --mount=type=bind,target=/tmp 	--mount=type=bind,from=nginx-files,src=common.sh,target=/usr/local/bin/common.sh 	--mount=type=bind,from=nginx-files,src=patch-os.sh,target=/usr/local/bin/patch-os.sh 	patch-os.sh 	&& common.sh
#124 0.156 Patching Debian
#124 0.754 Hit:1 http://deb.debian.org/debian bookworm InRelease
#124 0.760 Hit:2 http://deb.debian.org/debian bookworm-updates InRelease
#124 0.760 Hit:3 http://deb.debian.org/debian-security bookworm-security InRelease
#124 0.811 Err:1 http://deb.debian.org/debian bookworm InRelease
#124 0.812   Couldn't create temporary file /tmp/apt.conf.bvGASO for passing config to apt-key
#124 0.825 Err:2 http://deb.debian.org/debian bookworm-updates InRelease
#124 0.825   Couldn't create temporary file /tmp/apt.conf.KePWjI for passing config to apt-key
#124 0.837 Err:3 http://deb.debian.org/debian-security bookworm-security InRelease
#124 0.837   Couldn't create temporary file /tmp/apt.conf.uTj0mw for passing config to apt-key
#124 0.925 Reading package lists...
#124 1.158 W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://deb.debian.org/debian bookworm InRelease: Couldn't create temporary file /tmp/apt.conf.bvGASO for passing config to apt-key
#124 1.158 W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://deb.debian.org/debian bookworm-updates InRelease: Couldn't create temporary file /tmp/apt.conf.KePWjI for passing config to apt-key
#124 1.158 W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://deb.debian.org/debian-security bookworm-security InRelease: Couldn't create temporary file /tmp/apt.conf.uTj0mw for passing config to apt-key
#124 1.158 W: Failed to fetch http://deb.debian.org/debian/dists/bookworm/InRelease  Couldn't create temporary file /tmp/apt.conf.bvGASO for passing config to apt-key
#124 1.159 W: Failed to fetch http://deb.debian.org/debian/dists/bookworm-updates/InRelease  Couldn't create temporary file /tmp/apt.conf.KePWjI for passing config to apt-key
#124 1.159 W: Failed to fetch http://deb.debian.org/debian-security/dists/bookworm-security/InRelease  Couldn't create temporary file /tmp/apt.conf.uTj0mw for passing config to apt-key
#124 1.159 W: Some index files failed to download. They have been ignored, or old ones used instead.
#124 1.159 E: Unable to mkstemp /tmp/clearsigned.message.Um1gn0 - GetTempFile (30: Read-only file system)
#124 1.159 E: The package lists or status file could not be parsed or opened.
#124 1.344 Reading package lists...
#124 1.526 E: Unable to mkstemp /tmp/clearsigned.message.z3xLHq - GetTempFile (30: Read-only file system)
#124 1.526 E: The package lists or status file could not be parsed or opened.
```

This change moves where the code is mounted to within the build stage rather than `/tmp` it now uses `/code`.  This make the `/tmp` filesystem have the correct permissions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
