### PR TITLE
refactor: replace glog in k8s package 1

### DIFF
--- a/internal/k8s/appprotect_dos.go
+++ b/internal/k8s/appprotect_dos.go
@@ -22,7 +22,7 @@ func createAppProtectDosPolicyHandlers(lbc *LoadBalancerController) cache.Resour
 		UpdateFunc: func(oldObj, obj interface{}) {
 			oldPol := oldObj.(*unstructured.Unstructured)
 			newPol := obj.(*unstructured.Unstructured)
-			different, err := areResourcesDifferent(oldPol, newPol)
+			different, err := areResourcesDifferent(lbc.logger, oldPol, newPol)
 			if err != nil {
 				nl.Debugf(lbc.logger, "Error when comparing policy %v", err)
 				lbc.AddSyncQueue(newPol)
@@ -49,7 +49,7 @@ func createAppProtectDosLogConfHandlers(lbc *LoadBalancerController) cache.Resou
 		UpdateFunc: func(oldObj, obj interface{}) {
 			oldConf := oldObj.(*unstructured.Unstructured)
 			newConf := obj.(*unstructured.Unstructured)
-			different, err := areResourcesDifferent(oldConf, newConf)
+			different, err := areResourcesDifferent(lbc.logger, oldConf, newConf)
 			if err != nil {
 				nl.Debugf(lbc.logger, "Error when comparing DosLogConfs %v", err)
 				lbc.AddSyncQueue(newConf)

--- a/internal/k8s/appprotect_dos.go
+++ b/internal/k8s/appprotect_dos.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/golang/glog"
 	"github.com/nginxinc/kubernetes-ingress/internal/k8s/appprotectdos"
+	nl "github.com/nginxinc/kubernetes-ingress/internal/logger"
 	"github.com/nginxinc/kubernetes-ingress/pkg/apis/dos/v1beta1"
 	api_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -16,7 +16,7 @@ func createAppProtectDosPolicyHandlers(lbc *LoadBalancerController) cache.Resour
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pol := obj.(*unstructured.Unstructured)
-			glog.V(3).Infof("Adding AppProtectDosPolicy: %v", pol.GetName())
+			nl.Debugf(lbc.logger, "Adding AppProtectDosPolicy: %v", pol.GetName())
 			lbc.AddSyncQueue(pol)
 		},
 		UpdateFunc: func(oldObj, obj interface{}) {
@@ -24,11 +24,11 @@ func createAppProtectDosPolicyHandlers(lbc *LoadBalancerController) cache.Resour
 			newPol := obj.(*unstructured.Unstructured)
 			different, err := areResourcesDifferent(oldPol, newPol)
 			if err != nil {
-				glog.V(3).Infof("Error when comparing policy %v", err)
+				nl.Debugf(lbc.logger, "Error when comparing policy %v", err)
 				lbc.AddSyncQueue(newPol)
 			}
 			if different {
-				glog.V(3).Infof("ApDosPolicy %v changed, syncing", oldPol.GetName())
+				nl.Debugf(lbc.logger, "ApDosPolicy %v changed, syncing", oldPol.GetName())
 				lbc.AddSyncQueue(newPol)
 			}
 		},
@@ -43,7 +43,7 @@ func createAppProtectDosLogConfHandlers(lbc *LoadBalancerController) cache.Resou
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			conf := obj.(*unstructured.Unstructured)
-			glog.V(3).Infof("Adding AppProtectDosLogConf: %v", conf.GetName())
+			nl.Debugf(lbc.logger, "Adding AppProtectDosLogConf: %v", conf.GetName())
 			lbc.AddSyncQueue(conf)
 		},
 		UpdateFunc: func(oldObj, obj interface{}) {
@@ -51,11 +51,11 @@ func createAppProtectDosLogConfHandlers(lbc *LoadBalancerController) cache.Resou
 			newConf := obj.(*unstructured.Unstructured)
 			different, err := areResourcesDifferent(oldConf, newConf)
 			if err != nil {
-				glog.V(3).Infof("Error when comparing DosLogConfs %v", err)
+				nl.Debugf(lbc.logger, "Error when comparing DosLogConfs %v", err)
 				lbc.AddSyncQueue(newConf)
 			}
 			if different {
-				glog.V(3).Infof("ApDosLogConf %v changed, syncing", oldConf.GetName())
+				nl.Debugf(lbc.logger, "ApDosLogConf %v changed, syncing", oldConf.GetName())
 				lbc.AddSyncQueue(newConf)
 			}
 		},
@@ -70,7 +70,7 @@ func createAppProtectDosProtectedResourceHandlers(lbc *LoadBalancerController) c
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			conf := obj.(*v1beta1.DosProtectedResource)
-			glog.V(3).Infof("Adding DosProtectedResource: %v", conf.GetName())
+			nl.Debugf(lbc.logger, "Adding DosProtectedResource: %v", conf.GetName())
 			lbc.AddSyncQueue(conf)
 		},
 		UpdateFunc: func(oldObj, obj interface{}) {
@@ -78,7 +78,7 @@ func createAppProtectDosProtectedResourceHandlers(lbc *LoadBalancerController) c
 			newConf := obj.(*v1beta1.DosProtectedResource)
 
 			if !reflect.DeepEqual(oldConf.Spec, newConf.Spec) {
-				glog.V(3).Infof("DosProtectedResource %v changed, syncing", oldConf.GetName())
+				nl.Debugf(lbc.logger, "DosProtectedResource %v changed, syncing", oldConf.GetName())
 				lbc.AddSyncQueue(newConf)
 			}
 		},
@@ -118,7 +118,7 @@ func (nsi *namespacedInformer) addAppProtectDosProtectedResourceHandler(handlers
 
 func (lbc *LoadBalancerController) syncAppProtectDosPolicy(task task) {
 	key := task.Key
-	glog.V(3).Infof("Syncing AppProtectDosPolicy %v", key)
+	nl.Debugf(lbc.logger, "Syncing AppProtectDosPolicy %v", key)
 	var obj interface{}
 	var polExists bool
 	var err error
@@ -134,10 +134,10 @@ func (lbc *LoadBalancerController) syncAppProtectDosPolicy(task task) {
 	var problems []appprotectdos.Problem
 
 	if !polExists {
-		glog.V(2).Infof("Deleting APDosPolicy: %v\n", key)
+		nl.Debugf(lbc.logger, "Deleting APDosPolicy: %v\n", key)
 		changes, problems = lbc.dosConfiguration.DeletePolicy(key)
 	} else {
-		glog.V(2).Infof("Adding or Updating APDosPolicy: %v\n", key)
+		nl.Debugf(lbc.logger, "Adding or Updating APDosPolicy: %v\n", key)
 		changes, problems = lbc.dosConfiguration.AddOrUpdatePolicy(obj.(*unstructured.Unstructured))
 	}
 
@@ -147,7 +147,7 @@ func (lbc *LoadBalancerController) syncAppProtectDosPolicy(task task) {
 
 func (lbc *LoadBalancerController) syncAppProtectDosLogConf(task task) {
 	key := task.Key
-	glog.V(3).Infof("Syncing APDosLogConf %v", key)
+	nl.Debugf(lbc.logger, "Syncing APDosLogConf %v", key)
 	var obj interface{}
 	var confExists bool
 	var err error
@@ -163,10 +163,10 @@ func (lbc *LoadBalancerController) syncAppProtectDosLogConf(task task) {
 	var problems []appprotectdos.Problem
 
 	if !confExists {
-		glog.V(2).Infof("Deleting APDosLogConf: %v\n", key)
+		nl.Debugf(lbc.logger, "Deleting APDosLogConf: %v\n", key)
 		changes, problems = lbc.dosConfiguration.DeleteLogConf(key)
 	} else {
-		glog.V(2).Infof("Adding or Updating APDosLogConf: %v\n", key)
+		nl.Debugf(lbc.logger, "Adding or Updating APDosLogConf: %v\n", key)
 		changes, problems = lbc.dosConfiguration.AddOrUpdateLogConf(obj.(*unstructured.Unstructured))
 	}
 
@@ -176,7 +176,7 @@ func (lbc *LoadBalancerController) syncAppProtectDosLogConf(task task) {
 
 func (lbc *LoadBalancerController) syncDosProtectedResource(task task) {
 	key := task.Key
-	glog.V(3).Infof("Syncing DosProtectedResource %v", key)
+	nl.Debugf(lbc.logger, "Syncing DosProtectedResource %v", key)
 	var obj interface{}
 	var confExists bool
 	var err error
@@ -192,10 +192,10 @@ func (lbc *LoadBalancerController) syncDosProtectedResource(task task) {
 	var problems []appprotectdos.Problem
 
 	if confExists {
-		glog.V(2).Infof("Adding or Updating DosProtectedResource: %v\n", key)
+		nl.Debugf(lbc.logger, "Adding or Updating DosProtectedResource: %v\n", key)
 		changes, problems = lbc.dosConfiguration.AddOrUpdateDosProtectedResource(obj.(*v1beta1.DosProtectedResource))
 	} else {
-		glog.V(2).Infof("Deleting DosProtectedResource: %v\n", key)
+		nl.Debugf(lbc.logger, "Deleting DosProtectedResource: %v\n", key)
 		changes, problems = lbc.dosConfiguration.DeleteProtectedResource(key)
 	}
 
@@ -204,13 +204,13 @@ func (lbc *LoadBalancerController) syncDosProtectedResource(task task) {
 }
 
 func (lbc *LoadBalancerController) processAppProtectDosChanges(changes []appprotectdos.Change) {
-	glog.V(3).Infof("Processing %v App Protect Dos changes", len(changes))
+	nl.Debugf(lbc.logger, "Processing %v App Protect Dos changes", len(changes))
 
 	for _, c := range changes {
 		if c.Op == appprotectdos.AddOrUpdate {
 			switch impl := c.Resource.(type) {
 			case *appprotectdos.DosProtectedResourceEx:
-				glog.V(3).Infof("handling change UPDATE OR ADD for DOS protected %s/%s", impl.Obj.Namespace, impl.Obj.Name)
+				nl.Debugf(lbc.logger, "handling change UPDATE OR ADD for DOS protected %s/%s", impl.Obj.Namespace, impl.Obj.Name)
 				resources := lbc.configuration.FindResourcesForAppProtectDosProtected(impl.Obj.Namespace, impl.Obj.Name)
 				resourceExes := lbc.createExtendedResources(resources)
 				warnings, err := lbc.configurator.AddOrUpdateResourcesThatUseDosProtected(resourceExes.IngressExes, resourceExes.MergeableIngresses, resourceExes.VirtualServerExes)
@@ -240,7 +240,7 @@ func (lbc *LoadBalancerController) processAppProtectDosChanges(changes []appprot
 				lbc.configurator.DeleteAppProtectDosLogConf(impl.Obj)
 
 			case *appprotectdos.DosProtectedResourceEx:
-				glog.V(3).Infof("handling change DELETE for DOS protected %s/%s", impl.Obj.Namespace, impl.Obj.Name)
+				nl.Debugf(lbc.logger, "handling change DELETE for DOS protected %s/%s", impl.Obj.Namespace, impl.Obj.Name)
 				resources := lbc.configuration.FindResourcesForAppProtectDosProtected(impl.Obj.Namespace, impl.Obj.Name)
 				resourceExes := lbc.createExtendedResources(resources)
 				warnings, err := lbc.configurator.AddOrUpdateResourcesThatUseDosProtected(resourceExes.IngressExes, resourceExes.MergeableIngresses, resourceExes.VirtualServerExes)
@@ -251,7 +251,7 @@ func (lbc *LoadBalancerController) processAppProtectDosChanges(changes []appprot
 }
 
 func (lbc *LoadBalancerController) processAppProtectDosProblems(problems []appprotectdos.Problem) {
-	glog.V(3).Infof("Processing %v App Protect Dos problems", len(problems))
+	nl.Debugf(lbc.logger, "Processing %v App Protect Dos problems", len(problems))
 
 	for _, p := range problems {
 		eventType := api_v1.EventTypeWarning

--- a/internal/k8s/appprotect_waf.go
+++ b/internal/k8s/appprotect_waf.go
@@ -25,7 +25,7 @@ func createAppProtectPolicyHandlers(lbc *LoadBalancerController) cache.ResourceE
 		UpdateFunc: func(oldObj, obj interface{}) {
 			oldPol := oldObj.(*unstructured.Unstructured)
 			newPol := obj.(*unstructured.Unstructured)
-			different, err := areResourcesDifferent(oldPol, newPol)
+			different, err := areResourcesDifferent(lbc.logger, oldPol, newPol)
 			if err != nil {
 				nl.Debugf(lbc.logger, "Error when comparing policy %v", err)
 				lbc.AddSyncQueue(newPol)
@@ -52,7 +52,7 @@ func createAppProtectLogConfHandlers(lbc *LoadBalancerController) cache.Resource
 		UpdateFunc: func(oldObj, obj interface{}) {
 			oldConf := oldObj.(*unstructured.Unstructured)
 			newConf := obj.(*unstructured.Unstructured)
-			different, err := areResourcesDifferent(oldConf, newConf)
+			different, err := areResourcesDifferent(lbc.logger, oldConf, newConf)
 			if err != nil {
 				nl.Debugf(lbc.logger, "Error when comparing LogConfs %v", err)
 				lbc.AddSyncQueue(newConf)
@@ -79,7 +79,7 @@ func createAppProtectUserSigHandlers(lbc *LoadBalancerController) cache.Resource
 		UpdateFunc: func(oldObj, obj interface{}) {
 			oldSig := oldObj.(*unstructured.Unstructured)
 			newSig := obj.(*unstructured.Unstructured)
-			different, err := areResourcesDifferent(oldSig, newSig)
+			different, err := areResourcesDifferent(lbc.logger, oldSig, newSig)
 			if err != nil {
 				nl.Debugf(lbc.logger, "Error when comparing UserSigs %v", err)
 				lbc.AddSyncQueue(newSig)

--- a/internal/k8s/appprotect_waf.go
+++ b/internal/k8s/appprotect_waf.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/nginxinc/kubernetes-ingress/internal/configs"
 	"github.com/nginxinc/kubernetes-ingress/internal/k8s/appprotect"
 	"github.com/nginxinc/kubernetes-ingress/internal/k8s/appprotectcommon"
+	nl "github.com/nginxinc/kubernetes-ingress/internal/logger"
 	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
 	api_v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
@@ -19,7 +19,7 @@ func createAppProtectPolicyHandlers(lbc *LoadBalancerController) cache.ResourceE
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pol := obj.(*unstructured.Unstructured)
-			glog.V(3).Infof("Adding AppProtectPolicy: %v", pol.GetName())
+			nl.Debugf(lbc.logger, "Adding AppProtectPolicy: %v", pol.GetName())
 			lbc.AddSyncQueue(pol)
 		},
 		UpdateFunc: func(oldObj, obj interface{}) {
@@ -27,11 +27,11 @@ func createAppProtectPolicyHandlers(lbc *LoadBalancerController) cache.ResourceE
 			newPol := obj.(*unstructured.Unstructured)
 			different, err := areResourcesDifferent(oldPol, newPol)
 			if err != nil {
-				glog.V(3).Infof("Error when comparing policy %v", err)
+				nl.Debugf(lbc.logger, "Error when comparing policy %v", err)
 				lbc.AddSyncQueue(newPol)
 			}
 			if different {
-				glog.V(3).Infof("ApPolicy %v changed, syncing", oldPol.GetName())
+				nl.Debugf(lbc.logger, "ApPolicy %v changed, syncing", oldPol.GetName())
 				lbc.AddSyncQueue(newPol)
 			}
 		},
@@ -46,7 +46,7 @@ func createAppProtectLogConfHandlers(lbc *LoadBalancerController) cache.Resource
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			conf := obj.(*unstructured.Unstructured)
-			glog.V(3).Infof("Adding AppProtectLogConf: %v", conf.GetName())
+			nl.Debugf(lbc.logger, "Adding AppProtectLogConf: %v", conf.GetName())
 			lbc.AddSyncQueue(conf)
 		},
 		UpdateFunc: func(oldObj, obj interface{}) {
@@ -54,11 +54,11 @@ func createAppProtectLogConfHandlers(lbc *LoadBalancerController) cache.Resource
 			newConf := obj.(*unstructured.Unstructured)
 			different, err := areResourcesDifferent(oldConf, newConf)
 			if err != nil {
-				glog.V(3).Infof("Error when comparing LogConfs %v", err)
+				nl.Debugf(lbc.logger, "Error when comparing LogConfs %v", err)
 				lbc.AddSyncQueue(newConf)
 			}
 			if different {
-				glog.V(3).Infof("ApLogConf %v changed, syncing", oldConf.GetName())
+				nl.Debugf(lbc.logger, "ApLogConf %v changed, syncing", oldConf.GetName())
 				lbc.AddSyncQueue(newConf)
 			}
 		},
@@ -73,7 +73,7 @@ func createAppProtectUserSigHandlers(lbc *LoadBalancerController) cache.Resource
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sig := obj.(*unstructured.Unstructured)
-			glog.V(3).Infof("Adding AppProtectUserSig: %v", sig.GetName())
+			nl.Debugf(lbc.logger, "Adding AppProtectUserSig: %v", sig.GetName())
 			lbc.AddSyncQueue(sig)
 		},
 		UpdateFunc: func(oldObj, obj interface{}) {
@@ -81,11 +81,11 @@ func createAppProtectUserSigHandlers(lbc *LoadBalancerController) cache.Resource
 			newSig := obj.(*unstructured.Unstructured)
 			different, err := areResourcesDifferent(oldSig, newSig)
 			if err != nil {
-				glog.V(3).Infof("Error when comparing UserSigs %v", err)
+				nl.Debugf(lbc.logger, "Error when comparing UserSigs %v", err)
 				lbc.AddSyncQueue(newSig)
 			}
 			if different {
-				glog.V(3).Infof("ApUserSig %v changed, syncing", oldSig.GetName())
+				nl.Debugf(lbc.logger, "ApUserSig %v changed, syncing", oldSig.GetName())
 				lbc.AddSyncQueue(newSig)
 			}
 		},
@@ -125,7 +125,7 @@ func (nsi *namespacedInformer) addAppProtectUserSigHandler(handlers cache.Resour
 
 func (lbc *LoadBalancerController) syncAppProtectPolicy(task task) {
 	key := task.Key
-	glog.V(3).Infof("Syncing AppProtectPolicy %v", key)
+	nl.Debugf(lbc.logger, "Syncing AppProtectPolicy %v", key)
 
 	var obj interface{}
 	var polExists bool
@@ -142,11 +142,11 @@ func (lbc *LoadBalancerController) syncAppProtectPolicy(task task) {
 	var problems []appprotect.Problem
 
 	if !polExists {
-		glog.V(2).Infof("Deleting AppProtectPolicy: %v\n", key)
+		nl.Debugf(lbc.logger, "Deleting AppProtectPolicy: %v\n", key)
 
 		changes, problems = lbc.appProtectConfiguration.DeletePolicy(key)
 	} else {
-		glog.V(2).Infof("Adding or Updating AppProtectPolicy: %v\n", key)
+		nl.Debugf(lbc.logger, "Adding or Updating AppProtectPolicy: %v\n", key)
 
 		changes, problems = lbc.appProtectConfiguration.AddOrUpdatePolicy(obj.(*unstructured.Unstructured))
 	}
@@ -157,7 +157,7 @@ func (lbc *LoadBalancerController) syncAppProtectPolicy(task task) {
 
 func (lbc *LoadBalancerController) syncAppProtectLogConf(task task) {
 	key := task.Key
-	glog.V(3).Infof("Syncing AppProtectLogConf %v", key)
+	nl.Debugf(lbc.logger, "Syncing AppProtectLogConf %v", key)
 	var obj interface{}
 	var confExists bool
 	var err error
@@ -173,11 +173,11 @@ func (lbc *LoadBalancerController) syncAppProtectLogConf(task task) {
 	var problems []appprotect.Problem
 
 	if !confExists {
-		glog.V(2).Infof("Deleting AppProtectLogConf: %v\n", key)
+		nl.Debugf(lbc.logger, "Deleting AppProtectLogConf: %v\n", key)
 
 		changes, problems = lbc.appProtectConfiguration.DeleteLogConf(key)
 	} else {
-		glog.V(2).Infof("Adding or Updating AppProtectLogConf: %v\n", key)
+		nl.Debugf(lbc.logger, "Adding or Updating AppProtectLogConf: %v\n", key)
 
 		changes, problems = lbc.appProtectConfiguration.AddOrUpdateLogConf(obj.(*unstructured.Unstructured))
 	}
@@ -188,7 +188,7 @@ func (lbc *LoadBalancerController) syncAppProtectLogConf(task task) {
 
 func (lbc *LoadBalancerController) syncAppProtectUserSig(task task) {
 	key := task.Key
-	glog.V(3).Infof("Syncing AppProtectUserSig %v", key)
+	nl.Debugf(lbc.logger, "Syncing AppProtectUserSig %v", key)
 	var obj interface{}
 	var sigExists bool
 	var err error
@@ -204,11 +204,11 @@ func (lbc *LoadBalancerController) syncAppProtectUserSig(task task) {
 	var problems []appprotect.Problem
 
 	if !sigExists {
-		glog.V(2).Infof("Deleting AppProtectUserSig: %v\n", key)
+		nl.Debugf(lbc.logger, "Deleting AppProtectUserSig: %v\n", key)
 
 		change, problems = lbc.appProtectConfiguration.DeleteUserSig(key)
 	} else {
-		glog.V(2).Infof("Adding or Updating AppProtectUserSig: %v\n", key)
+		nl.Debugf(lbc.logger, "Adding or Updating AppProtectUserSig: %v\n", key)
 
 		change, problems = lbc.appProtectConfiguration.AddOrUpdateUserSig(obj.(*unstructured.Unstructured))
 	}
@@ -353,7 +353,7 @@ func (lbc *LoadBalancerController) getAppProtectPolicy(ing *networking.Ingress) 
 }
 
 func (lbc *LoadBalancerController) processAppProtectChanges(changes []appprotect.Change) {
-	glog.V(3).Infof("Processing %v App Protect changes", len(changes))
+	nl.Debugf(lbc.logger, "Processing %v App Protect changes", len(changes))
 
 	for _, c := range changes {
 		if c.Op == appprotect.AddOrUpdate {
@@ -463,13 +463,13 @@ func (lbc *LoadBalancerController) processAppProtectUserSigChange(change appprot
 
 	warnings, err := lbc.configurator.RefreshAppProtectUserSigs(change.UserSigs, delPols, allIngExes, allMergeableIngresses, allVsExes)
 	if err != nil {
-		glog.Errorf("Error when refreshing App Protect Policy User defined signatures: %v", err)
+		nl.Errorf(lbc.logger, "Error when refreshing App Protect Policy User defined signatures: %v", err)
 	}
 	lbc.updateResourcesStatusAndEvents(allResources, warnings, err)
 }
 
 func (lbc *LoadBalancerController) processAppProtectProblems(problems []appprotect.Problem) {
-	glog.V(3).Infof("Processing %v App Protect problems", len(problems))
+	nl.Debugf(lbc.logger, "Processing %v App Protect problems", len(problems))
 
 	for _, p := range problems {
 		eventType := api_v1.EventTypeWarning
@@ -479,7 +479,7 @@ func (lbc *LoadBalancerController) processAppProtectProblems(problems []appprote
 
 func (lbc *LoadBalancerController) cleanupUnwatchedAppWafResources(nsi *namespacedInformer) {
 	for _, obj := range nsi.appProtectPolicyLister.List() {
-		glog.V(3).Infof("Cleaning up unwatched appprotect policies in namespace: %v", nsi.namespace)
+		nl.Debugf(lbc.logger, "Cleaning up unwatched appprotect policies in namespace: %v", nsi.namespace)
 		appPol := obj.((*unstructured.Unstructured))
 		namespace := appPol.GetNamespace()
 		name := appPol.GetName()
@@ -489,7 +489,7 @@ func (lbc *LoadBalancerController) cleanupUnwatchedAppWafResources(nsi *namespac
 		lbc.processAppProtectProblems(problems)
 	}
 	for _, obj := range nsi.appProtectLogConfLister.List() {
-		glog.V(3).Infof("Cleaning up unwatched approtect logconfs in namespace: %v", nsi.namespace)
+		nl.Debugf(lbc.logger, "Cleaning up unwatched approtect logconfs in namespace: %v", nsi.namespace)
 		appLogConf := obj.((*unstructured.Unstructured))
 		namespace := appLogConf.GetNamespace()
 		name := appLogConf.GetName()
@@ -499,7 +499,7 @@ func (lbc *LoadBalancerController) cleanupUnwatchedAppWafResources(nsi *namespac
 		lbc.processAppProtectProblems(problems)
 	}
 	for _, obj := range nsi.appProtectUserSigLister.List() {
-		glog.V(3).Infof("Cleaning up unwatched usersigs in namespace: %v", nsi.namespace)
+		nl.Debugf(lbc.logger, "Cleaning up unwatched usersigs in namespace: %v", nsi.namespace)
 		appUserSig := obj.((*unstructured.Unstructured))
 		namespace := appUserSig.GetNamespace()
 		name := appUserSig.GetName()

--- a/internal/k8s/endpoint_slice.go
+++ b/internal/k8s/endpoint_slice.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"reflect"
 
-	"github.com/golang/glog"
+	nl "github.com/nginxinc/kubernetes-ingress/internal/logger"
 	discovery_v1 "k8s.io/api/discovery/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -13,7 +13,7 @@ func createEndpointSliceHandlers(lbc *LoadBalancerController) cache.ResourceEven
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			endpointSlice := obj.(*discovery_v1.EndpointSlice)
-			glog.V(3).Infof("Adding EndpointSlice: %v", endpointSlice.Name)
+			nl.Debugf(lbc.logger, "Adding EndpointSlice: %v", endpointSlice.Name)
 			lbc.AddSyncQueue(obj)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -21,20 +21,20 @@ func createEndpointSliceHandlers(lbc *LoadBalancerController) cache.ResourceEven
 			if !isEndpointSlice {
 				deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					glog.V(3).Infof("Error received unexpected object: %v", obj)
+					nl.Debugf(lbc.logger, "Error received unexpected object: %v", obj)
 					return
 				}
 				endpointSlice, ok = deletedState.Obj.(*discovery_v1.EndpointSlice)
 				if !ok {
-					glog.V(3).Infof("Error DeletedFinalStateUnknown contained non-EndpointSlice object: %v", deletedState.Obj)
+					nl.Debugf(lbc.logger, "Error DeletedFinalStateUnknown contained non-EndpointSlice object: %v", deletedState.Obj)
 					return
 				}
 			}
-			glog.V(3).Infof("Removing EndpointSlice: %v", endpointSlice.Name)
+			nl.Debugf(lbc.logger, "Removing EndpointSlice: %v", endpointSlice.Name)
 			lbc.AddSyncQueue(obj)
 		}, UpdateFunc: func(old, cur interface{}) {
 			if !reflect.DeepEqual(old, cur) {
-				glog.V(3).Infof("EndpointSlice %v changed, syncing", cur.(*discovery_v1.EndpointSlice).Name)
+				nl.Debugf(lbc.logger, "EndpointSlice %v changed, syncing", cur.(*discovery_v1.EndpointSlice).Name)
 				lbc.AddSyncQueue(cur)
 			}
 		},
@@ -86,10 +86,10 @@ func (lbc *LoadBalancerController) syncEndpointSlices(task task) bool {
 		for _, ingEx := range resourceExes.IngressExes {
 			if lbc.ingressRequiresEndpointsUpdate(ingEx, svcName) {
 				resourcesFound = true
-				glog.V(3).Infof("Updating EndpointSlices for %v", resourceExes.IngressExes)
+				nl.Debugf(lbc.logger, "Updating EndpointSlices for %v", resourceExes.IngressExes)
 				err = lbc.configurator.UpdateEndpoints(resourceExes.IngressExes)
 				if err != nil {
-					glog.Errorf("Error updating EndpointSlices for %v: %v", resourceExes.IngressExes, err)
+					nl.Errorf(lbc.logger, "Error updating EndpointSlices for %v: %v", resourceExes.IngressExes, err)
 				}
 				break
 			}
@@ -100,10 +100,10 @@ func (lbc *LoadBalancerController) syncEndpointSlices(task task) bool {
 		for _, mergeableIngresses := range resourceExes.MergeableIngresses {
 			if lbc.mergeableIngressRequiresEndpointsUpdate(mergeableIngresses, svcName) {
 				resourcesFound = true
-				glog.V(3).Infof("Updating EndpointSlices for %v", resourceExes.MergeableIngresses)
+				nl.Debugf(lbc.logger, "Updating EndpointSlices for %v", resourceExes.MergeableIngresses)
 				err = lbc.configurator.UpdateEndpointsMergeableIngress(resourceExes.MergeableIngresses)
 				if err != nil {
-					glog.Errorf("Error updating EndpointSlices for %v: %v", resourceExes.MergeableIngresses, err)
+					nl.Errorf(lbc.logger, "Error updating EndpointSlices for %v: %v", resourceExes.MergeableIngresses, err)
 				}
 				break
 			}
@@ -115,10 +115,10 @@ func (lbc *LoadBalancerController) syncEndpointSlices(task task) bool {
 			for _, vsEx := range resourceExes.VirtualServerExes {
 				if lbc.virtualServerRequiresEndpointsUpdate(vsEx, svcName) {
 					resourcesFound = true
-					glog.V(3).Infof("Updating EndpointSlices for %v", resourceExes.VirtualServerExes)
+					nl.Debugf(lbc.logger, "Updating EndpointSlices for %v", resourceExes.VirtualServerExes)
 					err := lbc.configurator.UpdateEndpointsForVirtualServers(resourceExes.VirtualServerExes)
 					if err != nil {
-						glog.Errorf("Error updating EndpointSlices for %v: %v", resourceExes.VirtualServerExes, err)
+						nl.Errorf(lbc.logger, "Error updating EndpointSlices for %v: %v", resourceExes.VirtualServerExes, err)
 					}
 					break
 				}
@@ -127,10 +127,10 @@ func (lbc *LoadBalancerController) syncEndpointSlices(task task) bool {
 
 		if len(resourceExes.TransportServerExes) > 0 {
 			resourcesFound = true
-			glog.V(3).Infof("Updating EndpointSlices for %v", resourceExes.TransportServerExes)
+			nl.Debugf(lbc.logger, "Updating EndpointSlices for %v", resourceExes.TransportServerExes)
 			err := lbc.configurator.UpdateEndpointsForTransportServers(resourceExes.TransportServerExes)
 			if err != nil {
-				glog.Errorf("Error updating EndpointSlices for %v: %v", resourceExes.TransportServerExes, err)
+				nl.Errorf(lbc.logger, "Error updating EndpointSlices for %v: %v", resourceExes.TransportServerExes, err)
 			}
 		}
 	}

--- a/internal/k8s/handlers_test.go
+++ b/internal/k8s/handlers_test.go
@@ -2,8 +2,13 @@ package k8s
 
 import (
 	"errors"
+	"log/slog"
+	"os"
+	"syscall"
 	"testing"
 
+	nic_glog "github.com/nginxinc/kubernetes-ingress/internal/logger/glog"
+	"github.com/nginxinc/kubernetes-ingress/internal/logger/levels"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -113,8 +118,9 @@ func TestAreResourcesDifferent(t *testing.T) {
 		},
 	}
 
+	l := slog.New(nic_glog.New(os.NewFile(uintptr(syscall.Stdout), os.DevNull), &nic_glog.Options{Level: levels.LevelInfo}))
 	for _, test := range tests {
-		result, err := areResourcesDifferent(test.oldR, test.newR)
+		result, err := areResourcesDifferent(l, test.oldR, test.newR)
 		if result != test.expected {
 			t.Errorf("areResourcesDifferent() returned %v but expected %v for the case of %s", result, test.expected, test.msg)
 		}

--- a/internal/k8s/handlers_test.go
+++ b/internal/k8s/handlers_test.go
@@ -2,9 +2,8 @@ package k8s
 
 import (
 	"errors"
+	"io"
 	"log/slog"
-	"os"
-	"syscall"
 	"testing"
 
 	nic_glog "github.com/nginxinc/kubernetes-ingress/internal/logger/glog"
@@ -118,7 +117,7 @@ func TestAreResourcesDifferent(t *testing.T) {
 		},
 	}
 
-	l := slog.New(nic_glog.New(os.NewFile(uintptr(syscall.Stdout), os.DevNull), &nic_glog.Options{Level: levels.LevelInfo}))
+	l := slog.New(nic_glog.New(io.Discard, &nic_glog.Options{Level: levels.LevelInfo}))
 	for _, test := range tests {
 		result, err := areResourcesDifferent(l, test.oldR, test.newR)
 		if result != test.expected {

--- a/internal/k8s/ingress_link.go
+++ b/internal/k8s/ingress_link.go
@@ -38,7 +38,7 @@ func createIngressLinkHandlers(lbc *LoadBalancerController) cache.ResourceEventH
 		UpdateFunc: func(old, cur interface{}) {
 			oldLink := old.(*unstructured.Unstructured)
 			curLink := cur.(*unstructured.Unstructured)
-			different, err := areResourcesDifferent(oldLink, curLink)
+			different, err := areResourcesDifferent(lbc.logger, oldLink, curLink)
 			if err != nil {
 				nl.Debugf(lbc.logger, "Error when comparing IngressLinks: %v", err)
 				lbc.AddSyncQueue(curLink)

--- a/internal/k8s/ingress_link.go
+++ b/internal/k8s/ingress_link.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"github.com/golang/glog"
+	nl "github.com/nginxinc/kubernetes-ingress/internal/logger"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -13,7 +13,7 @@ func createIngressLinkHandlers(lbc *LoadBalancerController) cache.ResourceEventH
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			link := obj.(*unstructured.Unstructured)
-			glog.V(3).Infof("Adding IngressLink: %v", link.GetName())
+			nl.Debugf(lbc.logger, "Adding IngressLink: %v", link.GetName())
 			lbc.AddSyncQueue(link)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -22,17 +22,17 @@ func createIngressLinkHandlers(lbc *LoadBalancerController) cache.ResourceEventH
 			if !isUnstructured {
 				deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					glog.V(3).Infof("Error received unexpected object: %v", obj)
+					nl.Debugf(lbc.logger, "Error received unexpected object: %v", obj)
 					return
 				}
 				link, ok = deletedState.Obj.(*unstructured.Unstructured)
 				if !ok {
-					glog.V(3).Infof("Error DeletedFinalStateUnknown contained non-Unstructured object: %v", deletedState.Obj)
+					nl.Debugf(lbc.logger, "Error DeletedFinalStateUnknown contained non-Unstructured object: %v", deletedState.Obj)
 					return
 				}
 			}
 
-			glog.V(3).Infof("Removing IngressLink: %v", link.GetName())
+			nl.Debugf(lbc.logger, "Removing IngressLink: %v", link.GetName())
 			lbc.AddSyncQueue(link)
 		},
 		UpdateFunc: func(old, cur interface{}) {
@@ -40,11 +40,11 @@ func createIngressLinkHandlers(lbc *LoadBalancerController) cache.ResourceEventH
 			curLink := cur.(*unstructured.Unstructured)
 			different, err := areResourcesDifferent(oldLink, curLink)
 			if err != nil {
-				glog.V(3).Infof("Error when comparing IngressLinks: %v", err)
+				nl.Debugf(lbc.logger, "Error when comparing IngressLinks: %v", err)
 				lbc.AddSyncQueue(curLink)
 			}
 			if different {
-				glog.V(3).Infof("IngressLink %v changed, syncing", oldLink.GetName())
+				nl.Debugf(lbc.logger, "IngressLink %v changed, syncing", oldLink.GetName())
 				lbc.AddSyncQueue(curLink)
 			}
 		},
@@ -69,7 +69,7 @@ func (lbc *LoadBalancerController) addIngressLinkHandler(handlers cache.Resource
 
 func (lbc *LoadBalancerController) syncIngressLink(task task) {
 	key := task.Key
-	glog.V(2).Infof("Adding, Updating or Deleting IngressLink: %v", key)
+	nl.Debugf(lbc.logger, "Adding, Updating or Deleting IngressLink: %v", key)
 
 	obj, exists, err := lbc.ingressLinkLister.GetByKey(key)
 	if err != nil {
@@ -87,13 +87,13 @@ func (lbc *LoadBalancerController) syncIngressLink(task task) {
 		// spec.virtualServerAddress contains the IP of the BIG-IP device
 		ip, found, err := unstructured.NestedString(link.Object, "spec", "virtualServerAddress")
 		if err != nil {
-			glog.Errorf("Failed to get virtualServerAddress from IngressLink %s: %v", key, err)
+			nl.Errorf(lbc.logger, "Failed to get virtualServerAddress from IngressLink %s: %v", key, err)
 			lbc.statusUpdater.ClearStatusFromIngressLink()
 		} else if !found {
-			glog.Errorf("virtualServerAddress is not found in IngressLink %s", key)
+			nl.Errorf(lbc.logger, "virtualServerAddress is not found in IngressLink %s", key)
 			lbc.statusUpdater.ClearStatusFromIngressLink()
 		} else if ip == "" {
-			glog.Warningf("IngressLink %s has the empty virtualServerAddress field", key)
+			nl.Warnf(lbc.logger, "IngressLink %s has the empty virtualServerAddress field", key)
 			lbc.statusUpdater.ClearStatusFromIngressLink()
 		} else {
 			lbc.statusUpdater.SaveStatusFromIngressLink(ip)
@@ -103,22 +103,22 @@ func (lbc *LoadBalancerController) syncIngressLink(task task) {
 	if lbc.reportStatusEnabled() {
 		ingresses := lbc.configuration.GetResourcesWithFilter(resourceFilter{Ingresses: true})
 
-		glog.V(3).Infof("Updating status for %v Ingresses", len(ingresses))
+		nl.Debugf(lbc.logger, "Updating status for %v Ingresses", len(ingresses))
 
 		err := lbc.statusUpdater.UpdateExternalEndpointsForResources(ingresses)
 		if err != nil {
-			glog.Errorf("Error updating ingress status in syncIngressLink: %v", err)
+			nl.Errorf(lbc.logger, "Error updating ingress status in syncIngressLink: %v", err)
 		}
 	}
 
 	if lbc.areCustomResourcesEnabled && lbc.reportCustomResourceStatusEnabled() {
 		virtualServers := lbc.configuration.GetResourcesWithFilter(resourceFilter{VirtualServers: true})
 
-		glog.V(3).Infof("Updating status for %v VirtualServers", len(virtualServers))
+		nl.Debugf(lbc.logger, "Updating status for %v VirtualServers", len(virtualServers))
 
 		err := lbc.statusUpdater.UpdateExternalEndpointsForResources(virtualServers)
 		if err != nil {
-			glog.V(3).Infof("Error updating VirtualServer/VirtualServerRoute status in syncIngressLink: %v", err)
+			nl.Debugf(lbc.logger, "Error updating VirtualServer/VirtualServerRoute status in syncIngressLink: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
### Proposed changes

Replace `glog` with `slog` in k8s package for:
- appprotect_dos.go
- appprotect_waf.go
- configmap.go
- endpoint_slice.go
- ingress_link.go
- leader.go
- handlers.go

NOTE:


| GLog Levels | Slog Levels |
|-|-|
| glog.V(3).Infof() | log.Debugf() |
| glog.V(3).Info() | log.Debug() |
| glog.V(2).Infof() | log.Debugf() |
| glog.V(2).Info() | log.Debugf() |
| glog.Infof() | log.Infof() |
| glog.Info() | log.Info() 
| glog.Warningf() | log.Warnf() |
| glog.Warning() | log.Warn() |
| glog.Errorf() | log.Errorf() |
| glog.Error() | log.Error() |
| glog.Fatalf() | log.Fatalf() |
| glog.Fatal() | log.Fatal() |

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
