### PR TITLE
Update app-protect-attack-signatures to 2026 versions

### DIFF
--- a/tests/data/modules/data.json
+++ b/tests/data/modules/data.json
@@ -88,7 +88,7 @@
         },
         {
           "name": "app-protect-attack-signatures",
-          "version": "2025"
+          "version": "2026"
         },
         {
           "name": "app-protect-threat-campaigns",
@@ -210,7 +210,7 @@
         },
         {
           "name": "app-protect-attack-signatures",
-          "version": "2025"
+          "version": "2026"
         },
         {
           "name": "app-protect-threat-campaigns",
@@ -357,7 +357,7 @@
         },
         {
           "name": "app-protect-attack-signatures",
-          "version": "2025"
+          "version": "2026"
         },
         {
           "name": "app-protect-threat-campaigns",
@@ -503,7 +503,7 @@
         },
         {
           "name": "app-protect-attack-signatures",
-          "version": "2025"
+          "version": "2026"
         },
         {
           "name": "app-protect-threat-campaigns",
@@ -591,7 +591,7 @@
         },
         {
           "name": "app-protect-attack-signatures",
-          "version": "2025"
+          "version": "2026"
         },
         {
           "name": "app-protect-threat-campaigns",
@@ -717,7 +717,7 @@
         },
         {
           "name": "app-protect-attack-signatures",
-          "version": "2025"
+          "version": "2026"
         },
         {
           "name": "app-protect-threat-campaigns",


### PR DESCRIPTION
### Proposed changes

The F5 WAF for NGINX team have updated their attack signatures version to 2026, this change updates our expected package versions to reflect that.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
