### PR TITLE
Remove double imports

### DIFF
--- a/internal/k8s/configmap.go
+++ b/internal/k8s/configmap.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 
 	"github.com/golang/glog"
-	api_v1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
@@ -59,7 +58,7 @@ func (lbc *LoadBalancerController) addConfigMapHandler(handlers cache.ResourceEv
 			"configmaps",
 			namespace,
 			fields.Everything()),
-		ObjectType:   &api_v1.ConfigMap{},
+		ObjectType:   &v1.ConfigMap{},
 		ResyncPeriod: lbc.resync,
 		Handler:      handlers,
 	}
@@ -77,7 +76,7 @@ func (lbc *LoadBalancerController) syncConfigMap(task task) {
 		return
 	}
 	if configExists {
-		lbc.configMap = obj.(*api_v1.ConfigMap)
+		lbc.configMap = obj.(*v1.ConfigMap)
 		externalStatusAddress, exists := lbc.configMap.Data["external-status-address"]
 		if exists {
 			lbc.statusUpdater.SaveStatusFromExternalStatus(externalStatusAddress)


### PR DESCRIPTION
### Proposed changes

This PR fixes double imports reported by `staticcheck`:

```shell
internal/k8s/configmap.go:7:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
	internal/k8s/configmap.go:8:2: other import of "k8s.io/api/core/v1"
internal/k8s/service.go:8:2: package "k8s.io/api/core/v1" is being imported more than once (ST1019)
	internal/k8s/service.go:9:2: other import of "k8s.io/api/core/v1"
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
