### PR TITLE
prevent auto publishing docs on push to release branch

### DIFF
--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -17,14 +17,17 @@ on:
         required: false
         default: ''
         type: string
+  workflow_call:
+    inputs:
+      environment:
+        description: "Environment to deploy to"
+        required: true
+        type: string
   pull_request:
     branches:
       - "*"
     paths:
       - "site/**"
-  push:
-    branches:
-      - "release-3.7"
 
 permissions:
   contents: read
@@ -43,8 +46,6 @@ jobs:
       doc_type: "hugo"
       environment: ${{ inputs.environment }}
       force_hugo_theme_version: ${{inputs.hugo_theme_override}}
-      auto_deploy_branch: "release-3.7"
-      auto_deploy_env: "prod"
     secrets:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS_DOCS }}
       AZURE_KEY_VAULT: ${{ secrets.AZURE_KEY_VAULT_DOCS }}


### PR DESCRIPTION
### Proposed changes

This change prevents auto-publishing of docs from the release branch.  This would be an issue when the release branch is created as we do not want the initial docs to be live.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
