### PR TITLE
refactor lbc to add metadata struct

### DIFF
--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -260,6 +260,7 @@ func main() {
 		ExternalServiceName:          *externalService,
 		IngressLink:                  *ingressLink,
 		ControllerNamespace:          controllerNamespace,
+		Pod:                          pod,
 		ReportIngressStatus:          *reportIngressStatus,
 		IsLeaderElectionEnabled:      *leaderElectionEnabled,
 		LeaderElectionLockName:       *leaderElectionLockName,

--- a/internal/k8s/ingress_link.go
+++ b/internal/k8s/ingress_link.go
@@ -56,7 +56,7 @@ func (lbc *LoadBalancerController) addIngressLinkHandler(handlers cache.Resource
 		options.FieldSelector = fields.Set{"metadata.name": name}.String()
 	}
 
-	informer := dynamicinformer.NewFilteredDynamicInformer(lbc.dynClient, ingressLinkGVR, lbc.controllerNamespace, lbc.resync,
+	informer := dynamicinformer.NewFilteredDynamicInformer(lbc.dynClient, ingressLinkGVR, lbc.metadata.namespace, lbc.resync,
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, optionsModifier)
 
 	informer.Informer().AddEventHandlerWithResyncPeriod(handlers, lbc.resync) //nolint:errcheck,gosec

--- a/internal/k8s/leader.go
+++ b/internal/k8s/leader.go
@@ -109,7 +109,7 @@ func createLeaderHandler(lbc *LoadBalancerController) leaderelection.LeaderCallb
 // addLeaderHandler adds the handler for leader election to the controller
 func (lbc *LoadBalancerController) addLeaderHandler(leaderHandler leaderelection.LeaderCallbacks) {
 	var err error
-	lbc.leaderElector, err = newLeaderElector(lbc.client, leaderHandler, lbc.controllerNamespace, lbc.leaderElectionLockName)
+	lbc.leaderElector, err = newLeaderElector(lbc.client, leaderHandler, lbc.metadata.namespace, lbc.leaderElectionLockName)
 	if err != nil {
 		nl.Debugf(lbc.Logger, "Error starting LeaderElection: %v", err)
 	}


### PR DESCRIPTION
### Proposed changes

Add metadata struct to lbc, for the NIC pod and namespace. In the future this can be extended to add other metadata related to NIC.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
