### PR TITLE
Update preflight to 1.16.0 & track version with renovate

### DIFF
--- a/.github/actions/certify-openshift-image/action.yml
+++ b/.github/actions/certify-openshift-image/action.yml
@@ -14,7 +14,7 @@ inputs:
   preflight_version:
     description: The version of the preflight utility to install
     required: false
-    default: 1.9.1
+    default: 1.16.0
   platforms:
     description: A comma separated list of architectures in the image manifest to certify
     required: false
@@ -47,14 +47,14 @@ runs:
           IFS=',' read -ra arch_list <<< "${{ inputs.platforms }}"
           for arch in "${arch_list[@]}"; do
               architecture=("${arch#*/}")
-              ./preflight check container ${{ inputs.image }} --pyxis-api-token ${{ inputs.pyxis_token }} --certification-project-id ${{ inputs.project_id }} --platform $architecture ${{ inputs.submit && '--submit' || '' }}
+              ./preflight check container ${{ inputs.image }} --pyxis-api-token ${{ inputs.pyxis_token }} --certification-component-id ${{ inputs.project_id }} --platform $architecture ${{ inputs.submit && '--submit' || '' }}
               if [ $? -ne 0 ]; then
                 result=1
               fi
           done
         else
           # no platforms passed, this is either a manifest or a single platform image
-          ./preflight check container ${{ inputs.image }} --pyxis-api-token ${{ inputs.pyxis_token }} --certification-project-id ${{ inputs.project_id }} ${{ inputs.submit && '--submit' || '' }}
+          ./preflight check container ${{ inputs.image }} --pyxis-api-token ${{ inputs.pyxis_token }} --certification-component-id ${{ inputs.project_id }} ${{ inputs.submit && '--submit' || '' }}
           result=$?
         fi
         echo "result=$result" >> $GITHUB_OUTPUT

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -328,7 +328,7 @@ jobs:
           image: quay.io/nginx/nginx-ingress:edge-ubi
           project_id: ${{ steps.secrets.outputs.PYXIS_CERTIFICATION_PROJECT_ID }}
           pyxis_token: ${{ steps.secrets.outputs.PYXIS_TOKEN }}
-          preflight_version: 1.14.1
+          preflight_version: 1.16.0 # renovate: datasource=github-releases depName=preflight packageName=redhat-openshift-ecosystem/openshift-preflight
 
   scan-docker-oss:
     name: Scan ${{ matrix.image }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,7 +361,7 @@ jobs:
           image: quay.io/nginx/nginx-ingress:${{ inputs.nic_version }}-ubi
           project_id: ${{ steps.secrets.outputs.PYXIS_CERTIFICATION_PROJECT_ID }}
           pyxis_token: ${{ steps.secrets.outputs.PYXIS_TOKEN }}
-          preflight_version: 1.14.1
+          preflight_version: 1.16.0 # renovate: datasource=github-releases depName=preflight packageName=redhat-openshift-ecosystem/openshift-preflight
 
   operator:
     if: ${{ ! cancelled() && ! failure() && ! inputs.dry_run && ! contains(inputs.skip_step, 'operator') && !contains(inputs.skip_step, 'publish-helm-chart') }}

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -205,5 +205,5 @@ jobs:
           project_id: ${{ steps.secrets.outputs.PYXIS_CERTIFICATION_PROJECT_ID }}
           pyxis_token: ${{ steps.secrets.outputs.PYXIS_TOKEN }}
           platforms: ""
-          preflight_version: 1.14.1
+          preflight_version: 1.16.0 # renovate: datasource=github-releases depName=preflight packageName=redhat-openshift-ecosystem/openshift-preflight
           submit: ${{ ! inputs.dry_run || true }}


### PR DESCRIPTION
### Proposed changes

- Update preflight version to 1.16.0
- Update the certification id flag to `--certification-component-id` to match the new preflight version
- Have renovate track the preflight version

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
