### PR TITLE
refactor secret name for clarity

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -572,7 +572,7 @@ func processDefaultServerSecret(ctx context.Context, kubeClient *kubernetes.Clie
 		}
 
 		bytes := configs.GenerateCertAndKeyFileContent(secret)
-		nginxManager.CreateSecret(configs.DefaultServerFileName, bytes, nginx.TLSSecretFileMode)
+		nginxManager.CreateSecret(configs.DefaultServerSecretFileName, bytes, nginx.TLSSecretFileMode)
 	} else {
 		_, err := os.Stat(configs.DefaultServerSecretPath)
 		if err != nil {
@@ -596,7 +596,7 @@ func processWildcardSecret(ctx context.Context, kubeClient *kubernetes.Clientset
 		}
 
 		bytes := configs.GenerateCertAndKeyFileContent(secret)
-		nginxManager.CreateSecret(configs.WildcardFileName, bytes, nginx.TLSSecretFileMode)
+		nginxManager.CreateSecret(configs.WildcardSecretFileName, bytes, nginx.TLSSecretFileMode)
 	}
 	return *wildcardTLSSecret != ""
 }

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -572,7 +572,7 @@ func processDefaultServerSecret(ctx context.Context, kubeClient *kubernetes.Clie
 		}
 
 		bytes := configs.GenerateCertAndKeyFileContent(secret)
-		nginxManager.CreateSecret(configs.DefaultServerSecretName, bytes, nginx.TLSSecretFileMode)
+		nginxManager.CreateSecret(configs.DefaultServerFileName, bytes, nginx.TLSSecretFileMode)
 	} else {
 		_, err := os.Stat(configs.DefaultServerSecretPath)
 		if err != nil {
@@ -596,7 +596,7 @@ func processWildcardSecret(ctx context.Context, kubeClient *kubernetes.Clientset
 		}
 
 		bytes := configs.GenerateCertAndKeyFileContent(secret)
-		nginxManager.CreateSecret(configs.WildcardSecretName, bytes, nginx.TLSSecretFileMode)
+		nginxManager.CreateSecret(configs.WildcardFileName, bytes, nginx.TLSSecretFileMode)
 	}
 	return *wildcardTLSSecret != ""
 }

--- a/internal/configs/configurator.go
+++ b/internal/configs/configurator.go
@@ -47,11 +47,11 @@ const DefaultServerSecretPath = "/etc/nginx/secrets/default" //nolint:gosec // G
 // DefaultSecretPath is the full default path to where secrets are stored and accessed.
 const DefaultSecretPath = "/etc/nginx/secrets" // #nosec G101
 
-// DefaultServerSecretName is the filename of the Secret with a TLS cert and a key for the default server.
-const DefaultServerSecretName = "default"
+// DefaultServerFileName is the filename of the Secret with a TLS cert and a key for the default server.
+const DefaultServerFileName = "default"
 
-// WildcardSecretName is the filename of the Secret with a TLS cert and a key for the ingress resources with TLS termination enabled but not secret defined.
-const WildcardSecretName = "wildcard"
+// WildcardFileName is the filename of the Secret with a TLS cert and a key for the ingress resources with TLS termination enabled but not secret defined.
+const WildcardFileName = "wildcard"
 
 // JWTKeyKey is the key of the data field of a Secret where the JWK must be stored.
 const JWTKeyKey = "jwk"

--- a/internal/configs/configurator.go
+++ b/internal/configs/configurator.go
@@ -47,11 +47,11 @@ const DefaultServerSecretPath = "/etc/nginx/secrets/default" //nolint:gosec // G
 // DefaultSecretPath is the full default path to where secrets are stored and accessed.
 const DefaultSecretPath = "/etc/nginx/secrets" // #nosec G101
 
-// DefaultServerFileName is the filename of the Secret with a TLS cert and a key for the default server.
-const DefaultServerFileName = "default"
+// DefaultServerSecretFileName is the filename of the Secret with a TLS cert and a key for the default server.
+const DefaultServerSecretFileName = "default"
 
-// WildcardFileName is the filename of the Secret with a TLS cert and a key for the ingress resources with TLS termination enabled but not secret defined.
-const WildcardFileName = "wildcard"
+// WildcardSecretFileName is the filename of the Secret with a TLS cert and a key for the ingress resources with TLS termination enabled but not secret defined.
+const WildcardSecretFileName = "wildcard"
 
 // JWTKeyKey is the key of the data field of a Secret where the JWK must be stored.
 const JWTKeyKey = "jwk"

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1656,7 +1656,7 @@ func (lbc *LoadBalancerController) reportCustomResourceStatusEnabled() bool {
 func (lbc *LoadBalancerController) syncSecret(task task) {
 	key := task.Key
 	var obj interface{}
-	var secrExists bool
+	var secretWatched bool
 	var err error
 
 	namespace, name, err := ParseNamespaceName(key)
@@ -1664,7 +1664,7 @@ func (lbc *LoadBalancerController) syncSecret(task task) {
 		nl.Warnf(lbc.Logger, "Secret key %v is invalid: %v", key, err)
 		return
 	}
-	obj, secrExists, err = lbc.getNamespacedInformer(namespace).secretLister.GetByKey(key)
+	obj, secretWatched, err = lbc.getNamespacedInformer(namespace).secretLister.GetByKey(key)
 	if err != nil {
 		lbc.syncQueue.Requeue(task, err)
 		return
@@ -1683,7 +1683,7 @@ func (lbc *LoadBalancerController) syncSecret(task task) {
 
 	nl.Debugf(lbc.Logger, "Found %v Resources with Secret %v", len(resources), key)
 
-	if !secrExists {
+	if !secretWatched {
 		lbc.secretStore.DeleteSecret(key)
 
 		nl.Debugf(lbc.Logger, "Deleting Secret: %v", key)
@@ -1780,9 +1780,9 @@ func (lbc *LoadBalancerController) handleSpecialSecretUpdate(secret *api_v1.Secr
 	secretNsName := secret.Namespace + "/" + secret.Name
 	switch secretNsName {
 	case lbc.specialSecrets.defaultServerSecret:
-		lbc.validationTLSSpecialSecret(secret, configs.DefaultServerSecretName, &specialTLSSecretsToUpdate)
+		lbc.validationTLSSpecialSecret(secret, configs.DefaultServerFileName, &specialTLSSecretsToUpdate)
 	case lbc.specialSecrets.wildcardTLSSecret:
-		lbc.validationTLSSpecialSecret(secret, configs.WildcardSecretName, &specialTLSSecretsToUpdate)
+		lbc.validationTLSSpecialSecret(secret, configs.WildcardFileName, &specialTLSSecretsToUpdate)
 	default:
 		nl.Warnf(lbc.Logger, "special secret not found")
 		return

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1780,9 +1780,9 @@ func (lbc *LoadBalancerController) handleSpecialSecretUpdate(secret *api_v1.Secr
 	secretNsName := secret.Namespace + "/" + secret.Name
 	switch secretNsName {
 	case lbc.specialSecrets.defaultServerSecret:
-		lbc.validationTLSSpecialSecret(secret, configs.DefaultServerFileName, &specialTLSSecretsToUpdate)
+		lbc.validationTLSSpecialSecret(secret, configs.DefaultServerSecretFileName, &specialTLSSecretsToUpdate)
 	case lbc.specialSecrets.wildcardTLSSecret:
-		lbc.validationTLSSpecialSecret(secret, configs.WildcardFileName, &specialTLSSecretsToUpdate)
+		lbc.validationTLSSpecialSecret(secret, configs.WildcardSecretFileName, &specialTLSSecretsToUpdate)
 	default:
 		nl.Warnf(lbc.Logger, "special secret not found")
 		return


### PR DESCRIPTION
### Proposed changes

- Small refactor of some secret file names to have better clarity of what the const is
- Refactor of `secrExists` to `secretWatched` to make that clearer to what it does

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
