### PR TITLE
Migrate client secret to OIDC for Azure Marketplace

### DIFF
--- a/.github/workflows/plus-release.yml
+++ b/.github/workflows/plus-release.yml
@@ -279,12 +279,16 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.gcr-auth.outputs.access_token }}
 
-      - name: Login to ACR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      - name: Azure login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
-          registry: nginxmktpl.azurecr.io
-          username: ${{ secrets.AZ_MKTPL_ID }}
-          password: ${{ secrets.AZ_MKTPL_SECRET }}
+          client-id: ${{ secrets.AZURE_MKTPL_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_MKTPL_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_MKTPL_SUBSCRIPTION_ID }}
+
+      - name: Azure Container Registry login
+        run: |
+          az acr login --name nginxmktpl
 
       - name: Publish images
         run: |


### PR DESCRIPTION
### Proposed changes

Replace client secret authentication with Github OIDC for publishing Azure marketplace images.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
