### PR TITLE
Update NGINX Ingress Controller to 5.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,5 +56,5 @@ jobs:
     with:
       chart_version: ${{ inputs.chart_version }}
       operator_version: ${{ inputs.operator_version }}
-      k8s_version: "1.33.1"
+      k8s_version: "v1.33.1"
       dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
This automated PR updates the NGINX Ingress Controller to 5.0.0.
        The Helm Chart was updated to 2.1.0.
        The Operator was updated to 1.0.0.
        Kubernetes was updated to v1.32.3.