### PR TITLE
remove index annotations from AWS marketplace images

### DIFF
--- a/.github/workflows/build-plus.yml
+++ b/.github/workflows/build-plus.yml
@@ -100,7 +100,7 @@ jobs:
           labels: |
             org.opencontainers.image.description=NGINX Plus Ingress Controller for Kubernetes
         env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: ${{ contains(inputs.target, 'aws') && 'manifest' || 'manifest,index' }}
 
       - name: Set base name variable
         id: base_name


### PR DESCRIPTION
### Proposed changes

AWS images are failing with
```
ERROR: failed to solve: index annotations not supported for single platform export
```

Remove index annotations from AWS images

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
