### PR TITLE
use correct manifest sha for building cares dependency

### DIFF
--- a/build/dependencies/Dockerfile.ubi9
+++ b/build/dependencies/Dockerfile.ubi9
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.21
-FROM redhat/ubi9:9.7-1764794285@sha256:adeb7e06f3fd702a24b98dc7569e2a5aae6bd76799cb2051a216e12f05711e2d AS rpm-build
+FROM redhat/ubi9:9.7-1764794285@sha256:d4feb579a84ead49894ec71fe54f14300992e202f3491d9bb22b62cc57affd49 AS rpm-build
 RUN mkdir -p /rpms/ \
     && dnf install rpm-build gcc make cmake -y \
     && rpmbuild --rebuild --nodebuginfo https://mirror.stream.centos.org/9-stream/BaseOS/source/tree/Packages/c-ares-1.19.1-2.el9.src.rpm \


### PR DESCRIPTION
### Proposed changes

Image sha in this file was set to be `amd64` only, whereas we need multi platform build of the dependency.
This change uses correct manifest sha for multi-platform builds.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
