### PR TITLE
refactor: replace glog in externaldns & certmanager

### DIFF
--- a/internal/certmanager/cm_controller.go
+++ b/internal/certmanager/cm_controller.go
@@ -26,7 +26,6 @@ import (
 	cm_informers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
 	cmlisters "github.com/cert-manager/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/cert-manager/cert-manager/pkg/controller"
-	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	kubeinformers "k8s.io/client-go/informers"
@@ -36,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
+	nl "github.com/nginxinc/kubernetes-ingress/internal/logger"
 	conf_v1 "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
 	k8s_nginx "github.com/nginxinc/kubernetes-ingress/pkg/client/clientset/versioned"
 	vsinformers "github.com/nginxinc/kubernetes-ingress/pkg/client/informers/externalversions"
@@ -136,7 +136,8 @@ func (c *CmController) addHandlers(nsi *namespacedInformer) {
 }
 
 func (c *CmController) processItem(ctx context.Context, key string) error {
-	glog.V(3).Infof("processing virtual server resource ")
+	l := nl.LoggerFromContext(ctx)
+	nl.Debugf(l, "processing virtual server resource ")
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
@@ -236,7 +237,9 @@ func (c *CmController) Run(stopCh <-chan struct{}) {
 	ctx, cancel := context.WithCancel(c.ctx)
 	defer cancel()
 
-	glog.Infof("Starting cert-manager control loop")
+	l := nl.LoggerFromContext(ctx)
+
+	nl.Info(l, "Starting cert-manager control loop")
 
 	var mustSync []cache.InformerSynced
 	for _, ig := range c.informerGroup {
@@ -245,17 +248,17 @@ func (c *CmController) Run(stopCh <-chan struct{}) {
 	}
 	// wait for all the informer caches we depend on are synced
 
-	glog.V(3).Infof("Waiting for %d caches to sync", len(mustSync))
+	nl.Debugf(l, "Waiting for %d caches to sync", len(mustSync))
 	if !cache.WaitForNamedCacheSync(ControllerName, stopCh, mustSync...) {
-		glog.Fatal("error syncing cm queue")
+		nl.Fatal(l, "error syncing cm queue")
 	}
 
-	glog.V(3).Infof("Queue is %v", c.queue.Len())
+	nl.Debugf(l, "Queue is %v", c.queue.Len())
 
 	go c.runWorker(ctx)
 
 	<-stopCh
-	glog.V(3).Infof("shutting down queue as workqueue signaled shutdown")
+	nl.Debugf(l, "shutting down queue as workqueue signaled shutdown")
 	for _, ig := range c.informerGroup {
 		ig.stop()
 	}
@@ -276,7 +279,8 @@ func (nsi *namespacedInformer) stop() {
 // processItem function in order to read and process a message on the
 // workqueue.
 func (c *CmController) runWorker(ctx context.Context) {
-	glog.V(3).Infof("processing items on the workqueue")
+	l := nl.LoggerFromContext(ctx)
+	nl.Debugf(l, "processing items on the workqueue")
 	for {
 		obj, shutdown := c.queue.Get()
 		if shutdown {
@@ -294,11 +298,11 @@ func (c *CmController) runWorker(ctx context.Context) {
 
 			err := c.processItem(ctx, key)
 			if err != nil {
-				glog.V(3).Infof("Re-queuing item due to error processing: %v", err)
+				nl.Debugf(l, "Re-queuing item due to error processing: %v", err)
 				c.queue.AddRateLimited(obj)
 				return
 			}
-			glog.V(3).Infof("finished processing work item")
+			nl.Debugf(l, "finished processing work item")
 			c.queue.Forget(obj)
 		}()
 	}
@@ -306,7 +310,8 @@ func (c *CmController) runWorker(ctx context.Context) {
 
 // AddNewNamespacedInformer adds watchers for a new namespace
 func (c *CmController) AddNewNamespacedInformer(ns string) {
-	glog.V(3).Infof("Adding or Updating cert-manager Watchers for Namespace: %v", ns)
+	l := nl.LoggerFromContext(c.ctx)
+	nl.Debugf(l, "Adding or Updating cert-manager Watchers for Namespace: %v", ns)
 	nsi := getNamespacedInformer(ns, c.informerGroup)
 	if nsi == nil {
 		nsi = c.newNamespacedInformer(ns)
@@ -319,7 +324,8 @@ func (c *CmController) AddNewNamespacedInformer(ns string) {
 
 // RemoveNamespacedInformer removes watchers for a namespace we are no longer watching
 func (c *CmController) RemoveNamespacedInformer(ns string) {
-	glog.V(3).Infof("Deleting cert-manager Watchers for Deleted Namespace: %v", ns)
+	l := nl.LoggerFromContext(c.ctx)
+	nl.Debugf(l, "Deleting cert-manager Watchers for Deleted Namespace: %v", ns)
 	nsi := getNamespacedInformer(ns, c.informerGroup)
 	if nsi != nil {
 		nsi.lock.Lock()

--- a/internal/externaldns/sync.go
+++ b/internal/externaldns/sync.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/golang/glog"
 	"github.com/google/go-cmp/cmp"
+	nl "github.com/nginxinc/kubernetes-ingress/internal/logger"
 	vsapi "github.com/nginxinc/kubernetes-ingress/pkg/apis/configuration/v1"
 	extdnsapi "github.com/nginxinc/kubernetes-ingress/pkg/apis/externaldns/v1"
 	clientset "github.com/nginxinc/kubernetes-ingress/pkg/client/clientset/versioned"
@@ -43,25 +43,26 @@ func SyncFnFor(rec record.EventRecorder, client clientset.Interface, ig map[stri
 		if !vs.Spec.ExternalDNS.Enable {
 			return nil
 		}
+		l := nl.LoggerFromContext(ctx)
 
 		if vs.Status.ExternalEndpoints == nil {
 			// It can take time for the external endpoints to sync - kick it back to the queue
-			glog.V(3).Info("Failed to determine external endpoints - retrying")
+			nl.Info(l, "Failed to determine external endpoints - retrying")
 			return fmt.Errorf("failed to determine external endpoints")
 		}
 
-		targets, recordType, err := getValidTargets(vs.Status.ExternalEndpoints)
+		targets, recordType, err := getValidTargets(ctx, vs.Status.ExternalEndpoints)
 		if err != nil {
-			glog.Error("Invalid external endpoint")
+			nl.Error(l, "Invalid external endpoint")
 			rec.Eventf(vs, corev1.EventTypeWarning, reasonBadConfig, "Invalid external endpoint")
 			return err
 		}
 
 		nsi := getNamespacedInformer(vs.Namespace, ig)
 
-		newDNSEndpoint, updateDNSEndpoint, err := buildDNSEndpoint(nsi.extdnslister, vs, targets, recordType)
+		newDNSEndpoint, updateDNSEndpoint, err := buildDNSEndpoint(ctx, nsi.extdnslister, vs, targets, recordType)
 		if err != nil {
-			glog.Errorf("incorrect DNSEndpoint config for VirtualServer resource: %s", err)
+			nl.Errorf(l, "incorrect DNSEndpoint config for VirtualServer resource: %s", err)
 			rec.Eventf(vs, corev1.EventTypeWarning, reasonBadConfig, "Incorrect DNSEndpoint config for VirtualServer resource: %s", err)
 			return err
 		}
@@ -70,15 +71,15 @@ func SyncFnFor(rec record.EventRecorder, client clientset.Interface, ig map[stri
 
 		// Create new DNSEndpoint object
 		if newDNSEndpoint != nil {
-			glog.V(3).Infof("Creating DNSEndpoint for VirtualServer resource: %v", vs.Name)
+			nl.Debugf(l, "Creating DNSEndpoint for VirtualServer resource: %v", vs.Name)
 			dep, err = client.ExternaldnsV1().DNSEndpoints(newDNSEndpoint.Namespace).Create(ctx, newDNSEndpoint, metav1.CreateOptions{})
 			if err != nil {
 				if apierrors.IsAlreadyExists(err) {
 					// Another replica likely created the DNSEndpoint since we last checked - kick it back to the queue
-					glog.V(3).Info("DNSEndpoint has been created since we last checked - retrying")
+					nl.Debugf(l, "DNSEndpoint has been created since we last checked - retrying")
 					return fmt.Errorf("DNSEndpoint has already been created")
 				}
-				glog.Errorf("Error creating DNSEndpoint for VirtualServer resource: %v", err)
+				nl.Errorf(l, "Error creating DNSEndpoint for VirtualServer resource: %v", err)
 				rec.Eventf(vs, corev1.EventTypeWarning, reasonBadConfig, "Error creating DNSEndpoint for VirtualServer resource %s", err)
 				return err
 			}
@@ -88,10 +89,10 @@ func SyncFnFor(rec record.EventRecorder, client clientset.Interface, ig map[stri
 
 		// Update existing DNSEndpoint object
 		if updateDNSEndpoint != nil {
-			glog.V(3).Infof("Updating DNSEndpoint for VirtualServer resource: %v", vs.Name)
+			nl.Debugf(l, "Updating DNSEndpoint for VirtualServer resource: %v", vs.Name)
 			dep, err = client.ExternaldnsV1().DNSEndpoints(updateDNSEndpoint.Namespace).Update(ctx, updateDNSEndpoint, metav1.UpdateOptions{})
 			if err != nil {
-				glog.Errorf("Error updating DNSEndpoint endpoint for VirtualServer resource: %v", err)
+				nl.Errorf(l, "Error updating DNSEndpoint endpoint for VirtualServer resource: %v", err)
 				rec.Eventf(vs, corev1.EventTypeWarning, reasonBadConfig, "Error updating DNSEndpoint for VirtualServer resource: %s", err)
 				return err
 			}
@@ -102,17 +103,18 @@ func SyncFnFor(rec record.EventRecorder, client clientset.Interface, ig map[stri
 	}
 }
 
-func getValidTargets(endpoints []vsapi.ExternalEndpoint) (extdnsapi.Targets, string, error) {
+func getValidTargets(ctx context.Context, endpoints []vsapi.ExternalEndpoint) (extdnsapi.Targets, string, error) {
 	var targets extdnsapi.Targets
 	var recordType string
 	var recordA bool
 	var recordCNAME bool
 	var recordAAAA bool
 	var err error
-	glog.V(3).Infof("Going through endpoints %v", endpoints)
+	l := nl.LoggerFromContext(ctx)
+	nl.Debugf(l, "Going through endpoints %v", endpoints)
 	for _, e := range endpoints {
 		if e.IP != "" {
-			glog.V(3).Infof("IP is defined: %v", e.IP)
+			nl.Debugf(l, "IP is defined: %v", e.IP)
 			if errMsg := validators.IsValidIP(field.NewPath(""), e.IP); len(errMsg) > 0 {
 				continue
 			}
@@ -124,7 +126,7 @@ func getValidTargets(endpoints []vsapi.ExternalEndpoint) (extdnsapi.Targets, str
 			}
 			targets = append(targets, e.IP)
 		} else if e.Hostname != "" {
-			glog.V(3).Infof("Hostname is defined: %v", e.Hostname)
+			nl.Debugf(l, "Hostname is defined: %v", e.Hostname)
 			targets = append(targets, e.Hostname)
 			recordCNAME = true
 		}
@@ -144,11 +146,12 @@ func getValidTargets(endpoints []vsapi.ExternalEndpoint) (extdnsapi.Targets, str
 	return targets, recordType, err
 }
 
-func buildDNSEndpoint(extdnsLister extdnslisters.DNSEndpointLister, vs *vsapi.VirtualServer, targets extdnsapi.Targets, recordType string) (*extdnsapi.DNSEndpoint, *extdnsapi.DNSEndpoint, error) {
+func buildDNSEndpoint(ctx context.Context, extdnsLister extdnslisters.DNSEndpointLister, vs *vsapi.VirtualServer, targets extdnsapi.Targets, recordType string) (*extdnsapi.DNSEndpoint, *extdnsapi.DNSEndpoint, error) {
 	var updateDNSEndpoint *extdnsapi.DNSEndpoint
 	var newDNSEndpoint *extdnsapi.DNSEndpoint
 	var existingDNSEndpoint *extdnsapi.DNSEndpoint
 	var err error
+	l := nl.LoggerFromContext(ctx)
 
 	existingDNSEndpoint, err = extdnsLister.DNSEndpoints(vs.Namespace).Get(vs.ObjectMeta.Name)
 
@@ -184,17 +187,17 @@ func buildDNSEndpoint(extdnsLister extdnslisters.DNSEndpointLister, vs *vsapi.Vi
 	vs = vs.DeepCopy()
 
 	if existingDNSEndpoint != nil {
-		glog.V(3).Infof("DNSEndpoint already exists for this object, ensuring it is up to date")
+		nl.Debugf(l, "DNSEndpoint already exists for this object, ensuring it is up to date")
 		if metav1.GetControllerOf(existingDNSEndpoint) == nil {
-			glog.V(3).Infof("DNSEndpoint has no owner. refusing to update non-owned resource")
+			nl.Debugf(l, "DNSEndpoint has no owner. refusing to update non-owned resource")
 			return nil, nil, nil
 		}
 		if !metav1.IsControlledBy(existingDNSEndpoint, vs) {
-			glog.V(3).Infof("external DNS endpoint resource is not owned by this object. refusing to update non-owned resource")
+			nl.Debugf(l, "external DNS endpoint resource is not owned by this object. refusing to update non-owned resource")
 			return nil, nil, nil
 		}
 		if !extdnsendpointNeedsUpdate(existingDNSEndpoint, dnsEndpoint) {
-			glog.V(3).Infof("external DNS resource is already up to date for object")
+			nl.Debugf(l, "external DNS resource is already up to date for object")
 			return nil, nil, nil
 		}
 

--- a/internal/externaldns/sync_test.go
+++ b/internal/externaldns/sync_test.go
@@ -77,7 +77,7 @@ func TestGetValidTargets(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			targets, recordType, err := getValidTargets(tc.endpoints)
+			targets, recordType, err := getValidTargets(context.Background(), tc.endpoints)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -283,11 +283,11 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 	}
 
 	if input.CertManagerEnabled {
-		lbc.certManagerController = cm_controller.NewCmController(cm_controller.BuildOpts(context.TODO(), lbc.restConfig, lbc.client, lbc.namespaceList, lbc.recorder, lbc.confClient, isDynamicNs))
+		lbc.certManagerController = cm_controller.NewCmController(cm_controller.BuildOpts(input.LoggerContext, lbc.restConfig, lbc.client, lbc.namespaceList, lbc.recorder, lbc.confClient, isDynamicNs))
 	}
 
 	if input.ExternalDNSEnabled {
-		lbc.externalDNSController = ed_controller.NewController(ed_controller.BuildOpts(context.TODO(), lbc.namespaceList, lbc.recorder, lbc.confClient, input.ResyncPeriod, isDynamicNs))
+		lbc.externalDNSController = ed_controller.NewController(ed_controller.BuildOpts(input.LoggerContext, lbc.namespaceList, lbc.recorder, lbc.confClient, input.ResyncPeriod, isDynamicNs))
 	}
 
 	nl.Debugf(lbc.logger, "Nginx Ingress Controller has class: %v", input.IngressClass)


### PR DESCRIPTION
### Proposed changes

Replace `glog` with `slog` in `certmanager` & `externaldns` packages for:
- certmanager/cm_controller.go
- certmanager/sync.go
- externaldns/controller.go
- externaldns/sync.go

NOTE:

| GLog Levels | Slog Levels |
|-|-|
| glog.V(3).Infof() | log.Debugf() |
| glog.V(3).Info() | log.Debug() |
| glog.V(2).Infof() | log.Debugf() |
| glog.V(2).Info() | log.Debugf() |
| glog.Infof() | log.Infof() |
| glog.Info() | log.Info() 
| glog.Warningf() | log.Warnf() |
| glog.Warning() | log.Warn() |
| glog.Errorf() | log.Errorf() |
| glog.Error() | log.Error() |
| glog.Fatalf() | log.Fatalf() |
| glog.Fatal() | log.Fatal() |

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
