### PR TITLE
Add benchmark tests for configurator

### DIFF
--- a/internal/configs/configurator_bench_test.go
+++ b/internal/configs/configurator_bench_test.go
@@ -88,7 +88,6 @@ func BenchUpdateEndpoints(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
-
 }
 
 func BenchmarkUpdateEndpointsMergeableIngress(b *testing.B) {

--- a/internal/configs/configurator_bench_test.go
+++ b/internal/configs/configurator_bench_test.go
@@ -1,0 +1,237 @@
+package configs
+
+import (
+	"testing"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/nginxinc/kubernetes-ingress/internal/configs/version1"
+	"github.com/nginxinc/kubernetes-ingress/internal/configs/version2"
+	"github.com/nginxinc/kubernetes-ingress/internal/nginx"
+	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
+)
+
+func createTestConfiguratorBench() (*Configurator, error) {
+	templateExecutor, err := version1.NewTemplateExecutor("version1/nginx-plus.tmpl", "version1/nginx-plus.ingress.tmpl")
+	if err != nil {
+		return nil, err
+	}
+
+	templateExecutorV2, err := version2.NewTemplateExecutor("version2/nginx-plus.virtualserver.tmpl", "version2/nginx-plus.transportserver.tmpl")
+	if err != nil {
+		return nil, err
+	}
+
+	manager := nginx.NewFakeManager("/etc/nginx")
+	cnf := NewConfigurator(ConfiguratorParams{
+		NginxManager:            manager,
+		StaticCfgParams:         createTestStaticConfigParams(),
+		Config:                  NewDefaultConfigParams(false),
+		TemplateExecutor:        templateExecutor,
+		TemplateExecutorV2:      templateExecutorV2,
+		LatencyCollector:        nil,
+		LabelUpdater:            nil,
+		IsPlus:                  false,
+		IsWildcardEnabled:       false,
+		IsPrometheusEnabled:     false,
+		IsLatencyMetricsEnabled: false,
+		NginxVersion:            nginx.NewVersion("nginx version: nginx/1.25.3 (nginx-plus-r31)"),
+	})
+	cnf.isReloadsEnabled = true
+	return cnf, nil
+}
+
+func BenchmarkAddOrUpdateIngress(b *testing.B) {
+	cnf, err := createTestConfiguratorBench()
+	if err != nil {
+		b.Fatal(err)
+	}
+	ingress := createCafeIngressEx()
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := cnf.AddOrUpdateIngress(&ingress)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAddOrUpdateMergeableIngress(b *testing.B) {
+	cnf, err := createTestConfiguratorBench()
+	if err != nil {
+		b.Fatal(err)
+	}
+	mergeableIngress := createMergeableCafeIngress()
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := cnf.AddOrUpdateMergeableIngress(mergeableIngress)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchUpdateEndpoints(b *testing.B) {
+	cnf, err := createTestConfiguratorBench()
+	if err != nil {
+		b.Fatal(err)
+	}
+	ingress := createCafeIngressEx()
+	ingresses := []*IngressEx{&ingress}
+
+	b.ResetTimer()
+	for range b.N {
+		err := cnf.UpdateEndpoints(ingresses)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+}
+
+func BenchmarkUpdateEndpointsMergeableIngress(b *testing.B) {
+	cnf, err := createTestConfiguratorBench()
+	if err != nil {
+		b.Fatal(err)
+	}
+	mergeableIngress := createMergeableCafeIngress()
+	mergeableIngresses := []*MergeableIngresses{mergeableIngress}
+
+	b.ResetTimer()
+	for range b.N {
+		err := cnf.UpdateEndpointsMergeableIngress(mergeableIngresses)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAddVirtualServerMetricsLabels(b *testing.B) {
+	cnf, err := createTestConfiguratorBench()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	cnf.isPlus = true
+	cnf.labelUpdater = newFakeLabelUpdater()
+	testLatencyCollector := newMockLatencyCollector()
+	cnf.latencyCollector = testLatencyCollector
+
+	vsEx := &VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "test-vs",
+				Namespace: "default",
+			},
+			Spec: conf_v1.VirtualServerSpec{
+				Host: "example.com",
+			},
+		},
+		PodsByIP: map[string]PodInfo{
+			"10.0.0.1:80": {Name: "pod-1"},
+			"10.0.0.2:80": {Name: "pod-2"},
+		},
+	}
+
+	upstreams := []version2.Upstream{
+		{
+			Name: "upstream-1",
+			Servers: []version2.UpstreamServer{
+				{
+					Address: "10.0.0.1:80",
+				},
+			},
+			UpstreamLabels: version2.UpstreamLabels{
+				Service:           "service-1",
+				ResourceType:      "virtualserver",
+				ResourceName:      vsEx.VirtualServer.Name,
+				ResourceNamespace: vsEx.VirtualServer.Namespace,
+			},
+		},
+		{
+			Name: "upstream-2",
+			Servers: []version2.UpstreamServer{
+				{
+					Address: "10.0.0.2:80",
+				},
+			},
+			UpstreamLabels: version2.UpstreamLabels{
+				Service:           "service-2",
+				ResourceType:      "virtualserver",
+				ResourceName:      vsEx.VirtualServer.Name,
+				ResourceNamespace: vsEx.VirtualServer.Namespace,
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		cnf.updateVirtualServerMetricsLabels(vsEx, upstreams)
+	}
+}
+
+func BenchmarkAddTransportServerMetricsLabels(b *testing.B) {
+	cnf, err := createTestConfiguratorBench()
+	if err != nil {
+		b.Fatal(err)
+	}
+	cnf.isPlus = true
+	cnf.labelUpdater = newFakeLabelUpdater()
+
+	tsEx := &TransportServerEx{
+		TransportServer: &conf_v1.TransportServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "test-transportserver",
+				Namespace: "default",
+			},
+			Spec: conf_v1.TransportServerSpec{
+				Listener: conf_v1.TransportServerListener{
+					Name:     "dns-tcp",
+					Protocol: "TCP",
+				},
+			},
+		},
+		PodsByIP: map[string]string{
+			"10.0.0.1:80": "pod-1",
+			"10.0.0.2:80": "pod-2",
+		},
+	}
+
+	streamUpstreams := []version2.StreamUpstream{
+		{
+			Name: "upstream-1",
+			Servers: []version2.StreamUpstreamServer{
+				{
+					Address: "10.0.0.1:80",
+				},
+			},
+			UpstreamLabels: version2.UpstreamLabels{
+				Service:           "service-1",
+				ResourceType:      "transportserver",
+				ResourceName:      tsEx.TransportServer.Name,
+				ResourceNamespace: tsEx.TransportServer.Namespace,
+			},
+		},
+		{
+			Name: "upstream-2",
+			Servers: []version2.StreamUpstreamServer{
+				{
+					Address: "10.0.0.2:80",
+				},
+			},
+			UpstreamLabels: version2.UpstreamLabels{
+				Service:           "service-2",
+				ResourceType:      "transportserver",
+				ResourceName:      tsEx.TransportServer.Name,
+				ResourceNamespace: tsEx.TransportServer.Namespace,
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		cnf.updateTransportServerMetricsLabels(tsEx, streamUpstreams)
+	}
+}


### PR DESCRIPTION
### Proposed changes

This PR adds initial benchmark tests for NIC `configurator`.

```shell
➜  kubernetes-ingress git:(test/configurator-benchmarks) ✗ go test -benchmem -run=^$  -bench . github.com/nginxinc/kubernetes-ingress/internal/configs
goos: darwin
goarch: arm64
pkg: github.com/nginxinc/kubernetes-ingress/internal/configs
cpu: Apple M1 Pro
BenchmarkAddOrUpdateIngress-10                 	   26958	     44135 ns/op	   18716 B/op	     321 allocs/op
BenchmarkAddOrUpdateMergeableIngress-10        	   22483	     53538 ns/op	   26157 B/op	     388 allocs/op
BenchmarkUpdateEndpointsMergeableIngress-10    	   22503	     53233 ns/op	   26157 B/op	     388 allocs/op
BenchmarkAddVirtualServerMetricsLabels-10      	  700798	      1665 ns/op	    1681 B/op	      25 allocs/op
BenchmarkAddTransportServerMetricsLabels-10    	  775048	      1530 ns/op	    1697 B/op	      25 allocs/op
PASS
ok  	github.com/nginxinc/kubernetes-ingress/internal/configs	8.394s
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
