### PR TITLE
Remove unnessary type assertion

### DIFF
--- a/internal/certmanager/test_files/reactors.go
+++ b/internal/certmanager/test_files/reactors.go
@@ -46,11 +46,7 @@ func ObjectCreatedReactor(t *testing.T, b *Builder, expectedObj runtime.Object) 
 		if !ok {
 			return
 		}
-		obj, ok := createAction.GetObject().(runtime.Object)
-		if !ok {
-			t.Errorf("object passed to Create does not implement runtime.Object")
-		}
-
+		obj := createAction.GetObject()
 		if !reflect.DeepEqual(obj, expectedObj) {
 			t.Errorf("expected %+v to equal %+v", obj, expectedObj)
 		}


### PR DESCRIPTION
### Proposed changes

Static check reported this unnessary type assertion, removed as its always a `runtime.Object`
```
internal/certmanager/test_files/reactors.go:49:14: type assertion to the same type: createAction.GetObject() already has type runtime.Object (S1040)
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
