### PR TITLE
fix: allow both default & wildcard secrets to be used at the same time

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1778,15 +1778,14 @@ func (lbc *LoadBalancerController) validationTLSSpecialSecret(secret *api_v1.Sec
 func (lbc *LoadBalancerController) handleSpecialSecretUpdate(secret *api_v1.Secret) {
 	var specialTLSSecretsToUpdate []string
 	secretNsName := secret.Namespace + "/" + secret.Name
-	switch secretNsName {
-	case lbc.specialSecrets.defaultServerSecret:
+
+	if secretNsName == lbc.specialSecrets.defaultServerSecret {
 		lbc.validationTLSSpecialSecret(secret, configs.DefaultServerSecretFileName, &specialTLSSecretsToUpdate)
-	case lbc.specialSecrets.wildcardTLSSecret:
-		lbc.validationTLSSpecialSecret(secret, configs.WildcardSecretFileName, &specialTLSSecretsToUpdate)
-	default:
-		nl.Warnf(lbc.Logger, "special secret not found")
-		return
 	}
+	if secretNsName == lbc.specialSecrets.wildcardTLSSecret {
+		lbc.validationTLSSpecialSecret(secret, configs.WildcardSecretFileName, &specialTLSSecretsToUpdate)
+	}
+
 	err := lbc.configurator.AddOrUpdateSpecialTLSSecrets(secret, specialTLSSecretsToUpdate)
 	if err != nil {
 		nl.Errorf(lbc.Logger, "Error when updating the special Secret %v: %v", secretNsName, err)


### PR DESCRIPTION
### Proposed changes

In PR https://github.com/nginxinc/kubernetes-ingress/pull/6808 we refactored special secret updates.  A bug was introduced to only update one special secret if both the default and wildcard secret parameters point to the same secret

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
