### PR TITLE
Generate valid yaml for readOnly fs

### DIFF
--- a/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/nginx-ingress/templates/_helpers.tpl
@@ -333,7 +333,7 @@ List of volumes for controller.
   emptyDir: {}
 {{- end }}
 {{- if .Values.controller.appprotect.v5 }}
-{{- toYaml .Values.controller.appprotect.volumes }}
+{{ toYaml .Values.controller.appprotect.volumes }}
 {{- end }}
 {{- if .Values.controller.volumes }}
 {{ toYaml .Values.controller.volumes }}


### PR DESCRIPTION
Co-authored-by: Jim Ryan j.ryan@f5.com

### Proposed changes

This PR fixes an issue causing Helm to crash when the `readOnlyRootFilesystem` option was on the NIC container, and WAF was enabled simultaneously



### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
