### PR TITLE
Docs: Fix link in security.md

### DIFF
--- a/site/content/configuration/security.md
+++ b/site/content/configuration/security.md
@@ -34,7 +34,7 @@ By default, the ServiceAccount has access to all Secret resources in the cluster
 ### Configure root filesystem as read-only
 
 {{< caution >}}
- This feature is compatible with [NGINX App Protect WAFv5](https://docs.nginx.com/nginx-app-protect-waf-v5/). It is not compatible with [NGINX App Protect WAF](https://docs.nginx.com/nginx-app-protect-waf/) or [NGINX App Protect DoS](https://docs.nginx.com/nginx-app-protect-dos/).
+ This feature is compatible with [NGINX App Protect WAFv5](https://docs.nginx.com/nginx-app-protect-waf/v5/). It is not compatible with [NGINX App Protect WAFv4](https://docs.nginx.com/nginx-app-protect-waf/v4/) or [NGINX App Protect DoS](https://docs.nginx.com/nginx-app-protect-dos/).
 {{< /caution >}}
 
 NGINX Ingress Controller is designed to be resilient against attacks in various ways, such as running the service as non-root to avoid changes to files. We recommend setting filesystems on all containers to read-only, this includes `nginx-ingress-controller`, though also includes `waf-enforcer` and `waf-config-mgr` when NGINX App Protect WAFv5 is in use.  This is so that the attack surface is further reduced by limiting changes to binaries and libraries.


### PR DESCRIPTION
Broken link found in kubernetes-ingress by Docs Nightly Automation Testing

Fixing a broken link to WAFv5 docs.
- Typo in newly added link in KIC docs here https://docs.nginx.com/nginx-ingress-controller/configuration/security#configure-root-filesystem-as-read-only
- Actual: https://docs.nginx.com/nginx-app-protect-waf-v5/
- Expected: https://docs.nginx.com/nginx-app-protect-waf/v5/

Also making the "incompatible link" more specific to v4 to avoid confusion. Previously it was bringing user to top level WAF which included v4 & v5. 

**Please Merge and Cherry Pick into release branch if approved.**

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
