### PR TITLE
Update the NAP threat campaigns version

### DIFF
--- a/tests/data/modules/data.json
+++ b/tests/data/modules/data.json
@@ -92,7 +92,7 @@
         },
         {
           "name": "app-protect-threat-campaigns",
-          "version": "2025"
+          "version": "2026"
         },
         {
           "name": "nginx-agent",
@@ -214,7 +214,7 @@
         },
         {
           "name": "app-protect-threat-campaigns",
-          "version": "2025"
+          "version": "2026"
         },
         {
           "name": "nginx-plus-module-appprotectdos",
@@ -361,7 +361,7 @@
         },
         {
           "name": "app-protect-threat-campaigns",
-          "version": "2025"
+          "version": "2026"
         }
       ],
       "system": "alpine",
@@ -507,7 +507,7 @@
         },
         {
           "name": "app-protect-threat-campaigns",
-          "version": "2025"
+          "version": "2026"
         }
       ],
       "system": "ubi",
@@ -595,7 +595,7 @@
         },
         {
           "name": "app-protect-threat-campaigns",
-          "version": "2025"
+          "version": "2026"
         }
       ],
       "system": "ubi",
@@ -721,7 +721,7 @@
         },
         {
           "name": "app-protect-threat-campaigns",
-          "version": "2025"
+          "version": "2026"
         },
         {
           "name": "app-protect-dos",


### PR DESCRIPTION
### Proposed changes

NAP seems to have released a new version of their threat campaign module. And thus all our tests are failing.

Waiting for them to confirm this happened.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
