### PR TITLE
rename flag `nginx-configmaps` to `nginx-configmap`

### DIFF
--- a/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/nginx-ingress/templates/_helpers.tpl
@@ -225,7 +225,7 @@ Build the args for the service binary.
 - -app-protect-dos-max-workers={{ .Values.controller.appprotectdos.maxWorkers }}
 - -app-protect-dos-memory={{ .Values.controller.appprotectdos.memory }}
 {{ end }}
-- -nginx-configmaps=$(POD_NAMESPACE)/{{ include "nginx-ingress.configName" . }}
+- -nginx-configmap=$(POD_NAMESPACE)/{{ include "nginx-ingress.configName" . }}
 {{- if .Values.controller.defaultTLS.secret }}
 - -default-server-tls-secret={{ .Values.controller.defaultTLS.secret }}
 {{ else if and (.Values.controller.defaultTLS.cert) (.Values.controller.defaultTLS.key) }}

--- a/charts/tests/__snapshots__/helmunit_test.snap
+++ b/charts/tests/__snapshots__/helmunit_test.snap
@@ -378,7 +378,7 @@ spec:
           - -app-protect-dos-max-workers=5
           - -app-protect-dos-memory=1024
           
-          - -nginx-configmaps=$(POD_NAMESPACE)/appprotect-dos-nginx-ingress
+          - -nginx-configmap=$(POD_NAMESPACE)/appprotect-dos-nginx-ingress
           - -ingress-class=nginx
           - -health-status=false
           - -health-status-uri=/nginx-health
@@ -816,7 +816,7 @@ spec:
           - -nginx-reload-timeout=60000
           - -enable-app-protect=true
           - -enable-app-protect-dos=false
-          - -nginx-configmaps=$(POD_NAMESPACE)/appprotect-waf-nginx-ingress
+          - -nginx-configmap=$(POD_NAMESPACE)/appprotect-waf-nginx-ingress
           - -ingress-class=nginx
           - -health-status=false
           - -health-status-uri=/nginx-health
@@ -1271,7 +1271,7 @@ spec:
           - -enable-app-protect=true
           - -app-protect-enforcer-address="localhost:50001"
           - -enable-app-protect-dos=false
-          - -nginx-configmaps=$(POD_NAMESPACE)/appprotect-wafv5-nginx-ingress
+          - -nginx-configmap=$(POD_NAMESPACE)/appprotect-wafv5-nginx-ingress
           - -ingress-class=nginx
           - -health-status=false
           - -health-status-uri=/nginx-health
@@ -1706,7 +1706,7 @@ spec:
           - -nginx-reload-timeout=60000
           - -enable-app-protect=false
           - -enable-app-protect-dos=false
-          - -nginx-configmaps=$(POD_NAMESPACE)/custom-resources-nginx-ingress
+          - -nginx-configmap=$(POD_NAMESPACE)/custom-resources-nginx-ingress
           - -ingress-class=nginx
           - -health-status=false
           - -health-status-uri=/nginx-health
@@ -2128,7 +2128,7 @@ spec:
           - -nginx-reload-timeout=60000
           - -enable-app-protect=false
           - -enable-app-protect-dos=false
-          - -nginx-configmaps=$(POD_NAMESPACE)/daemonset-nginx-ingress
+          - -nginx-configmap=$(POD_NAMESPACE)/daemonset-nginx-ingress
           - -ingress-class=nginx
           - -health-status=false
           - -health-status-uri=/nginx-health
@@ -2556,7 +2556,7 @@ spec:
           - -nginx-reload-timeout=60000
           - -enable-app-protect=false
           - -enable-app-protect-dos=false
-          - -nginx-configmaps=$(POD_NAMESPACE)/default-nginx-ingress
+          - -nginx-configmap=$(POD_NAMESPACE)/default-nginx-ingress
           - -ingress-class=nginx
           - -health-status=false
           - -health-status-uri=/nginx-health
@@ -2984,7 +2984,7 @@ spec:
           - -nginx-reload-timeout=60000
           - -enable-app-protect=false
           - -enable-app-protect-dos=false
-          - -nginx-configmaps=$(POD_NAMESPACE)/global-configuration-nginx-ingress
+          - -nginx-configmap=$(POD_NAMESPACE)/global-configuration-nginx-ingress
           - -ingress-class=nginx
           - -health-status=false
           - -health-status-uri=/nginx-health
@@ -3434,7 +3434,7 @@ spec:
           - -nginx-reload-timeout=60000
           - -enable-app-protect=false
           - -enable-app-protect-dos=false
-          - -nginx-configmaps=$(POD_NAMESPACE)/ingress-class-nginx-ingress
+          - -nginx-configmap=$(POD_NAMESPACE)/ingress-class-nginx-ingress
           - -ingress-class=changed
           - -health-status=false
           - -health-status-uri=/nginx-health
@@ -3864,7 +3864,7 @@ spec:
           - -nginx-reload-timeout=60000
           - -enable-app-protect=false
           - -enable-app-protect-dos=false
-          - -nginx-configmaps=$(POD_NAMESPACE)/namespace-nginx-ingress
+          - -nginx-configmap=$(POD_NAMESPACE)/namespace-nginx-ingress
           - -ingress-class=nginx
           - -health-status=false
           - -health-status-uri=/nginx-health
@@ -4292,7 +4292,7 @@ spec:
           - -nginx-reload-timeout=60000
           - -enable-app-protect=false
           - -enable-app-protect-dos=false
-          - -nginx-configmaps=$(POD_NAMESPACE)/plus-nginx-ingress
+          - -nginx-configmap=$(POD_NAMESPACE)/plus-nginx-ingress
           - -ingress-class=nginx
           - -health-status=false
           - -health-status-uri=/nginx-health

--- a/cmd/nginx-ingress/flags.go
+++ b/cmd/nginx-ingress/flags.go
@@ -50,7 +50,7 @@ var (
 	watchNamespaceLabel = flag.String("watch-namespace-label", "",
 		`Configures the Ingress Controller to watch only those namespaces with label foo=bar. By default the Ingress Controller watches all namespaces. Mutually exclusive with "watch-namespace". `)
 
-	nginxConfigMaps = flag.String("nginx-configmaps", "",
+	nginxConfigMap = flag.String("nginx-configmap", "",
 		`A ConfigMap resource for customizing NGINX configuration. If a ConfigMap is set,
 	but the Ingress Controller is not able to fetch it from Kubernetes API, the Ingress Controller will fail to start.
 	Format: <namespace>/<name>`)

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -265,7 +265,7 @@ func main() {
 		IsLeaderElectionEnabled:      *leaderElectionEnabled,
 		LeaderElectionLockName:       *leaderElectionLockName,
 		WildcardTLSSecret:            *wildcardTLSSecret,
-		ConfigMaps:                   *nginxConfigMaps,
+		ConfigMaps:                   *nginxConfigMap,
 		GlobalConfiguration:          *globalConfiguration,
 		AreCustomResourcesEnabled:    *enableCustomResources,
 		EnableOIDC:                   *enableOIDC,
@@ -875,14 +875,14 @@ func mustProcessGlobalConfiguration(ctx context.Context) {
 
 func processConfigMaps(kubeClient *kubernetes.Clientset, cfgParams *configs.ConfigParams, nginxManager nginx.Manager, templateExecutor *version1.TemplateExecutor, eventLog record.EventRecorder) *configs.ConfigParams {
 	l := nl.LoggerFromContext(cfgParams.Context)
-	if *nginxConfigMaps != "" {
-		ns, name, err := k8s.ParseNamespaceName(*nginxConfigMaps)
+	if *nginxConfigMap != "" {
+		ns, name, err := k8s.ParseNamespaceName(*nginxConfigMap)
 		if err != nil {
-			nl.Fatalf(l, "Error parsing the nginx-configmaps argument: %v", err)
+			nl.Fatalf(l, "Error parsing the nginx-configmap argument: %v", err)
 		}
 		cfm, err := kubeClient.CoreV1().ConfigMaps(ns).Get(context.TODO(), name, meta_v1.GetOptions{})
 		if err != nil {
-			nl.Fatalf(l, "Error when getting %v: %v", *nginxConfigMaps, err)
+			nl.Fatalf(l, "Error when getting %v: %v", *nginxConfigMap, err)
 		}
 		cfgParams, _ = configs.ParseConfigMap(cfgParams.Context, cfm, *nginxPlus, *appProtect, *appProtectDos, *enableTLSPassthrough, eventLog)
 		if cfgParams.MainServerSSLDHParamFileContent != nil {

--- a/cmd/nginx-ingress/main.go
+++ b/cmd/nginx-ingress/main.go
@@ -265,7 +265,7 @@ func main() {
 		IsLeaderElectionEnabled:      *leaderElectionEnabled,
 		LeaderElectionLockName:       *leaderElectionLockName,
 		WildcardTLSSecret:            *wildcardTLSSecret,
-		ConfigMaps:                   *nginxConfigMap,
+		ConfigMap:                    *nginxConfigMap,
 		GlobalConfiguration:          *globalConfiguration,
 		AreCustomResourcesEnabled:    *enableCustomResources,
 		EnableOIDC:                   *enableOIDC,

--- a/deployments/daemon-set/nginx-ingress.yaml
+++ b/deployments/daemon-set/nginx-ingress.yaml
@@ -87,7 +87,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         args:
-          - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
+          - -nginx-configmap=$(POD_NAMESPACE)/nginx-config
           - -report-ingress-status
           - -external-service=nginx-ingress
          #- -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret

--- a/deployments/daemon-set/nginx-plus-ingress.yaml
+++ b/deployments/daemon-set/nginx-plus-ingress.yaml
@@ -88,7 +88,7 @@ spec:
               fieldPath: metadata.name
         args:
           - -nginx-plus
-          - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
+          - -nginx-configmap=$(POD_NAMESPACE)/nginx-config
           - -report-ingress-status
           - -external-service=nginx-ingress
          #- -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret

--- a/deployments/deployment/nginx-ingress.yaml
+++ b/deployments/deployment/nginx-ingress.yaml
@@ -86,7 +86,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         args:
-          - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
+          - -nginx-configmap=$(POD_NAMESPACE)/nginx-config
           - -report-ingress-status
           - -external-service=nginx-ingress
          #- -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret

--- a/deployments/deployment/nginx-plus-ingress.yaml
+++ b/deployments/deployment/nginx-plus-ingress.yaml
@@ -89,7 +89,7 @@ spec:
               fieldPath: metadata.name
         args:
           - -nginx-plus
-          - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
+          - -nginx-configmap=$(POD_NAMESPACE)/nginx-config
           - -report-ingress-status
           - -external-service=nginx-ingress
          #- -default-server-tls-secret=$(POD_NAMESPACE)/default-server-secret

--- a/examples/custom-resources/service-insight/README.md
+++ b/examples/custom-resources/service-insight/README.md
@@ -59,7 +59,7 @@ spec:
         ...
         args:
           - -nginx-plus
-          - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
+          - -nginx-configmap=$(POD_NAMESPACE)/nginx-config
         ...
           - -enable-service-insight
 
@@ -348,7 +348,7 @@ spec:
         ...
         args:
           - -nginx-plus
-          - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
+          - -nginx-configmap=$(POD_NAMESPACE)/nginx-config
         ...
           - -enable-service-insight
           - -service-insight-tls-secret=default/service-insight-secret
@@ -399,7 +399,7 @@ Containers:
     Host Ports:    0/TCP, 0/TCP, 0/TCP, 0/TCP, 0/TCP
     Args:
       -nginx-plus
-      -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
+      -nginx-configmap=$(POD_NAMESPACE)/nginx-config
       ...
       -enable-service-insight
       -service-insight-tls-secret=default/service-insight-secret

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -133,7 +133,7 @@ type LoadBalancerController struct {
 	Logger                        *slog.Logger
 	cancel                        context.CancelFunc
 	configurator                  *configs.Configurator
-	watchNginxConfigMaps          bool
+	watchNginxConfigMap           bool
 	watchGlobalConfiguration      bool
 	watchIngressLink              bool
 	isNginxPlus                   bool
@@ -208,7 +208,7 @@ type NewLoadBalancerControllerInput struct {
 	IsLeaderElectionEnabled      bool
 	LeaderElectionLockName       string
 	WildcardTLSSecret            string
-	ConfigMaps                   string
+	ConfigMap                    string
 	GlobalConfiguration          string
 	AreCustomResourcesEnabled    bool
 	EnableOIDC                   bool
@@ -271,7 +271,7 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 		isLatencyMetricsEnabled:      input.IsLatencyMetricsEnabled,
 		isIPV6Disabled:               input.IsIPV6Disabled,
 		weightChangesDynamicReload:   input.DynamicWeightChangesReload,
-		nginxConfigMapName:           input.ConfigMaps,
+		nginxConfigMapName:           input.ConfigMap,
 	}
 
 	lbc.syncQueue = newTaskQueue(lbc.Logger, lbc.sync)
@@ -316,13 +316,13 @@ func NewLoadBalancerController(input NewLoadBalancerControllerInput) *LoadBalanc
 		}
 	}
 
-	if input.ConfigMaps != "" {
-		nginxConfigMapsNS, nginxConfigMapsName, err := ParseNamespaceName(input.ConfigMaps)
+	if input.ConfigMap != "" {
+		nginxConfigMapNS, nginxConfigMapName, err := ParseNamespaceName(input.ConfigMap)
 		if err != nil {
 			nl.Warn(lbc.Logger, err)
 		} else {
-			lbc.watchNginxConfigMaps = true
-			lbc.addConfigMapHandler(createConfigMapHandlers(lbc, nginxConfigMapsName), nginxConfigMapsNS)
+			lbc.watchNginxConfigMap = true
+			lbc.addConfigMapHandler(createConfigMapHandlers(lbc, nginxConfigMapName), nginxConfigMapNS)
 		}
 	}
 
@@ -617,7 +617,7 @@ func (lbc *LoadBalancerController) Run() {
 		nif.start()
 	}
 
-	if lbc.watchNginxConfigMaps {
+	if lbc.watchNginxConfigMap {
 		go lbc.configMapController.Run(lbc.ctx.Done())
 	}
 

--- a/site/content/configuration/global-configuration/command-line-arguments.md
+++ b/site/content/configuration/global-configuration/command-line-arguments.md
@@ -217,11 +217,11 @@ Path to the main NGINX configuration template.
 - Default for NGINX is `nginx.tmpl`.
 - Default for NGINX Plus is `nginx-plus.tmpl`.
 
-<a name="cmdoption-nginx-configmaps"></a>
+<a name="cmdoption-nginx-configmap"></a>
 
 ---
 
-### -nginx-configmaps `<string>`
+### -nginx-configmap `<string>`
 
 A ConfigMap resource for customizing NGINX configuration. If a ConfigMap is set, but NGINX Ingress Controller is not able to fetch it from Kubernetes API, NGINX Ingress Controller will fail to start.
 

--- a/site/content/installation/integrations/app-protect-waf-v5/compile-waf-policies.md
+++ b/site/content/installation/integrations/app-protect-waf-v5/compile-waf-policies.md
@@ -292,7 +292,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         args:
-          - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
+          - -nginx-configmap=$(POD_NAMESPACE)/nginx-config
           - -report-ingress-status
           - -external-service=nginx-ingress
 ```

--- a/site/content/troubleshooting/troubleshoot-common.md
+++ b/site/content/troubleshooting/troubleshoot-common.md
@@ -91,7 +91,7 @@ Here is a small snippet of setting these command line arguments in the `args` se
 
 ```yaml
 args:
-  - -nginx-configmaps=$(POD_NAMESPACE)/nginx-config
+  - -nginx-configmap=$(POD_NAMESPACE)/nginx-config
   - -enable-cert-manager
   - -nginx-debug
   - -log-level=debug


### PR DESCRIPTION
### Proposed changes

The flag `nginx-configmaps` was plural, but only took in one configmap. This changes it to be singular (`nginx-configmap`), and matches the new `mgmt-configmap`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

