### PR TITLE
Fix shell variable globbing issue using quotes

### DIFF
--- a/.github/scripts/release-docs.sh
+++ b/.github/scripts/release-docs.sh
@@ -75,7 +75,6 @@ if [ "${DEBUG}" != "false" ]; then
 fi
 
 echo "INFO: Generating release notes from github draft release"
-# shellcheck disable=SC2086
 release_notes_content=$("${ROOTDIR}"/.github/scripts/pull-release-notes.py "${ic_version}" "${helm_chart_version}" "${k8s_versions}" "${release_date}")
 if [ $? -ne 0 ]; then
     echo "ERROR: failed to fetch release notes from GitHub draft release for version ${ic_version}"


### PR DESCRIPTION
### Proposed changes

Release PR workflow crashes out possibly due to not recognising inputs. This update adds quotes around that part of the workflow.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
