### PR TITLE
Do not specify null nodePort

### DIFF
--- a/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/nginx-ingress/templates/controller-service.yaml
@@ -52,7 +52,9 @@ spec:
     protocol: TCP
     name: {{ .Values.controller.service.httpPort.name }}
   {{- if or (eq .Values.controller.service.type "LoadBalancer") (eq .Values.controller.service.type "NodePort") }}
-    nodePort: {{ .Values.controller.service.httpPort.nodePort }}
+    {{- with .Values.controller.service.httpPort.nodePort }}
+    nodePort: {{ . }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- if .Values.controller.service.httpsPort.enable }}
@@ -61,7 +63,9 @@ spec:
     protocol: TCP
     name: {{ .Values.controller.service.httpsPort.name }}
   {{- if or (eq .Values.controller.service.type "LoadBalancer") (eq .Values.controller.service.type "NodePort") }}
-    nodePort: {{ .Values.controller.service.httpsPort.nodePort }}
+    {{- with .Values.controller.service.httpsPort.nodePort }}
+    nodePort: {{ . }}
+    {{- end }}
   {{- end }}
 {{- end }}
   selector:


### PR DESCRIPTION


### Proposed changes

When installing the Helm chart, I have the following diff in ArgoCD:

```diff

===== /Service nginx-ingress/nginx-ingress-controller ======
--- /tmp/argocd-diff326846605/nginx-ingress-controller-live.yaml	2026-01-21 14:13:48.435116990 +0000
+++ /tmp/argocd-diff326846605/nginx-ingress-controller	2026-01-21 14:13:48.434116990 +0000
@@ -63,24 +63,22 @@
   clusterIPs:
   - 10.96.28.189
   externalTrafficPolicy: Local
   healthCheckNodePort: 31260
   internalTrafficPolicy: Cluster
   ipFamilies:
   - IPv4
   ipFamilyPolicy: SingleStack
   ports:
   - name: http
-    nodePort: 32489
     port: 80
     protocol: TCP
     targetPort: 80
   - name: https
-    nodePort: 30182
     port: 443
     protocol: TCP
     targetPort: 443
   selector:
     app.kubernetes.io/instance: nginx-ingress
     app.kubernetes.io/name: nginx-ingress
   sessionAffinity: None
   type: LoadBalancer
```

(with default values).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
