### PR TITLE
Listener directive refactor

### DIFF
--- a/internal/configs/version2/template_helper.go
+++ b/internal/configs/version2/template_helper.go
@@ -75,10 +75,10 @@ func buildListenerDirectives(listenerType protocol, s Server, port string) strin
 			directives += buildListenDirective(s.HTTPIPv6, port, false, s.ProxyProtocol, false, ipv6)
 		}
 	} else {
-		directives += buildListenDirective(s.HTTPSIPv4, port, false, s.ProxyProtocol, false, ipv4)
+		directives += buildListenDirective(s.HTTPSIPv4, port, true, s.ProxyProtocol, false, ipv4)
 		if !s.DisableIPV6 {
 			directives += spacing
-			directives += buildListenDirective(s.HTTPSIPv6, port, false, s.ProxyProtocol, false, ipv6)
+			directives += buildListenDirective(s.HTTPSIPv6, port, true, s.ProxyProtocol, false, ipv6)
 		}
 	}
 
@@ -98,7 +98,7 @@ func getCustomPort(listenerType protocol, s Server) string {
 	if listenerType == http {
 		return strconv.Itoa(s.HTTPPort)
 	}
-	return strconv.Itoa(s.HTTPSPort) + " ssl"
+	return strconv.Itoa(s.HTTPSPort)
 }
 
 func buildListenDirective(ip string, port string, tls bool, proxyProtocol bool, udp bool, ipType ipType) string {

--- a/internal/configs/version2/template_helper.go
+++ b/internal/configs/version2/template_helper.go
@@ -69,16 +69,16 @@ func buildListenerDirectives(listenerType protocol, s Server, port string) strin
 	var directives string
 
 	if listenerType == http {
-		directives += buildListenDirective(s.HTTPIPv4, port, s.ProxyProtocol, ipv4)
+		directives += buildHTTPListenDirective(s.HTTPIPv4, port, s.ProxyProtocol, ipv4)
 		if !s.DisableIPV6 {
 			directives += spacing
-			directives += buildListenDirective(s.HTTPIPv6, port, s.ProxyProtocol, ipv6)
+			directives += buildHTTPListenDirective(s.HTTPIPv6, port, s.ProxyProtocol, ipv6)
 		}
 	} else {
-		directives += buildListenDirective(s.HTTPSIPv4, port, s.ProxyProtocol, ipv4)
+		directives += buildHTTPListenDirective(s.HTTPSIPv4, port, s.ProxyProtocol, ipv4)
 		if !s.DisableIPV6 {
 			directives += spacing
-			directives += buildListenDirective(s.HTTPSIPv6, port, s.ProxyProtocol, ipv6)
+			directives += buildHTTPListenDirective(s.HTTPSIPv6, port, s.ProxyProtocol, ipv6)
 		}
 	}
 
@@ -101,7 +101,7 @@ func getCustomPort(listenerType protocol, s Server) string {
 	return strconv.Itoa(s.HTTPSPort) + " ssl"
 }
 
-func buildListenDirective(ip string, port string, proxyProtocol bool, ipType ipType) string {
+func buildHTTPListenDirective(ip string, port string, proxyProtocol bool, ipType ipType) string {
 	base := "listen"
 	var directive string
 

--- a/internal/configs/version2/template_helper.go
+++ b/internal/configs/version2/template_helper.go
@@ -86,10 +86,12 @@ func buildListenerDirectives(listenerType protocol, s Server, port string) strin
 }
 
 func getDefaultPort(listenerType protocol) string {
-	if listenerType == http {
-		return "80"
+	s := Server{
+		HTTPPort:  80,
+		HTTPSPort: 443,
 	}
-	return "443 ssl"
+
+	return getCustomPort(listenerType, s)
 }
 
 func getCustomPort(listenerType protocol, s Server) string {

--- a/internal/configs/version2/template_helper.go
+++ b/internal/configs/version2/template_helper.go
@@ -69,16 +69,16 @@ func buildListenerDirectives(listenerType protocol, s Server, port string) strin
 	var directives string
 
 	if listenerType == http {
-		directives += buildHTTPListenDirective(s.HTTPIPv4, port, s.ProxyProtocol, ipv4)
+		directives += buildListenDirective(s.HTTPIPv4, port, false, s.ProxyProtocol, false, ipv4)
 		if !s.DisableIPV6 {
 			directives += spacing
-			directives += buildHTTPListenDirective(s.HTTPIPv6, port, s.ProxyProtocol, ipv6)
+			directives += buildListenDirective(s.HTTPIPv6, port, false, s.ProxyProtocol, false, ipv6)
 		}
 	} else {
-		directives += buildHTTPListenDirective(s.HTTPSIPv4, port, s.ProxyProtocol, ipv4)
+		directives += buildListenDirective(s.HTTPSIPv4, port, false, s.ProxyProtocol, false, ipv4)
 		if !s.DisableIPV6 {
 			directives += spacing
-			directives += buildHTTPListenDirective(s.HTTPSIPv6, port, s.ProxyProtocol, ipv6)
+			directives += buildListenDirective(s.HTTPSIPv6, port, false, s.ProxyProtocol, false, ipv6)
 		}
 	}
 
@@ -99,32 +99,6 @@ func getCustomPort(listenerType protocol, s Server) string {
 		return strconv.Itoa(s.HTTPPort)
 	}
 	return strconv.Itoa(s.HTTPSPort) + " ssl"
-}
-
-func buildHTTPListenDirective(ip string, port string, proxyProtocol bool, ipType ipType) string {
-	base := "listen"
-	var directive string
-
-	if ipType == ipv6 {
-		if ip != "" {
-			directive = fmt.Sprintf("%s [%s]:%s", base, ip, port)
-		} else {
-			directive = fmt.Sprintf("%s [::]:%s", base, port)
-		}
-	} else {
-		if ip != "" {
-			directive = fmt.Sprintf("%s %s:%s", base, ip, port)
-		} else {
-			directive = fmt.Sprintf("%s %s", base, port)
-		}
-	}
-
-	if proxyProtocol {
-		directive += " proxy_protocol"
-	}
-
-	directive += ";\n"
-	return directive
 }
 
 func buildListenDirective(ip string, port string, tls bool, proxyProtocol bool, udp bool, ipType ipType) string {

--- a/internal/configs/version2/template_helper.go
+++ b/internal/configs/version2/template_helper.go
@@ -106,17 +106,16 @@ func buildListenDirective(ip string, port string, tls bool, proxyProtocol bool, 
 	var directive string
 
 	if ipType == ipv6 {
-		if ip != "" {
-			directive = fmt.Sprintf("%s [%s]:%s", base, ip, port)
-		} else {
-			directive = fmt.Sprintf("%s [::]:%s", base, port)
+		if ip == "" {
+			ip = "::"
 		}
+		ip = fmt.Sprintf("[%s]", ip)
+	}
+
+	if ip != "" {
+		directive = fmt.Sprintf("%s %s:%s", base, ip, port)
 	} else {
-		if ip != "" {
-			directive = fmt.Sprintf("%s %s:%s", base, ip, port)
-		} else {
-			directive = fmt.Sprintf("%s %s", base, port)
-		}
+		directive = fmt.Sprintf("%s %s", base, port)
 	}
 
 	if tls {


### PR DESCRIPTION
### Proposed changes

- reuse getCustomPort() for default http(s) ports
- collapse http & transport server directive generation into one function
- remove custom `ssl` logic in getCustomPort()

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
