### PR TITLE
remove type field for objects with schema ref

### DIFF
--- a/charts/nginx-ingress/values.schema.json
+++ b/charts/nginx-ingress/values.schema.json
@@ -1349,7 +1349,7 @@
             "allocateLoadBalancerNodePorts": {
               "default": false,
               "title": "The allocateLoadBalancerNodePorts Schema",
-              "ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.33.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/allocateLoadBalancerNodePorts"
+              "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.33.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/allocateLoadBalancerNodePorts"
             },
             "ipFamilyPolicy": {
               "default": "",
@@ -1362,7 +1362,7 @@
             "ipFamilies": {
               "default": [],
               "title": "The ipFamilies Schema",
-              "ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.33.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/ipFamilies"
+              "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.33.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServiceSpec/properties/ipFamilies"
             },
             "httpPort": {
               "type": "object",
@@ -1483,7 +1483,7 @@
               "default": [],
               "title": "The customPorts",
               "items": {
-                "ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.33.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServicePort"
+                "$ref": "https://raw.githubusercontent.com/nginxinc/kubernetes-json-schema/master/v1.33.1/_definitions.json#/definitions/io.k8s.api.core.v1.ServicePort"
               }
             },
             "sessionAffinity": {


### PR DESCRIPTION
### Proposed changes

- remove `type` from schema file for objects with `ref` to external schema

fixes:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
nginx-ingress:
- at '/controller/topologySpreadConstraints': got array, want object

```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
