### PR TITLE
add retry to version check in logs

### DIFF
--- a/tests/suite/test_build_info.py
+++ b/tests/suite/test_build_info.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import time
 
 import pytest
 import yaml
@@ -23,6 +24,7 @@ class TestBuildVersion:
         while "Version=" not in _info and count < 5:
             _info = self.send_build_info(kube_apis, ingress_controller_prerequisites)
             count += 1
+            time.sleep(1)
         _version = _info[_info.find("Version=") + len("Version=") : _info.rfind("Commit=")]
         logging.info(_version)
         print(f"Version from pod logs: {_version}")

--- a/tests/suite/test_build_info.py
+++ b/tests/suite/test_build_info.py
@@ -18,10 +18,14 @@ class TestBuildVersion:
             chart = yaml.safe_load(f)
             ic_ver = chart["appVersion"]
             print(f"NIC version from chart: {ic_ver}")
-
         _info = self.send_build_info(kube_apis, ingress_controller_prerequisites)
-        _version = _info[_info.find("Version=") + len("Version=") : _info.rfind("GitCommit=")]
+        count = 0
+        while "Version=" not in _info and count < 5:
+            _info = self.send_build_info(kube_apis, ingress_controller_prerequisites)
+            count += 1
+        _version = _info[_info.find("Version=") + len("Version=") : _info.rfind("Commit=")]
         logging.info(_version)
+        print(f"Version from pod logs: {_version}")
         assert _version != " "
         assert ic_ver in _version
 


### PR DESCRIPTION
### Proposed changes

- add retry to version check in logs

```
============================= TestBuildVersion :: test_build_version =============================
NIC version from chart: 3.7.0
Start waiting for all pods in a namespace to be Ready
Pod nginx-ingress-74f5644d56-qcvmc has image nginx/nginx-ingress:edge
All pods are Ready
Version and GitCommit info: Version=3.7.0 Commit=e222833af9a4e1c7d47b3745f713f27eeb17073b Date=2024-09-24T17:49:47Z DirtyState=false Arch=linux/amd64 Go=go1.23.1
Version from pod logs: 3.7.0 
PASSED
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
