### PR TITLE
add nil check to apikey suppliedIn

### DIFF
--- a/pkg/apis/configuration/validation/policy.go
+++ b/pkg/apis/configuration/validation/policy.go
@@ -294,9 +294,20 @@ func validateOIDC(oidc *v1.OIDC, fieldPath *field.Path) field.ErrorList {
 
 func validateAPIKey(apiKey *v1.APIKey, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	if apiKey == nil {
+		allErrs = append(allErrs, field.Required(fieldPath, "apiKey cannot be nil"))
+		return allErrs
+	}
+
+	if apiKey.SuppliedIn == nil {
+		allErrs = append(allErrs, field.Required(fieldPath.Child("suppliedIn"), "suppliedIn cannot be nil"))
+		return allErrs
+	}
+
 	if apiKey.SuppliedIn.Query == nil && apiKey.SuppliedIn.Header == nil {
 		msg := "at least one query or header name must be provided"
-		allErrs = append(allErrs, field.Required(fieldPath.Child("SuppliedIn"), msg))
+		allErrs = append(allErrs, field.Required(fieldPath.Child("suppliedIn"), msg))
 	}
 
 	if apiKey.SuppliedIn.Header != nil {
@@ -316,10 +327,10 @@ func validateAPIKey(apiKey *v1.APIKey, fieldPath *field.Path) field.ErrorList {
 	}
 
 	if apiKey.ClientSecret == "" {
-		allErrs = append(allErrs, field.Required(fieldPath.Child("clientSecret"), ""))
+		allErrs = append(allErrs, field.Required(fieldPath.Child("clientSecret"), "clientSecret cannot be empty"))
+	} else {
+		allErrs = append(allErrs, validateSecretName(apiKey.ClientSecret, fieldPath.Child("clientSecret"))...)
 	}
-
-	allErrs = append(allErrs, validateSecretName(apiKey.ClientSecret, fieldPath.Child("clientSecret"))...)
 
 	return allErrs
 }

--- a/pkg/apis/configuration/validation/policy_test.go
+++ b/pkg/apis/configuration/validation/policy_test.go
@@ -1680,6 +1680,16 @@ func TestValidateAPIKeyPolicy_FailsOnInvalidInput(t *testing.T) {
 			},
 			msg: "invalid secret name",
 		},
+		{
+			apiKey: &v1.APIKey{
+				ClientSecret: "secret_1",
+			},
+			msg: "no suppliedIn provided",
+		},
+
+		{
+			apiKey: nil, msg: "no apikey provided",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Proposed changes

Add nil check in apiKey auth policy's suppliedIn field.

Instead of a stack trace, the policy will now be invalid
```
I20241030 11:30:59.581640   1 controller.go:2430] Skipping invalid Policy default/api-key-policy: spec.apiKey.suppliedIn: Required value: suppliedIn cannot be nil
``` 
A VS that uses an invalid policy will then return 500s for each request.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
