### PR TITLE
fix status updates for VS endpoints 

### DIFF
--- a/internal/k8s/status.go
+++ b/internal/k8s/status.go
@@ -405,7 +405,7 @@ func (su *statusUpdater) retryUpdateVirtualServerRouteStatus(vsrCopy *conf_v1.Vi
 	return nil
 }
 
-func hasVsStatusChanged(vs *conf_v1.VirtualServer, state string, reason string, message string) bool {
+func (su *statusUpdater) hasVsStatusChanged(vs *conf_v1.VirtualServer, state string, reason string, message string) bool {
 	if vs.Status.State != state {
 		return true
 	}
@@ -415,6 +415,10 @@ func hasVsStatusChanged(vs *conf_v1.VirtualServer, state string, reason string, 
 	}
 
 	if vs.Status.Message != message {
+		return true
+	}
+
+	if !reflect.DeepEqual(vs.Status.ExternalEndpoints, su.externalEndpoints) {
 		return true
 	}
 
@@ -486,7 +490,7 @@ func (su *statusUpdater) UpdateVirtualServerStatus(vs *conf_v1.VirtualServer, st
 
 	vsCopy := vsLatest.(*conf_v1.VirtualServer).DeepCopy()
 
-	if !hasVsStatusChanged(vsCopy, state, reason, message) {
+	if !su.hasVsStatusChanged(vsCopy, state, reason, message) {
 		return nil
 	}
 
@@ -503,7 +507,7 @@ func (su *statusUpdater) UpdateVirtualServerStatus(vs *conf_v1.VirtualServer, st
 	return err
 }
 
-func hasVsrStatusChanged(vsr *conf_v1.VirtualServerRoute, state string, reason string, message string, referencedByString string) bool {
+func (su *statusUpdater) hasVsrStatusChanged(vsr *conf_v1.VirtualServerRoute, state string, reason string, message string, referencedByString string) bool {
 	if vsr.Status.State != state {
 		return true
 	}
@@ -517,6 +521,10 @@ func hasVsrStatusChanged(vsr *conf_v1.VirtualServerRoute, state string, reason s
 	}
 
 	if referencedByString != "" && vsr.Status.ReferencedBy != referencedByString {
+		return true
+	}
+
+	if !reflect.DeepEqual(vsr.Status.ExternalEndpoints, su.externalEndpoints) {
 		return true
 	}
 
@@ -548,7 +556,7 @@ func (su *statusUpdater) UpdateVirtualServerRouteStatusWithReferencedBy(vsr *con
 
 	vsrCopy := vsrLatest.(*conf_v1.VirtualServerRoute).DeepCopy()
 
-	if !hasVsrStatusChanged(vsrCopy, state, reason, message, referencedByString) {
+	if !su.hasVsrStatusChanged(vsrCopy, state, reason, message, referencedByString) {
 		return nil
 	}
 
@@ -587,7 +595,7 @@ func (su *statusUpdater) UpdateVirtualServerRouteStatus(vsr *conf_v1.VirtualServ
 
 	vsrCopy := vsrLatest.(*conf_v1.VirtualServerRoute).DeepCopy()
 
-	if !hasVsrStatusChanged(vsrCopy, state, reason, message, "") {
+	if !su.hasVsrStatusChanged(vsrCopy, state, reason, message, "") {
 		return nil
 	}
 


### PR DESCRIPTION
### Proposed changes

- Fix status updates for VS when `external-status-address` is set via configmap, relevant doc: https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/reporting-resources-status/

Closes https://github.com/nginx/kubernetes-ingress/issues/8073

cm:
```
Name:         test-release-nginx-ingress
Namespace:    default
Data
====
external-status-address:
----
10.0.0.2

```

before:
```
NAME       STATE   HOST                   IP              PORTS      AGE
cafe       Valid   cafe-vs.example.com    10.0.0.2        [80,443]   33m <- New VS
keycloak   Valid   keycloak.example.com   35.233.10.138   [80,443]   24h <- Old VS
webapp     Valid   webapp.example.com     35.233.10.138   [80,443]   24h <- Old VS
```
after:
```
NAME       STATE   HOST                   IP         PORTS      AGE
cafe       Valid   cafe-vs.example.com    10.0.0.2   [80,443]   33m
keycloak   Valid   keycloak.example.com   10.0.0.2   [80,443]   24h
webapp     Valid   webapp.example.com     10.0.0.2   [80,443]   24h
```
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
