### PR TITLE
Update python to 3.13 and disable pytest-profiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ pythonpath = [
     "tests/suite/fixtures",
     "tests/suite/utils",
 ]
-addopts = "--tb=native -ra --disable-warnings -x -l --profile -v --strict-markers"
+addopts = "--tb=native -ra --disable-warnings -x -l -v --strict-markers"
 log_cli = true
 markers =[
     "agent",

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,7 +5,7 @@ FROM kindest/node:v1.31.1@sha256:cd224d8da58d50907d1dd41d476587643dad2ffd9f6a4d9
 # this is here so we can grab the latest version of skopeo and have dependabot keep it up to date
 FROM quay.io/skopeo/stable:v1.16.1
 
-FROM python:3.12@sha256:05855f5bf06f5a004b0c1a8aaac73a9d9ea54390fc289d3e80ef52c4f90d5585
+FROM python:3.13@sha256:45803c375b95ea33f482e53a461eca8f247617667d703660a06ccf5eb3d05326
 
 RUN apt-get update \
 	&& apt-get install -y curl git \

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -537,7 +537,7 @@ pytest-metadata==3.1.1 \
     # via
     #   -r requirements.txt
     #   pytest-html
-# Broken on pyton version 3.13+
+# Broken on python version 3.13+
 # pytest-profiling==1.7.0 \
 #     --hash=sha256:93938f147662225d2b8bd5af89587b979652426a8a6ffd7e73ec4a23e24b7f29 \
 #     --hash=sha256:999cc9ac94f2e528e3f5d43465da277429984a1c237ae9818f8cfd0b06acb019

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -537,10 +537,11 @@ pytest-metadata==3.1.1 \
     # via
     #   -r requirements.txt
     #   pytest-html
-pytest-profiling==1.7.0 \
-    --hash=sha256:93938f147662225d2b8bd5af89587b979652426a8a6ffd7e73ec4a23e24b7f29 \
-    --hash=sha256:999cc9ac94f2e528e3f5d43465da277429984a1c237ae9818f8cfd0b06acb019
-    # via -r requirements.txt
+# Broken on pyton version 3.13+
+# pytest-profiling==1.7.0 \
+#     --hash=sha256:93938f147662225d2b8bd5af89587b979652426a8a6ffd7e73ec4a23e24b7f29 \
+#     --hash=sha256:999cc9ac94f2e528e3f5d43465da277429984a1c237ae9818f8cfd0b06acb019
+#     # via -r requirements.txt
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427


### PR DESCRIPTION
### Proposed changes

- update python to 3.13
- remove `pytest-profiling ` temporarily

It is removed due to python version 3.13 deprecating the pipes module which is required for pytest-profiling. Disabling for now until pytests has a alternative.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
