### PR TITLE
refactor: change glog in configs package

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -131,7 +131,8 @@ func main() {
 	mustProcessGlobalConfiguration(ctx)
 
 	cfgParams := configs.NewDefaultConfigParams(*nginxPlus)
-	cfgParams = processConfigMaps(ctx, kubeClient, cfgParams, nginxManager, templateExecutor)
+	cfgParams.Context = ctx
+	cfgParams = processConfigMaps(kubeClient, cfgParams, nginxManager, templateExecutor)
 
 	staticCfgParams := &configs.StaticConfigParams{
 		DisableIPV6:                    *disableIPV6,
@@ -162,7 +163,7 @@ func main() {
 		AppProtectBundlePath:           appProtectBundlePath,
 	}
 
-	mustProcessNginxConfig(ctx, staticCfgParams, cfgParams, templateExecutor, nginxManager)
+	mustProcessNginxConfig(staticCfgParams, cfgParams, templateExecutor, nginxManager)
 
 	if *enableTLSPassthrough {
 		var emptyFile []byte
@@ -202,7 +203,7 @@ func main() {
 	)
 
 	if *enableServiceInsight {
-		createHealthProbeEndpoint(ctx, kubeClient, plusClient, cnf)
+		createHealthProbeEndpoint(kubeClient, plusClient, cnf)
 	}
 
 	lbcInput := k8s.NewLoadBalancerControllerInput{
@@ -266,7 +267,7 @@ func main() {
 		}()
 	}
 
-	go handleTermination(ctx, lbc, nginxManager, syslogListener, process)
+	go handleTermination(lbc, nginxManager, syslogListener, process)
 
 	lbc.Run()
 
@@ -606,8 +607,8 @@ func createGlobalConfigurationValidator() *cr_validation.GlobalConfigurationVali
 
 // mustProcessNginxConfig calls internally os.Exit
 // if can't generate a valid NGINX config.
-func mustProcessNginxConfig(ctx context.Context, staticCfgParams *configs.StaticConfigParams, cfgParams *configs.ConfigParams, templateExecutor *version1.TemplateExecutor, nginxManager nginx.Manager) {
-	l := nl.LoggerFromContext(ctx)
+func mustProcessNginxConfig(staticCfgParams *configs.StaticConfigParams, cfgParams *configs.ConfigParams, templateExecutor *version1.TemplateExecutor, nginxManager nginx.Manager) {
+	l := nl.LoggerFromContext(cfgParams.Context)
 	ngxConfig := configs.GenerateNginxMainConfig(staticCfgParams, cfgParams)
 	content, err := templateExecutor.ExecuteMainConfigTemplate(ngxConfig)
 	if err != nil {
@@ -655,8 +656,8 @@ func getAndValidateSecret(kubeClient *kubernetes.Clientset, secretNsName string)
 	return secret, nil
 }
 
-func handleTermination(ctx context.Context, lbc *k8s.LoadBalancerController, nginxManager nginx.Manager, listener metrics.SyslogListener, cpcfg childProcesses) {
-	l := nl.LoggerFromContext(ctx)
+func handleTermination(lbc *k8s.LoadBalancerController, nginxManager nginx.Manager, listener metrics.SyslogListener, cpcfg childProcesses) {
+	l := nl.LoggerFromContext(lbc.Context)
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM)
 
@@ -801,8 +802,8 @@ func createPlusAndLatencyCollectors(
 	return plusCollector, syslogListener, lc
 }
 
-func createHealthProbeEndpoint(ctx context.Context, kubeClient *kubernetes.Clientset, plusClient *client.NginxClient, cnf *configs.Configurator) {
-	l := nl.LoggerFromContext(ctx)
+func createHealthProbeEndpoint(kubeClient *kubernetes.Clientset, plusClient *client.NginxClient, cnf *configs.Configurator) {
+	l := nl.LoggerFromContext(cnf.CfgParams.Context)
 	if !*enableServiceInsight {
 		return
 	}
@@ -834,8 +835,8 @@ func mustProcessGlobalConfiguration(ctx context.Context) {
 	}
 }
 
-func processConfigMaps(ctx context.Context, kubeClient *kubernetes.Clientset, cfgParams *configs.ConfigParams, nginxManager nginx.Manager, templateExecutor *version1.TemplateExecutor) *configs.ConfigParams {
-	l := nl.LoggerFromContext(ctx)
+func processConfigMaps(kubeClient *kubernetes.Clientset, cfgParams *configs.ConfigParams, nginxManager nginx.Manager, templateExecutor *version1.TemplateExecutor) *configs.ConfigParams {
+	l := nl.LoggerFromContext(cfgParams.Context)
 	if *nginxConfigMaps != "" {
 		ns, name, err := k8s.ParseNamespaceName(*nginxConfigMaps)
 		if err != nil {
@@ -845,7 +846,7 @@ func processConfigMaps(ctx context.Context, kubeClient *kubernetes.Clientset, cf
 		if err != nil {
 			nl.Fatalf(l, "Error when getting %v: %v", *nginxConfigMaps, err)
 		}
-		cfgParams = configs.ParseConfigMap(cfm, *nginxPlus, *appProtect, *appProtectDos, *enableTLSPassthrough)
+		cfgParams = configs.ParseConfigMap(cfgParams.Context, cfm, *nginxPlus, *appProtect, *appProtectDos, *enableTLSPassthrough)
 		if cfgParams.MainServerSSLDHParamFileContent != nil {
 			fileName, err := nginxManager.CreateDHParam(*cfgParams.MainServerSSLDHParamFileContent)
 			if err != nil {

--- a/internal/configs/config_params.go
+++ b/internal/configs/config_params.go
@@ -1,6 +1,8 @@
 package configs
 
 import (
+	"context"
+
 	"github.com/nginxinc/kubernetes-ingress/internal/configs/version2"
 	"github.com/nginxinc/kubernetes-ingress/internal/nginx"
 	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
@@ -9,6 +11,7 @@ import (
 // ConfigParams holds NGINX configuration parameters that affect the main NGINX config
 // as well as configs for Ingress resources.
 type ConfigParams struct {
+	Context                                context.Context
 	ClientMaxBodySize                      string
 	DefaultServerAccessLogOff              bool
 	DefaultServerReturn                    string

--- a/internal/configs/configmaps_test.go
+++ b/internal/configs/configmaps_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"context"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -44,7 +45,7 @@ func TestParseConfigMapWithAppProtectCompressedRequestsAction(t *testing.T) {
 				"app-protect-compressed-requests-action": test.action,
 			},
 		}
-		result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
+		result := ParseConfigMap(context.Background(), cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
 		if result.MainAppProtectCompressedRequestsAction != test.expect {
 			t.Errorf("ParseConfigMap() returned %q but expected %q for the case %s", result.MainAppProtectCompressedRequestsAction, test.expect, test.msg)
 		}
@@ -113,7 +114,7 @@ func TestParseConfigMapWithAppProtectReconnectPeriod(t *testing.T) {
 				"app-protect-reconnect-period-seconds": test.period,
 			},
 		}
-		result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
+		result := ParseConfigMap(context.Background(), cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
 		if result.MainAppProtectReconnectPeriod != test.expect {
 			t.Errorf("ParseConfigMap() returned %q but expected %q for the case %s", result.MainAppProtectReconnectPeriod, test.expect, test.msg)
 		}
@@ -154,7 +155,7 @@ func TestParseConfigMapWithTLSPassthroughProxyProtocol(t *testing.T) {
 					"real-ip-header": test.realIPheader,
 				},
 			}
-			result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
+			result := ParseConfigMap(context.Background(), cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
 			if result.RealIPHeader != test.want {
 				t.Errorf("want %q, got %q", test.want, result.RealIPHeader)
 			}
@@ -196,7 +197,7 @@ func TestParseConfigMapWithoutTLSPassthroughProxyProtocol(t *testing.T) {
 					"real-ip-header": test.realIPheader,
 				},
 			}
-			result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
+			result := ParseConfigMap(context.Background(), cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
 			if result.RealIPHeader != test.want {
 				t.Errorf("want %q, got %q", test.want, result.RealIPHeader)
 			}
@@ -243,7 +244,7 @@ func TestParseConfigMapAccessLog(t *testing.T) {
 					"access-log-off": test.accessLogOff,
 				},
 			}
-			result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
+			result := ParseConfigMap(context.Background(), cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
 			if result.MainAccessLog != test.want {
 				t.Errorf("want %q, got %q", test.want, result.MainAccessLog)
 			}
@@ -275,7 +276,7 @@ func TestParseConfigMapAccessLogDefault(t *testing.T) {
 					"access-log-off": "False",
 				},
 			}
-			result := ParseConfigMap(cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
+			result := ParseConfigMap(context.Background(), cm, nginxPlus, hasAppProtect, hasAppProtectDos, hasTLSPassthrough)
 			if result.MainAccessLog != test.want {
 				t.Errorf("want %q, got %q", test.want, result.MainAccessLog)
 			}

--- a/internal/configs/configurator_test.go
+++ b/internal/configs/configurator_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"reflect"
@@ -59,6 +60,7 @@ func createTestConfigurator(t *testing.T) *Configurator {
 		NginxVersion:            nginx.NewVersion("nginx version: nginx/1.25.3 (nginx-plus-r31)"),
 	})
 	cnf.isReloadsEnabled = true
+	cnf.CfgParams.Context = context.Background()
 	return cnf
 }
 
@@ -89,6 +91,7 @@ func createTestConfiguratorInvalidIngressTemplate(t *testing.T) *Configurator {
 		IsLatencyMetricsEnabled: false,
 	})
 	cnf.isReloadsEnabled = true
+	cnf.CfgParams.Context = context.Background()
 	return cnf
 }
 

--- a/internal/configs/ingress_test.go
+++ b/internal/configs/ingress_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -21,6 +22,7 @@ func TestGenerateNginxCfg(t *testing.T) {
 	cafeIngressEx := createCafeIngressEx()
 	isPlus := false
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 	result, warnings := generateNginxCfg(NginxCfgParams{
@@ -30,7 +32,7 @@ func TestGenerateNginxCfg(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               isPlus,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -59,6 +61,7 @@ func TestGenerateNginxCfgForJWT(t *testing.T) {
 
 	isPlus := true
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 	expected.Servers[0].JWTAuth = &version1.JWTAuth{
@@ -81,7 +84,7 @@ func TestGenerateNginxCfgForJWT(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               true,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -111,6 +114,7 @@ func TestGenerateNginxCfgForBasicAuth(t *testing.T) {
 
 	isPlus := false
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 	expected.Servers[0].BasicAuth = &version1.BasicAuth{
@@ -125,7 +129,7 @@ func TestGenerateNginxCfgForBasicAuth(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               true,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -143,6 +147,7 @@ func TestGenerateNginxCfgWithMissingTLSSecret(t *testing.T) {
 	cafeIngressEx := createCafeIngressEx()
 	cafeIngressEx.SecretRefs["cafe-secret"].Error = errors.New("secret doesn't exist")
 	configParams := NewDefaultConfigParams(false)
+	configParams.Context = context.Background()
 
 	result, resultWarnings := generateNginxCfg(NginxCfgParams{
 		staticParams:         &StaticConfigParams{},
@@ -151,7 +156,7 @@ func TestGenerateNginxCfgWithMissingTLSSecret(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               false,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -177,6 +182,7 @@ func TestGenerateNginxCfgWithWildcardTLSSecret(t *testing.T) {
 	cafeIngressEx := createCafeIngressEx()
 	cafeIngressEx.Ingress.Spec.TLS[0].SecretName = ""
 	configParams := NewDefaultConfigParams(false)
+	configParams.Context = context.Background()
 
 	result, warnings := generateNginxCfg(NginxCfgParams{
 		staticParams:         &StaticConfigParams{},
@@ -185,7 +191,7 @@ func TestGenerateNginxCfgWithWildcardTLSSecret(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               false,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    true,
 	})
@@ -207,6 +213,7 @@ func TestGenerateNginxCfgWithIPV6Disabled(t *testing.T) {
 	cafeIngressEx := createCafeIngressEx()
 	isPlus := false
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 	expected.Servers[0].DisableIPV6 = true
@@ -218,7 +225,7 @@ func TestGenerateNginxCfgWithIPV6Disabled(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               isPlus,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -473,12 +480,13 @@ func TestGenerateNginxCfgForMergeableIngresses(t *testing.T) {
 	expected := createExpectedConfigForMergeableCafeIngress(isPlus)
 
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	result, warnings := generateNginxCfgForMergeableIngresses(NginxCfgParams{
 		mergeableIngs:        mergeableIngresses,
 		apResources:          nil,
 		dosResource:          nil,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isPlus:               false,
 		isResolverConfigured: false,
 		staticParams:         &StaticConfigParams{},
@@ -507,12 +515,13 @@ func TestGenerateNginxConfigForCrossNamespaceMergeableIngresses(t *testing.T) {
 
 	expected := createExpectedConfigForCrossNamespaceMergeableCafeIngress()
 	configParams := NewDefaultConfigParams(false)
+	configParams.Context = context.Background()
 
 	result, warnings := generateNginxCfgForMergeableIngresses(NginxCfgParams{
 		mergeableIngs:        mergeableIngresses,
 		apResources:          nil,
 		dosResource:          nil,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isPlus:               false,
 		isResolverConfigured: false,
 		staticParams:         &StaticConfigParams{},
@@ -581,12 +590,13 @@ func TestGenerateNginxCfgForMergeableIngressesForJWT(t *testing.T) {
 	minionJwtKeyFileNames := make(map[string]string)
 	minionJwtKeyFileNames[objectMetaToFileName(&mergeableIngresses.Minions[0].Ingress.ObjectMeta)] = "/etc/nginx/secrets/default-coffee-jwk"
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	result, warnings := generateNginxCfgForMergeableIngresses(NginxCfgParams{
 		mergeableIngs:        mergeableIngresses,
 		apResources:          nil,
 		dosResource:          nil,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isPlus:               isPlus,
 		isResolverConfigured: false,
 		staticParams:         &StaticConfigParams{},
@@ -641,12 +651,13 @@ func TestGenerateNginxCfgForMergeableIngressesForBasicAuth(t *testing.T) {
 	}
 
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	result, warnings := generateNginxCfgForMergeableIngresses(NginxCfgParams{
 		mergeableIngs:        mergeableIngresses,
 		apResources:          nil,
 		dosResource:          nil,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isPlus:               isPlus,
 		isResolverConfigured: false,
 		staticParams:         &StaticConfigParams{},
@@ -673,12 +684,13 @@ func TestGenerateNginxCfgForMergeableIngressesWithUseClusterIP(t *testing.T) {
 
 	expected := createExpectedConfigForMergeableCafeIngressWithUseClusterIP()
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	result, warnings := generateNginxCfgForMergeableIngresses(NginxCfgParams{
 		mergeableIngs:        mergeableIngresses,
 		apResources:          nil,
 		dosResource:          nil,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isPlus:               isPlus,
 		isResolverConfigured: false,
 		staticParams:         &StaticConfigParams{},
@@ -975,6 +987,7 @@ func TestGenerateNginxCfgWithUseClusterIP(t *testing.T) {
 	cafeIngressEx.Ingress.Annotations["nginx.org/use-cluster-ip"] = "true"
 	isPlus := false
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expected := createExpectedConfigForCafeIngressWithUseClusterIP()
 
@@ -985,7 +998,7 @@ func TestGenerateNginxCfgWithUseClusterIP(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               false,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -1019,6 +1032,7 @@ func TestGenerateNginxCfgWithUseClusterIPWithNamedPorts(t *testing.T) {
 
 	isPlus := false
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expected := createExpectedConfigForCafeIngressWithUseClusterIPNamedPorts()
 
@@ -1029,7 +1043,7 @@ func TestGenerateNginxCfgWithUseClusterIPWithNamedPorts(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               false,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -1057,6 +1071,7 @@ func TestGenerateNginxCfgForLimitReq(t *testing.T) {
 
 	isPlus := false
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expectedZones := []version1.LimitReqZone{
 		{
@@ -1079,7 +1094,7 @@ func TestGenerateNginxCfgForLimitReq(t *testing.T) {
 
 	result, warnings := generateNginxCfg(NginxCfgParams{
 		ingEx:         &cafeIngressEx,
-		baseCfgParams: configParams,
+		BaseCfgParams: configParams,
 		staticParams:  &StaticConfigParams{},
 		isPlus:        isPlus,
 	})
@@ -1113,6 +1128,7 @@ func TestGenerateNginxCfgForLimitReqDefaults(t *testing.T) {
 
 	isPlus := false
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expectedZones := []version1.LimitReqZone{
 		{
@@ -1133,7 +1149,7 @@ func TestGenerateNginxCfgForLimitReqDefaults(t *testing.T) {
 
 	result, warnings := generateNginxCfg(NginxCfgParams{
 		ingEx:         &cafeIngressEx,
-		baseCfgParams: configParams,
+		BaseCfgParams: configParams,
 		staticParams:  &StaticConfigParams{},
 		isPlus:        isPlus,
 	})
@@ -1215,10 +1231,11 @@ func TestGenerateNginxCfgForMergeableIngressesForLimitReq(t *testing.T) {
 	isPlus := false
 
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	result, warnings := generateNginxCfgForMergeableIngresses(NginxCfgParams{
 		mergeableIngs: mergeableIngresses,
-		baseCfgParams: configParams,
+		BaseCfgParams: configParams,
 		isPlus:        isPlus,
 		staticParams:  &StaticConfigParams{},
 	})
@@ -1260,6 +1277,7 @@ func TestGenerateNginxCfgForLimitReqWithScaling(t *testing.T) {
 
 	isPlus := false
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expectedZones := []version1.LimitReqZone{
 		{
@@ -1282,7 +1300,7 @@ func TestGenerateNginxCfgForLimitReqWithScaling(t *testing.T) {
 
 	result, warnings := generateNginxCfg(NginxCfgParams{
 		ingEx:                     &cafeIngressEx,
-		baseCfgParams:             configParams,
+		BaseCfgParams:             configParams,
 		staticParams:              &StaticConfigParams{},
 		isPlus:                    isPlus,
 		ingressControllerReplicas: 4,
@@ -1367,10 +1385,11 @@ func TestGenerateNginxCfgForMergeableIngressesForLimitReqWithScaling(t *testing.
 	isPlus := false
 
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	result, warnings := generateNginxCfgForMergeableIngresses(NginxCfgParams{
 		mergeableIngs:             mergeableIngresses,
-		baseCfgParams:             configParams,
+		BaseCfgParams:             configParams,
 		isPlus:                    isPlus,
 		staticParams:              &StaticConfigParams{},
 		ingressControllerReplicas: 2,
@@ -1778,6 +1797,7 @@ func TestGenerateNginxCfgForSpiffe(t *testing.T) {
 	cafeIngressEx := createCafeIngressEx()
 	isPlus := false
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 	expected.SpiffeClientCerts = true
@@ -1792,7 +1812,7 @@ func TestGenerateNginxCfgForSpiffe(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               false,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -1812,6 +1832,7 @@ func TestGenerateNginxCfgForInternalRoute(t *testing.T) {
 	cafeIngressEx.Ingress.Annotations[internalRouteAnnotation] = "true"
 	isPlus := false
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 
 	expected := createExpectedConfigForCafeIngressEx(isPlus)
 	expected.Servers[0].SpiffeCerts = true
@@ -1824,7 +1845,7 @@ func TestGenerateNginxCfgForInternalRoute(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               false,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -2295,6 +2316,7 @@ func TestGenerateNginxCfgForAppProtect(t *testing.T) {
 	isPlus := true
 
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
 	apResources := &AppProtectResources{
 		AppProtectPolicy:   "/etc/nginx/waf/nac-policies/default_dataguard-alarm",
 		AppProtectLogconfs: []string{"/etc/nginx/waf/nac-logconfs/default_logconf syslog:server=127.0.0.1:514"},
@@ -2317,7 +2339,7 @@ func TestGenerateNginxCfgForAppProtect(t *testing.T) {
 		dosResource:          nil,
 		isMinion:             false,
 		isPlus:               isPlus,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -2357,6 +2379,8 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtect(t *testing.T) {
 
 	isPlus := true
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
+
 	apResources := &AppProtectResources{
 		AppProtectPolicy:   "/etc/nginx/waf/nac-policies/default_dataguard-alarm",
 		AppProtectLogconfs: []string{"/etc/nginx/waf/nac-logconfs/default_logconf syslog:server=127.0.0.1:514"},
@@ -2376,7 +2400,7 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtect(t *testing.T) {
 		mergeableIngs:        mergeableIngresses,
 		apResources:          apResources,
 		dosResource:          nil,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isPlus:               isPlus,
 		isResolverConfigured: false,
 		staticParams:         staticCfgParams,
@@ -2397,6 +2421,8 @@ func TestGenerateNginxCfgForAppProtectDos(t *testing.T) {
 
 	isPlus := true
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
+
 	dosResource := &appProtectDosResource{
 		AppProtectDosEnable:        "on",
 		AppProtectDosName:          "dos.example.com",
@@ -2429,7 +2455,7 @@ func TestGenerateNginxCfgForAppProtectDos(t *testing.T) {
 		dosResource:          dosResource,
 		isMinion:             false,
 		isPlus:               isPlus,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isResolverConfigured: false,
 		isWildcardEnabled:    false,
 	})
@@ -2466,6 +2492,9 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtectDos(t *testing.T) {
 
 	isPlus := true
 	configParams := NewDefaultConfigParams(isPlus)
+	configParams.Context = context.Background()
+
+	configParams.Context = context.Background()
 	dosResource := &appProtectDosResource{
 		AppProtectDosEnable:        "on",
 		AppProtectDosName:          "dos.example.com",
@@ -2495,7 +2524,7 @@ func TestGenerateNginxCfgForMergeableIngressesForAppProtectDos(t *testing.T) {
 		mergeableIngs:        mergeableIngresses,
 		apResources:          nil,
 		dosResource:          dosResource,
-		baseCfgParams:        configParams,
+		BaseCfgParams:        configParams,
 		isPlus:               isPlus,
 		isResolverConfigured: false,
 		staticParams:         staticCfgParams,

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -11,9 +12,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/nginxinc/kubernetes-ingress/internal/configs/version2"
 	"github.com/nginxinc/kubernetes-ingress/internal/k8s/secrets"
+	nl "github.com/nginxinc/kubernetes-ingress/internal/logger"
 	"github.com/nginxinc/kubernetes-ingress/internal/nginx"
 	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
 	api_v1 "k8s.io/api/core/v1"
@@ -1440,11 +1441,13 @@ func generateAPIKeyClientMap(mapName string, apiKeyClients []apiKeyClient) *vers
 }
 
 func (p *policiesCfg) addWAFConfig(
+	ctx context.Context,
 	waf *conf_v1.WAF,
 	polKey string,
 	polNamespace string,
 	apResources *appProtectResourcesForVS,
 ) *validationResults {
+	l := nl.LoggerFromContext(ctx)
 	res := newValidationResults()
 	if p.WAF != nil {
 		res.addWarningf("Multiple WAF policies in the same context is not valid. WAF policy %s will be ignored", polKey)
@@ -1483,7 +1486,7 @@ func (p *policiesCfg) addWAFConfig(
 	}
 
 	if waf.SecurityLog != nil && waf.SecurityLogs == nil {
-		glog.V(2).Info("the field securityLog is deprecated and will be removed in future releases. Use field securityLogs instead")
+		nl.Info(l, "the field securityLog is deprecated and will be removed in future releases. Use field securityLogs instead")
 		waf.SecurityLogs = append(waf.SecurityLogs, waf.SecurityLog)
 	}
 
@@ -1573,7 +1576,7 @@ func (vsc *virtualServerConfigurator) generatePolicies(
 				res = config.addAPIKeyConfig(pol.Spec.APIKey, key, polNamespace, ownerDetails.vsNamespace,
 					ownerDetails.vsName, policyOpts.secretRefs)
 			case pol.Spec.WAF != nil:
-				res = config.addWAFConfig(pol.Spec.WAF, key, polNamespace, policyOpts.apResources)
+				res = config.addWAFConfig(vsc.cfgParams.Context, pol.Spec.WAF, key, polNamespace, policyOpts.apResources)
 			default:
 				res = newValidationResults()
 			}
@@ -2817,6 +2820,7 @@ func createUpstreamsForPlus(
 	baseCfgParams *ConfigParams,
 	staticParams *StaticConfigParams,
 ) []version2.Upstream {
+	l := nl.LoggerFromContext(baseCfgParams.Context)
 	var upstreams []version2.Upstream
 
 	isPlus := true
@@ -2826,7 +2830,7 @@ func createUpstreamsForPlus(
 	for _, u := range virtualServerEx.VirtualServer.Spec.Upstreams {
 		isExternalNameSvc := virtualServerEx.ExternalNameSvcs[GenerateExternalNameSvcKey(virtualServerEx.VirtualServer.Namespace, u.Service)]
 		if isExternalNameSvc {
-			glog.V(3).Infof("Service %s is Type ExternalName, skipping NGINX Plus endpoints update via API", u.Service)
+			nl.Infof(l, "Service %s is Type ExternalName, skipping NGINX Plus endpoints update via API", u.Service)
 			continue
 		}
 
@@ -2850,7 +2854,7 @@ func createUpstreamsForPlus(
 		for _, u := range vsr.Spec.Upstreams {
 			isExternalNameSvc := virtualServerEx.ExternalNameSvcs[GenerateExternalNameSvcKey(vsr.Namespace, u.Service)]
 			if isExternalNameSvc {
-				glog.V(3).Infof("Service %s is Type ExternalName, skipping NGINX Plus endpoints update via API", u.Service)
+				nl.Infof(l, "Service %s is Type ExternalName, skipping NGINX Plus endpoints update via API", u.Service)
 				continue
 			}
 

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -1200,6 +1201,7 @@ func TestGenerateVirtualServerConfigWithBackupForNGINXPlus(t *testing.T) {
 	}
 
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -1512,6 +1514,7 @@ func TestGenerateVirtualServerConfig_DoesNotGenerateBackupOnMissingBackupNameFor
 	}
 
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -1818,6 +1821,7 @@ func TestGenerateVirtualServerConfig_DoesNotGenerateBackupOnMissingBackupPortFor
 		},
 	}
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -2122,6 +2126,7 @@ func TestGenerateVirtualServerConfig_DoesNotGenerateBackupOnMissingBackupPortAnd
 	}
 
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -2597,6 +2602,7 @@ func TestGenerateVirtualServerConfig(t *testing.T) {
 	}
 
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -3281,7 +3287,7 @@ func TestGenerateVirtualServerConfigIPV6Disabled(t *testing.T) {
 		},
 	}
 
-	baseCfgParams := ConfigParams{}
+	baseCfgParams := ConfigParams{Context: context.Background()}
 
 	expected := version2.VirtualServerConfig{
 		Upstreams: []version2.Upstream{
@@ -3497,7 +3503,8 @@ func TestGenerateVirtualServerConfigGrpcErrorPageWarning(t *testing.T) {
 	}
 
 	baseCfgParams := ConfigParams{
-		HTTP2: true,
+		Context: context.Background(),
+		HTTP2:   true,
 	}
 
 	expected := version2.VirtualServerConfig{
@@ -3770,6 +3777,7 @@ func TestGenerateVirtualServerConfigWithSpiffeCerts(t *testing.T) {
 	}
 
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -3882,6 +3890,7 @@ func TestGenerateVirtualServerConfigWithInternalRoutes(t *testing.T) {
 	}
 
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -3995,6 +4004,7 @@ func TestGenerateVirtualServerConfigWithInternalRoutesWarning(t *testing.T) {
 	}
 
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -4176,7 +4186,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithSplits(t *testing.T) {
 		},
 	}
 
-	baseCfgParams := ConfigParams{}
+	baseCfgParams := ConfigParams{Context: context.Background()}
 
 	expected := version2.VirtualServerConfig{
 		Upstreams: []version2.Upstream{
@@ -4467,7 +4477,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithMatches(t *testing.T) {
 		},
 	}
 
-	baseCfgParams := ConfigParams{}
+	baseCfgParams := ConfigParams{Context: context.Background()}
 
 	expected := version2.VirtualServerConfig{
 		Upstreams: []version2.Upstream{
@@ -4880,7 +4890,7 @@ func TestGenerateVirtualServerConfigForVirtualServerRoutesWithDos(t *testing.T) 
 		},
 	}
 
-	baseCfgParams := ConfigParams{}
+	baseCfgParams := ConfigParams{Context: context.Background()}
 
 	expected := []version2.Location{
 		{
@@ -5181,7 +5191,7 @@ func TestGenerateVirtualServerConfigForVirtualServerWithReturns(t *testing.T) {
 		},
 	}
 
-	baseCfgParams := ConfigParams{}
+	baseCfgParams := ConfigParams{Context: context.Background()}
 
 	expected := version2.VirtualServerConfig{
 		Maps: []version2.Map{
@@ -5791,6 +5801,7 @@ func TestGenerateVirtualServerConfigJWKSPolicy(t *testing.T) {
 	}
 
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -6048,6 +6059,7 @@ func TestGenerateVirtualServerConfigAPIKeyPolicy(t *testing.T) {
 	}
 
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -6221,6 +6233,7 @@ func TestGenerateVirtualServerConfigAPIKeyClientMaps(t *testing.T) {
 	}
 
 	baseCfgParams := ConfigParams{
+		Context:         context.Background(),
 		ServerTokens:    "off",
 		Keepalive:       16,
 		ServerSnippets:  []string{"# server snippet"},
@@ -7151,7 +7164,7 @@ func TestGeneratePolicies(t *testing.T) {
 		},
 	}
 
-	vsc := newVirtualServerConfigurator(&ConfigParams{}, false, false, &StaticConfigParams{}, false, &fakeBV)
+	vsc := newVirtualServerConfigurator(&ConfigParams{Context: context.Background()}, false, false, &StaticConfigParams{}, false, &fakeBV)
 	// required to test the scaling of the ratelimit
 	vsc.IngressControllerReplicas = 2
 
@@ -7251,7 +7264,7 @@ func TestGeneratePolicies_GeneratesWAFPolicyOnValidApBundle(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			vsc := newVirtualServerConfigurator(&ConfigParams{}, false, false, &StaticConfigParams{}, false, &fakeBV)
+			vsc := newVirtualServerConfigurator(&ConfigParams{Context: context.Background()}, false, false, &StaticConfigParams{}, false, &fakeBV)
 			res := vsc.generatePolicies(ownerDetails, tc.policyRefs, tc.policies, tc.context, policyOptions{apResources: &appProtectResourcesForVS{}})
 			res.BundleValidator = nil
 			if !cmp.Equal(tc.want, res) {
@@ -8814,7 +8827,7 @@ func TestGeneratePoliciesFails(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.msg, func(t *testing.T) {
-			vsc := newVirtualServerConfigurator(&ConfigParams{}, false, false, &StaticConfigParams{}, false, &fakeBV)
+			vsc := newVirtualServerConfigurator(&ConfigParams{Context: context.Background()}, false, false, &StaticConfigParams{}, false, &fakeBV)
 
 			if test.oidcPolCfg != nil {
 				vsc.oidcPolCfg = test.oidcPolCfg
@@ -8929,6 +8942,7 @@ func TestGenerateUpstream(t *testing.T) {
 		"backup.service.svc.test.corp.local:8080",
 	}
 	cfgParams := ConfigParams{
+		Context:          context.Background(),
 		LBMethod:         "random",
 		MaxFails:         1,
 		MaxConns:         0,
@@ -9056,7 +9070,7 @@ func TestGenerateUpstreamForExternalNameService(t *testing.T) {
 	name := "test-upstream"
 	endpoints := []string{"example.com"}
 	upstream := conf_v1.Upstream{Service: name}
-	cfgParams := ConfigParams{}
+	cfgParams := ConfigParams{Context: context.Background()}
 
 	expected := version2.Upstream{
 		Name: name,
@@ -9090,6 +9104,7 @@ func TestGenerateUpstreamWithNTLM(t *testing.T) {
 		"192.168.10.10:8080",
 	}
 	cfgParams := ConfigParams{
+		Context:          context.Background(),
 		LBMethod:         "random",
 		MaxFails:         1,
 		MaxConns:         0,
@@ -9354,6 +9369,7 @@ func TestGenerateBuffer(t *testing.T) {
 func TestGenerateLocationForProxying(t *testing.T) {
 	t.Parallel()
 	cfgParams := ConfigParams{
+		Context:              context.Background(),
 		ProxyConnectTimeout:  "30s",
 		ProxyReadTimeout:     "31s",
 		ProxySendTimeout:     "32s",
@@ -9400,6 +9416,7 @@ func TestGenerateLocationForProxying(t *testing.T) {
 func TestGenerateLocationForGrpcProxying(t *testing.T) {
 	t.Parallel()
 	cfgParams := ConfigParams{
+		Context:              context.Background(),
 		ProxyConnectTimeout:  "30s",
 		ProxyReadTimeout:     "31s",
 		ProxySendTimeout:     "32s",
@@ -9634,7 +9651,7 @@ func TestGenerateSSLConfig(t *testing.T) {
 		{
 			inputTLS:         nil,
 			inputSecretRefs:  map[string]*secrets.SecretReference{},
-			inputCfgParams:   &ConfigParams{},
+			inputCfgParams:   &ConfigParams{Context: context.Background()},
 			wildcard:         false,
 			expectedSSL:      nil,
 			expectedWarnings: Warnings{},
@@ -9645,7 +9662,7 @@ func TestGenerateSSLConfig(t *testing.T) {
 				Secret: "",
 			},
 			inputSecretRefs:  map[string]*secrets.SecretReference{},
-			inputCfgParams:   &ConfigParams{},
+			inputCfgParams:   &ConfigParams{Context: context.Background()},
 			wildcard:         false,
 			expectedSSL:      nil,
 			expectedWarnings: Warnings{},
@@ -9656,7 +9673,7 @@ func TestGenerateSSLConfig(t *testing.T) {
 				Secret: "",
 			},
 			inputSecretRefs: map[string]*secrets.SecretReference{},
-			inputCfgParams:  &ConfigParams{},
+			inputCfgParams:  &ConfigParams{Context: context.Background()},
 			wildcard:        true,
 			expectedSSL: &version2.SSL{
 				HTTP2:           false,
@@ -9671,7 +9688,7 @@ func TestGenerateSSLConfig(t *testing.T) {
 			inputTLS: &conf_v1.TLS{
 				Secret: "missing",
 			},
-			inputCfgParams: &ConfigParams{},
+			inputCfgParams: &ConfigParams{Context: context.Background()},
 			wildcard:       false,
 			inputSecretRefs: map[string]*secrets.SecretReference{
 				"default/missing": {
@@ -9691,7 +9708,7 @@ func TestGenerateSSLConfig(t *testing.T) {
 			inputTLS: &conf_v1.TLS{
 				Secret: "mistyped",
 			},
-			inputCfgParams: &ConfigParams{},
+			inputCfgParams: &ConfigParams{Context: context.Background()},
 			wildcard:       false,
 			inputSecretRefs: map[string]*secrets.SecretReference{
 				"default/mistyped": {
@@ -9721,7 +9738,7 @@ func TestGenerateSSLConfig(t *testing.T) {
 					Path: "secret.pem",
 				},
 			},
-			inputCfgParams: &ConfigParams{},
+			inputCfgParams: &ConfigParams{Context: context.Background()},
 			wildcard:       false,
 			expectedSSL: &version2.SSL{
 				HTTP2:           false,
@@ -9737,7 +9754,7 @@ func TestGenerateSSLConfig(t *testing.T) {
 	namespace := "default"
 
 	for _, test := range tests {
-		vsc := newVirtualServerConfigurator(&ConfigParams{}, false, false, &StaticConfigParams{}, test.wildcard, &fakeBV)
+		vsc := newVirtualServerConfigurator(&ConfigParams{Context: context.Background()}, false, false, &StaticConfigParams{}, test.wildcard, &fakeBV)
 
 		// it is ok to use nil as the owner
 		result := vsc.generateSSLConfig(nil, test.inputTLS, namespace, test.inputSecretRefs, test.inputCfgParams)
@@ -10025,7 +10042,7 @@ func TestCreateUpstreamsForPlus(t *testing.T) {
 		},
 	}
 
-	result := createUpstreamsForPlus(&virtualServerEx, &ConfigParams{}, &StaticConfigParams{})
+	result := createUpstreamsForPlus(&virtualServerEx, &ConfigParams{Context: context.Background()}, &StaticConfigParams{})
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("createUpstreamsForPlus returned \n%v but expected \n%v", result, expected)
 	}
@@ -10180,7 +10197,7 @@ func TestGenerateSplits(t *testing.T) {
 	upstreamNamer := NewUpstreamNamerForVirtualServer(&virtualServer)
 	variableNamer := NewVSVariableNamer(&virtualServer)
 	scIndex := 1
-	cfgParams := ConfigParams{}
+	cfgParams := ConfigParams{Context: context.Background()}
 	crUpstreams := map[string]conf_v1.Upstream{
 		"vs_default_cafe_coffee-v1": {
 			Service: "coffee-v1",
@@ -11796,7 +11813,7 @@ func TestGenerateSplitsWeightChangesDynamicReload(t *testing.T) {
 	upstreamNamer := NewUpstreamNamerForVirtualServer(&virtualServer)
 	variableNamer := NewVSVariableNamer(&virtualServer)
 	scIndex := 1
-	cfgParams := ConfigParams{}
+	cfgParams := ConfigParams{Context: context.Background()}
 	crUpstreams := map[string]conf_v1.Upstream{
 		"vs_default_cafe_coffee-v1": {
 			Service: "coffee-v1",
@@ -12117,7 +12134,7 @@ func TestGenerateDefaultSplitsConfig(t *testing.T) {
 		},
 	}
 
-	cfgParams := ConfigParams{}
+	cfgParams := ConfigParams{Context: context.Background()}
 	locSnippet := ""
 	enableSnippets := false
 	weightChangesDynamicReload := false
@@ -12519,7 +12536,7 @@ func TestGenerateMatchesConfig(t *testing.T) {
 		},
 	}
 
-	cfgParams := ConfigParams{}
+	cfgParams := ConfigParams{Context: context.Background()}
 	enableSnippets := false
 	weightChangesDynamicReload := false
 	locSnippets := ""
@@ -12932,7 +12949,7 @@ func TestGenerateMatchesConfigWithMultipleSplits(t *testing.T) {
 		},
 	}
 
-	cfgParams := ConfigParams{}
+	cfgParams := ConfigParams{Context: context.Background()}
 	enableSnippets := false
 	weightChangesWithoutReload := false
 	locSnippets := ""
@@ -13682,7 +13699,7 @@ func TestGenerateEndpointsForUpstream(t *testing.T) {
 	for _, test := range tests {
 		isWildcardEnabled := false
 		vsc := newVirtualServerConfigurator(
-			&ConfigParams{},
+			&ConfigParams{Context: context.Background()},
 			test.isPlus,
 			test.isResolverConfigured,
 			&StaticConfigParams{},
@@ -13728,7 +13745,7 @@ func TestGenerateSlowStartForPlusWithInCompatibleLBMethods(t *testing.T) {
 	}
 
 	for _, lbMethod := range tests {
-		vsc := newVirtualServerConfigurator(&ConfigParams{}, true, false, &StaticConfigParams{}, false, &fakeBV)
+		vsc := newVirtualServerConfigurator(&ConfigParams{Context: context.Background()}, true, false, &StaticConfigParams{}, false, &fakeBV)
 		result := vsc.generateSlowStartForPlus(&conf_v1.VirtualServer{}, upstream, lbMethod)
 
 		if !reflect.DeepEqual(result, expected) {
@@ -13762,7 +13779,7 @@ func TestGenerateSlowStartForPlus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		vsc := newVirtualServerConfigurator(&ConfigParams{}, true, false, &StaticConfigParams{}, false, &fakeBV)
+		vsc := newVirtualServerConfigurator(&ConfigParams{Context: context.Background()}, true, false, &StaticConfigParams{}, false, &fakeBV)
 		result := vsc.generateSlowStartForPlus(&conf_v1.VirtualServer{}, test.upstream, test.lbMethod)
 		if !reflect.DeepEqual(result, test.expected) {
 			t.Errorf("generateSlowStartForPlus returned %v, but expected %v", result, test.expected)
@@ -13863,7 +13880,7 @@ func TestGenerateUpstreamWithQueue(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		vsc := newVirtualServerConfigurator(&ConfigParams{}, test.isPlus, false, &StaticConfigParams{}, false, &fakeBV)
+		vsc := newVirtualServerConfigurator(&ConfigParams{Context: context.Background()}, test.isPlus, false, &StaticConfigParams{}, false, &fakeBV)
 		result := vsc.generateUpstream(nil, test.name, test.upstream, false, []string{}, []string{})
 		if !reflect.DeepEqual(result, test.expected) {
 			t.Errorf("generateUpstream() returned %v but expected %v for the case of %v", result, test.expected, test.msg)
@@ -14998,7 +15015,7 @@ func TestAddWafConfig(t *testing.T) {
 
 	for _, test := range tests {
 		polCfg := newPoliciesConfig(&fakeBV)
-		result := polCfg.addWAFConfig(test.wafInput, test.polKey, test.polNamespace, test.apResources)
+		result := polCfg.addWAFConfig(context.Background(), test.wafInput, test.polKey, test.polNamespace, test.apResources)
 		if diff := cmp.Diff(test.expected.warnings, result.warnings); diff != "" {
 			t.Errorf("policiesCfg.addWAFConfig() '%v' mismatch (-want +got):\n%s", test.msg, diff)
 		}

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -2360,7 +2360,7 @@ func newConfigurator(t *testing.T) *configs.Configurator {
 		IsPrometheusEnabled:     false,
 		IsLatencyMetricsEnabled: false,
 	})
-
+	cnf.CfgParams.Context = context.Background()
 	return cnf
 }
 


### PR DESCRIPTION
### Proposed changes

Replace `glog` with `slog` in configs package for:
- configmaps.go
- configurator.go
- ingress.go
- virtualserver.go
- annotations.go

add Context to cfgParams. 
made configParams  and BaseCfgParams public to access Context.

NOTE:

| GLog Levels | Slog Levels |
|-|-|
| glog.V(3).Infof() | log.Debugf() |
| glog.V(3).Info() | log.Debug() |
| glog.V(2).Infof() | log.Debugf() |
| glog.V(2).Info() | log.Debugf() |
| glog.Infof() | log.Infof() |
| glog.Info() | log.Info() 
| glog.Warningf() | log.Warnf() |
| glog.Warning() | log.Warn() |
| glog.Errorf() | log.Errorf() |
| glog.Error() | log.Error() |
| glog.Fatalf() | log.Fatalf() |
| glog.Fatal() | log.Fatal() |

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
