### PR TITLE
Add proxy_ssl_verify and related nginx directives to OIDC configuration

### DIFF
--- a/internal/configs/oidc/oidc.conf
+++ b/internal/configs/oidc/oidc.conf
@@ -12,7 +12,12 @@
         proxy_cache jwk;                              # Cache the JWK Set received from IdP
         proxy_cache_valid 200 12h;                    # How long to consider keys "fresh"
         proxy_cache_use_stale error timeout updating; # Use old JWK Set if cannot reach IdP
-        proxy_ssl_server_name on;                     # For SNI to the IdP
+
+        proxy_ssl_verify on;                          # Enforce TLS certificate verification
+        proxy_ssl_verify_depth 2;                     # Allow intermediate CA chains of depth 2
+        proxy_ssl_server_name on;                     # Send SNI to IdP host
+        proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt; # Use system CA bundle
+
         proxy_method GET;                             # In case client request was non-GET
         proxy_set_header Content-Length "";           # ''
         proxy_pass $oidc_jwt_keyfile;                 # Expecting to find a URI here
@@ -42,7 +47,11 @@
         # Exclude client headers to avoid CORS errors with certain IdPs (e.g., Microsoft Entra ID)
         proxy_pass_request_headers off;
 
-        proxy_ssl_server_name on; # For SNI to the IdP
+        proxy_ssl_verify on;         # Enforce TLS certificate verification
+        proxy_ssl_verify_depth 2;    # Allow intermediate CA chains of depth 2
+        proxy_ssl_server_name on;    # Send SNI to IdP host
+        proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt; # Use system CA bundle
+
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_header      Authorization $arg_secret_basic;
         proxy_pass            $oidc_token_endpoint;
@@ -57,7 +66,11 @@
         # Exclude client headers to avoid CORS errors with certain IdPs (e.g., Microsoft Entra ID)
         proxy_pass_request_headers off;
 
-        proxy_ssl_server_name on; # For SNI to the IdP
+        proxy_ssl_verify on;         # Enforce TLS certificate verification
+        proxy_ssl_verify_depth 2;    # Allow intermediate CA chains of depth 2
+        proxy_ssl_server_name on;    # Send SNI to IdP host
+        proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt; # Use system CA bundle
+
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_header      Authorization $arg_secret_basic;
         proxy_pass            $oidc_token_endpoint;


### PR DESCRIPTION
### Proposed changes

Sync commit https://github.com/nginxinc/nginx-openid-connect/commit/c866e23e730495d0ceb8419052e130650065ac88 from upstream repo.  This adds the upstream TLS verification directives to the called IDP endpoint.

Upgrade testing completed with v5.2.1 and `examples/custom-resources/oidc`.  Adding self-signed TLS to upstream IDP without also having the self-signed cert CA added to the pod CA list causes authentication to fail.

*Note, this change is debian specific, users of Alpine or UBI images will need to mount a CA bundle to `/etc/ssl/certs/ca-certificates.crt`*

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
