### PR TITLE
Fix issues reported by staticcheck

### DIFF
--- a/internal/certmanager/sync_test.go
+++ b/internal/certmanager/sync_test.go
@@ -519,7 +519,7 @@ func TestSync(t *testing.T) {
 				t.Errorf("Not all expected reactors were called: %v", err)
 			}
 			if err := b.AllActionsExecuted(); err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 		}
 	}

--- a/internal/certmanager/test_files/context_builder.go
+++ b/internal/certmanager/test_files/context_builder.go
@@ -174,10 +174,10 @@ func (b *Builder) CheckAndFinish(args ...interface{}) {
 		b.T.Errorf("Not all expected reactors were called: %v", err)
 	}
 	if err := b.AllActionsExecuted(); err != nil {
-		b.T.Errorf(err.Error())
+		b.T.Error(err.Error())
 	}
 	if err := b.AllEventsCalled(); err != nil {
-		b.T.Errorf(err.Error())
+		b.T.Error(err.Error())
 	}
 
 	// resync listers before running checks

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -1479,7 +1479,7 @@ func TestGenerateVirtualServerConfigWithBackupForNGINXPlus(t *testing.T) {
 
 	got, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
 	if !cmp.Equal(want, got) {
-		t.Errorf(cmp.Diff(want, got))
+		t.Error(cmp.Diff(want, got))
 	}
 	if len(warnings) != 0 {
 		t.Errorf("GenerateVirtualServerConfig returned warnings: %v", vsc.warnings)
@@ -1786,7 +1786,7 @@ func TestGenerateVirtualServerConfig_DoesNotGenerateBackupOnMissingBackupNameFor
 
 	got, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
 	if !cmp.Equal(want, got) {
-		t.Errorf(cmp.Diff(want, got))
+		t.Error(cmp.Diff(want, got))
 	}
 	if len(warnings) != 0 {
 		t.Errorf("GenerateVirtualServerConfig returned warnings: %v", vsc.warnings)
@@ -2092,7 +2092,7 @@ func TestGenerateVirtualServerConfig_DoesNotGenerateBackupOnMissingBackupPortFor
 
 	got, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
 	if !cmp.Equal(want, got) {
-		t.Errorf(cmp.Diff(want, got))
+		t.Error(cmp.Diff(want, got))
 	}
 	if len(warnings) != 0 {
 		t.Errorf("GenerateVirtualServerConfig returned warnings: %v", vsc.warnings)
@@ -2396,7 +2396,7 @@ func TestGenerateVirtualServerConfig_DoesNotGenerateBackupOnMissingBackupPortAnd
 
 	got, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
 	if !cmp.Equal(want, got) {
-		t.Errorf(cmp.Diff(want, got))
+		t.Error(cmp.Diff(want, got))
 	}
 	if len(warnings) != 0 {
 		t.Errorf("GenerateVirtualServerConfig returned warnings: %v", vsc.warnings)
@@ -6347,19 +6347,19 @@ func TestGenerateVirtualServerConfigAPIKeyClientMaps(t *testing.T) {
 			})
 
 			if !cmp.Equal(tc.expectedSpecAPIKey, vsConf.Server.APIKey) {
-				t.Errorf(cmp.Diff(tc.expectedSpecAPIKey, vsConf.Server.APIKey))
+				t.Error(cmp.Diff(tc.expectedSpecAPIKey, vsConf.Server.APIKey))
 			}
 
 			if !cmp.Equal(tc.expectedRoute1APIKey, vsConf.Server.Locations[0].APIKey) {
-				t.Errorf(cmp.Diff(tc.expectedRoute1APIKey, vsConf.Server.Locations[0].APIKey))
+				t.Error(cmp.Diff(tc.expectedRoute1APIKey, vsConf.Server.Locations[0].APIKey))
 			}
 
 			if !cmp.Equal(tc.expectedRoute2APIKey, vsConf.Server.Locations[1].APIKey) {
-				t.Errorf(cmp.Diff(tc.expectedRoute2APIKey, vsConf.Server.Locations[1].APIKey))
+				t.Error(cmp.Diff(tc.expectedRoute2APIKey, vsConf.Server.Locations[1].APIKey))
 			}
 
 			if !cmp.Equal(tc.expectedMapList, vsConf.Maps) {
-				t.Errorf(cmp.Diff(tc.expectedMapList, vsConf.Maps))
+				t.Error(cmp.Diff(tc.expectedMapList, vsConf.Maps))
 			}
 
 			if len(warnings) != 0 {
@@ -7161,7 +7161,7 @@ func TestGeneratePolicies(t *testing.T) {
 			result.BundleValidator = nil
 
 			if !cmp.Equal(tc.expected, result) {
-				t.Errorf(cmp.Diff(tc.expected, result))
+				t.Error(cmp.Diff(tc.expected, result))
 			}
 			if len(vsc.warnings) > 0 {
 				t.Errorf("generatePolicies() returned unexpected warnings %v for the case of %s", vsc.warnings, tc.msg)
@@ -15803,7 +15803,7 @@ func TestRFC1123ToSnake(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if !cmp.Equal(rfc1123ToSnake(tt.input), tt.expected) {
-				t.Errorf(cmp.Diff(rfc1123ToSnake(tt.input), tt.expected))
+				t.Error(cmp.Diff(rfc1123ToSnake(tt.input), tt.expected))
 			}
 		})
 	}

--- a/internal/externaldns/sync_test.go
+++ b/internal/externaldns/sync_test.go
@@ -82,10 +82,10 @@ func TestGetValidTargets(t *testing.T) {
 				t.Fatal(err)
 			}
 			if !cmp.Equal(tc.wantTargets, targets) {
-				t.Errorf(cmp.Diff(tc.wantTargets, targets))
+				t.Error(cmp.Diff(tc.wantTargets, targets))
 			}
 			if recordType != tc.wantRecord {
-				t.Errorf(cmp.Diff(tc.wantRecord, recordType))
+				t.Error(cmp.Diff(tc.wantRecord, recordType))
 			}
 		})
 	}

--- a/internal/k8s/validation.go
+++ b/internal/k8s/validation.go
@@ -968,7 +968,7 @@ var escapedStringsFmtRegexp = regexp.MustCompile("^" + escapedStringsFmt + "$")
 func ValidateEscapedString(body string, examples ...string) error {
 	if !escapedStringsFmtRegexp.MatchString(body) {
 		msg := validation.RegexError(escapedStringsErrMsg, escapedStringsFmt, examples...)
-		return fmt.Errorf(msg)
+		return errors.New(msg)
 	}
 	return nil
 }

--- a/pkg/apis/configuration/validation/common.go
+++ b/pkg/apis/configuration/validation/common.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -21,7 +22,7 @@ var escapedStringsFmtRegexp = regexp.MustCompile("^" + escapedStringsFmt + "$")
 func ValidateEscapedString(body string, examples ...string) error {
 	if !escapedStringsFmtRegexp.MatchString(body) {
 		msg := validation.RegexError(escapedStringsErrMsg, escapedStringsFmt, examples...)
-		return fmt.Errorf(msg)
+		return errors.New(msg)
 	}
 	return nil
 }


### PR DESCRIPTION
### Proposed changes

This PR addresses errors reported by [`staticcheck`](https://staticcheck.dev) (printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006))

```shell
➜  kubernetes-ingress git:(chore/staticcheck) ✗ staticcheck --version
staticcheck 2024.1.1 (0.5.1)
```

```shell
staticcheck ./...
```

```shell
internal/certmanager/sync_test.go:522:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/certmanager/test_files/context_builder.go:177:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/certmanager/test_files/context_builder.go:180:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/configs/virtualserver_test.go:1482:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/configs/virtualserver_test.go:1789:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/configs/virtualserver_test.go:2095:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/configs/virtualserver_test.go:2399:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/configs/virtualserver_test.go:6350:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/configs/virtualserver_test.go:6354:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/configs/virtualserver_test.go:6358:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/configs/virtualserver_test.go:6362:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/configs/virtualserver_test.go:7164:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/configs/virtualserver_test.go:15806:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/externaldns/sync_test.go:85:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/externaldns/sync_test.go:88:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/k8s/appprotect/app_protect_configuration.go:211:89: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/k8s/appprotect/app_protect_configuration.go:218:89: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/k8s/appprotect/app_protect_configuration.go:227:92: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/k8s/appprotect/app_protect_configuration.go:246:20: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/k8s/appprotect/app_protect_configuration.go:254:20: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/k8s/appprotect/app_protect_configuration.go:281:84: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/k8s/appprotect/app_protect_configuration.go:293:74: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
internal/k8s/validation.go:971:10: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/apis/configuration/validation/common.go:24:10: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
``` 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
