### PR TITLE
[cherry-pick] docs: enableGitInfo config (#6577)

### DIFF
--- a/docs/config/_default/config.toml
+++ b/docs/config/_default/config.toml
@@ -1,6 +1,6 @@
 title = "NGINX Ingress Controller"
 baseURL = "/"
-enableGitInfo = false
+enableGitInfo = true
 staticDir = ["static"]
 languageCode = "en-us"
 description = "Enterprise-grade Ingress load balancing on Kubernetes platforms."


### PR DESCRIPTION
Cherry-pick enableGitInfo config and docs-action bump

This enables enableGitInfo config to fix incorrect last-modified docs values.

