### PR TITLE
add policy owner type 

### DIFF
--- a/internal/configs/ingress.go
+++ b/internal/configs/ingress.go
@@ -154,7 +154,7 @@ func generateNginxCfg(ncp NginxCfgParams) (version1.IngressNginxConfig, Warnings
 		var warnings Warnings
 		ownerDetails := policyOwnerDetails{
 			owner:           ncp.ingEx.Ingress,
-			ownerType:       "ingress",
+			ownerType:       "ing",
 			ownerName:       ncp.ingEx.Ingress.Name,
 			ownerNamespace:  ncp.ingEx.Ingress.Namespace,
 			parentName:      ncp.ingEx.Ingress.Name,

--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -599,9 +599,7 @@ func (p *policiesCfg) addAPIKeyConfig(
 	apiKey *conf_v1.APIKey,
 	polKey string,
 	polNamespace string,
-	parentNamespace string,
-	parentName string,
-	ownerType string,
+	ownerDetails policyOwnerDetails,
 	secretRefs map[string]*secrets.SecretReference,
 ) *validationResults {
 	res := newValidationResults()
@@ -632,11 +630,11 @@ func (p *policiesCfg) addAPIKeyConfig(
 
 	p.APIKey.Clients = generateAPIKeyClients(secretRef.Secret.Data)
 
-	ownerTypeName := formatOwnerType(ownerType)
+	ownerTypeName := formatOwnerType(ownerDetails.ownerType)
 	mapName := fmt.Sprintf(
 		"apikey_auth_client_name_%s_%s_%s_%s",
-		rfc1123ToSnake(parentNamespace),
-		rfc1123ToSnake(parentName),
+		rfc1123ToSnake(ownerDetails.parentNamespace),
+		rfc1123ToSnake(ownerDetails.parentName),
 		ownerTypeName,
 		strings.Split(rfc1123ToSnake(polKey), "/")[1],
 	)
@@ -735,7 +733,7 @@ func (p *policiesCfg) addWAFConfig(
 func (p *policiesCfg) addCacheConfig(
 	cache *conf_v1.Cache,
 	polKey string,
-	parentNamespace, parentName, ownerNamespace, ownerName, ownerType string,
+	ownerDetails policyOwnerDetails,
 ) *validationResults {
 	res := newValidationResults()
 	if p.Cache != nil {
@@ -743,31 +741,31 @@ func (p *policiesCfg) addCacheConfig(
 		return res
 	}
 
-	p.Cache = generateCacheConfig(cache, parentNamespace, parentName, ownerNamespace, ownerName, ownerType)
+	p.Cache = generateCacheConfig(cache, ownerDetails)
 	return res
 }
 
 // generateCORSVariableName creates a unique variable name for CORS map based on VS/VSR owner details.
-func generateCORSVariableName(polKey, parentNamespace, parentName, ownerNamespace, ownerName, ownerType string) string {
+func generateCORSVariableName(polKey string, ownerDetails policyOwnerDetails) string {
 	polNamespace, polName, ok := strings.Cut(polKey, "/")
-	ownerTypeName := formatOwnerType(ownerType)
+	ownerTypeName := formatOwnerType(ownerDetails.ownerType)
 	if !ok || polNamespace == "" || polName == "" {
-		if parentNamespace == ownerNamespace && parentName == ownerName {
-			return fmt.Sprintf("cors_origin_%s_%s_%s", rfc1123ToSnake(parentNamespace), rfc1123ToSnake(parentName), ownerTypeName)
+		if ownerDetails.parentNamespace == ownerDetails.ownerNamespace && ownerDetails.parentName == ownerDetails.ownerName {
+			return fmt.Sprintf("cors_origin_%s_%s_%s", rfc1123ToSnake(ownerDetails.parentNamespace), rfc1123ToSnake(ownerDetails.parentName), ownerTypeName)
 		}
 		return fmt.Sprintf("cors_origin_%s_%s_%s_%s_%s",
-			rfc1123ToSnake(parentNamespace),
-			rfc1123ToSnake(parentName),
-			rfc1123ToSnake(ownerNamespace),
-			rfc1123ToSnake(ownerName),
+			rfc1123ToSnake(ownerDetails.parentNamespace),
+			rfc1123ToSnake(ownerDetails.parentName),
+			rfc1123ToSnake(ownerDetails.ownerNamespace),
+			rfc1123ToSnake(ownerDetails.ownerName),
 			ownerTypeName,
 		)
 	}
 
-	if parentNamespace == ownerNamespace && parentName == ownerName {
+	if ownerDetails.parentNamespace == ownerDetails.ownerNamespace && ownerDetails.parentName == ownerDetails.ownerName {
 		return fmt.Sprintf("cors_origin_%s_%s_%s_%s_%s",
-			rfc1123ToSnake(parentNamespace),
-			rfc1123ToSnake(parentName),
+			rfc1123ToSnake(ownerDetails.parentNamespace),
+			rfc1123ToSnake(ownerDetails.parentName),
 			ownerTypeName,
 			rfc1123ToSnake(polNamespace),
 			rfc1123ToSnake(polName),
@@ -775,10 +773,10 @@ func generateCORSVariableName(polKey, parentNamespace, parentName, ownerNamespac
 	}
 
 	return fmt.Sprintf("cors_origin_%s_%s_%s_%s_%s_%s_%s",
-		rfc1123ToSnake(parentNamespace),
-		rfc1123ToSnake(parentName),
-		rfc1123ToSnake(ownerNamespace),
-		rfc1123ToSnake(ownerName),
+		rfc1123ToSnake(ownerDetails.parentNamespace),
+		rfc1123ToSnake(ownerDetails.parentName),
+		rfc1123ToSnake(ownerDetails.ownerNamespace),
+		rfc1123ToSnake(ownerDetails.ownerName),
 		ownerTypeName,
 		rfc1123ToSnake(polNamespace),
 		rfc1123ToSnake(polName),
@@ -943,11 +941,7 @@ func generateCORSHeaders(cors *conf_v1.CORS, originValue string) []version2.AddH
 func (p *policiesCfg) addCORSConfig(
 	cors *conf_v1.CORS,
 	polKey string,
-	parentNamespace,
-	parentName,
-	ownerNamespace,
-	ownerName,
-	ownerType string,
+	ownerDetails policyOwnerDetails,
 ) *validationResults {
 	res := newValidationResults()
 
@@ -958,7 +952,7 @@ func (p *policiesCfg) addCORSConfig(
 		} else if len(cors.AllowOrigin) == 1 && !isWildcardOrigin(cors.AllowOrigin[0]) {
 			originValue = escapeNginxString(cors.AllowOrigin[0])
 		} else {
-			policyVarName := generateCORSVariableName(polKey, parentNamespace, parentName, ownerNamespace, ownerName, ownerType)
+			policyVarName := generateCORSVariableName(polKey, ownerDetails)
 			originValue = fmt.Sprintf("$%s", policyVarName)
 			p.CORSMap = generateCORSOriginMap(cors.AllowOrigin, policyVarName)
 		}
@@ -1024,14 +1018,13 @@ func generatePolicies(
 			case pol.Spec.OIDC != nil:
 				res = config.addOIDCConfig(pol.Spec.OIDC, key, polNamespace, policyOpts)
 			case pol.Spec.APIKey != nil:
-				res = config.addAPIKeyConfig(pol.Spec.APIKey, key, polNamespace, ownerDetails.parentNamespace,
-					ownerDetails.parentName, ownerDetails.ownerType, policyOpts.secretRefs)
+				res = config.addAPIKeyConfig(pol.Spec.APIKey, key, polNamespace, ownerDetails, policyOpts.secretRefs)
 			case pol.Spec.WAF != nil:
 				res = config.addWAFConfig(ctx, pol.Spec.WAF, key, polNamespace, policyOpts.apResources)
 			case pol.Spec.Cache != nil:
-				res = config.addCacheConfig(pol.Spec.Cache, key, ownerDetails.parentNamespace, ownerDetails.parentName, ownerDetails.ownerNamespace, ownerDetails.ownerName, ownerDetails.ownerType)
+				res = config.addCacheConfig(pol.Spec.Cache, key, ownerDetails)
 			case pol.Spec.CORS != nil:
-				res = config.addCORSConfig(pol.Spec.CORS, key, ownerDetails.parentNamespace, ownerDetails.parentName, ownerDetails.ownerNamespace, ownerDetails.ownerName, ownerDetails.ownerType)
+				res = config.addCORSConfig(pol.Spec.CORS, key, ownerDetails)
 			default:
 				res = newValidationResults()
 			}
@@ -1264,25 +1257,25 @@ func generateAuthJwtClaimSet(jwtCondition conf_v1.JWTCondition, owner policyOwne
 	}
 }
 
-func generateAuthJwtClaimSetVariable(claim string, parentNamespace string, parentName string) string {
-	return strings.ReplaceAll(fmt.Sprintf("$jwt_%v_%v_%v", parentNamespace, parentName, strings.Join(strings.Split(claim, "."), "_")), "-", "_")
+func generateAuthJwtClaimSetVariable(claim string, namespace string, name string) string {
+	return strings.ReplaceAll(fmt.Sprintf("$jwt_%v_%v_%v", namespace, name, strings.Join(strings.Split(claim, "."), "_")), "-", "_")
 }
 
 func generateAuthJwtClaimSetClaim(claim string) string {
 	return strings.Join(strings.Split(claim, "."), " ")
 }
 
-func generateCacheConfig(cache *conf_v1.Cache, parentNamespace, parentName, ownerNamespace, ownerName, ownerType string) *version2.Cache {
+func generateCacheConfig(cache *conf_v1.Cache, ownerDetails policyOwnerDetails) *version2.Cache {
 	// Create unique zone name including VS namespace/name and owner namespace/name for policy reuse
 	// This ensures that the same cache policy can be safely reused across different VS/VSR
-	ownerTypeName := formatOwnerType(ownerType)
+	ownerTypeName := formatOwnerType(ownerDetails.ownerType)
 	var uniqueZoneName string
-	if parentNamespace == ownerNamespace && parentName == ownerName {
+	if ownerDetails.parentNamespace == ownerDetails.ownerNamespace && ownerDetails.parentName == ownerDetails.ownerName {
 		// Policy is applied directly to VirtualServer, use VS namespace/name only
-		uniqueZoneName = fmt.Sprintf("%s_%s_%s_%s", parentNamespace, parentName, ownerTypeName, cache.CacheZoneName)
+		uniqueZoneName = fmt.Sprintf("%s_%s_%s_%s", ownerDetails.parentNamespace, ownerDetails.parentName, ownerTypeName, cache.CacheZoneName)
 	} else {
 		// Policy is applied to VirtualServerRoute, include both VS and owner info
-		uniqueZoneName = fmt.Sprintf("%s_%s_%s_%s_%s_%s", parentNamespace, parentName, ownerNamespace, ownerName, ownerTypeName, cache.CacheZoneName)
+		uniqueZoneName = fmt.Sprintf("%s_%s_%s_%s_%s_%s", ownerDetails.parentNamespace, ownerDetails.parentName, ownerDetails.ownerNamespace, ownerDetails.ownerName, ownerTypeName, cache.CacheZoneName)
 	}
 
 	// Set cache key with default if not provided

--- a/internal/configs/policy_test.go
+++ b/internal/configs/policy_test.go
@@ -23,7 +23,7 @@ func TestGeneratePolicies(t *testing.T) {
 	ctx := context.Background()
 	ownerDetails := policyOwnerDetails{
 		owner:           nil, // nil is OK for the unit test
-		ownerType:       "virtualserver",
+		ownerType:       "vs",
 		ownerNamespace:  "default",
 		parentNamespace: "default",
 		parentName:      "test",
@@ -910,7 +910,7 @@ func TestGeneratePolicies(t *testing.T) {
 					Key: &version2.APIKey{
 						Header:  []string{"X-API-Key"},
 						Query:   []string{"api-key"},
-						MapName: "apikey_auth_client_name_default_test_virtualserver_api_key_policy",
+						MapName: "apikey_auth_client_name_default_test_vs_api_key_policy",
 					},
 					Enabled:   true,
 					ClientMap: nil,
@@ -954,7 +954,7 @@ func TestGeneratePolicies(t *testing.T) {
 					Key: &version2.APIKey{
 						Header:  []string{"X-API-Key"},
 						Query:   []string{"api-key"},
-						MapName: "apikey_auth_client_name_default_test_virtualserver_api_key_policy",
+						MapName: "apikey_auth_client_name_default_test_vs_api_key_policy",
 					},
 					Enabled:   true,
 					ClientMap: nil,
@@ -1027,7 +1027,7 @@ func TestGeneratePolicies(t *testing.T) {
 			expected: policiesCfg{
 				Context: ctx,
 				Cache: &version2.Cache{
-					ZoneName: "default_test_virtualserver_basic-cache",
+					ZoneName: "default_test_vs_basic-cache",
 					ZoneSize: "10m",
 					Valid:    map[string]string{},
 					CacheKey: "$scheme$proxy_host$request_uri",
@@ -1088,7 +1088,7 @@ func TestGeneratePolicies(t *testing.T) {
 			expected: policiesCfg{
 				Context: ctx,
 				Cache: &version2.Cache{
-					ZoneName:              "default_test_virtualserver_full-cache",
+					ZoneName:              "default_test_vs_full-cache",
 					ZoneSize:              "100m",
 					Time:                  "1h",
 					Valid:                 map[string]string{"any": "1h"},
@@ -1147,7 +1147,7 @@ func TestGeneratePolicies(t *testing.T) {
 			expected: policiesCfg{
 				Context: ctx,
 				Cache: &version2.Cache{
-					ZoneName: "default_test_virtualserver_status-cache",
+					ZoneName: "default_test_vs_status-cache",
 					ZoneSize: "50m",
 					Time:     "30m",
 					Valid: map[string]string{
@@ -1186,7 +1186,7 @@ func TestGeneratePolicies(t *testing.T) {
 			expected: policiesCfg{
 				Context: ctx,
 				Cache: &version2.Cache{
-					ZoneName:       "default_test_virtualserver_methods-cache",
+					ZoneName:       "default_test_vs_methods-cache",
 					ZoneSize:       "25m",
 					Valid:          map[string]string{},
 					AllowedMethods: []string{"GET", "HEAD"},
@@ -1221,7 +1221,7 @@ func TestGeneratePolicies(t *testing.T) {
 			expected: policiesCfg{
 				Context: ctx,
 				Cache: &version2.Cache{
-					ZoneName:        "default_test_virtualserver_purge-cache",
+					ZoneName:        "default_test_vs_purge-cache",
 					ZoneSize:        "75m",
 					Valid:           map[string]string{},
 					CachePurgeAllow: []string{"192.168.1.0/24", "10.0.0.1"},
@@ -1254,7 +1254,7 @@ func TestGeneratePolicies(t *testing.T) {
 			expected: policiesCfg{
 				Context: ctx,
 				Cache: &version2.Cache{
-					ZoneName: "default_test_virtualserver_implicit-cache",
+					ZoneName: "default_test_vs_implicit-cache",
 					ZoneSize: "15m",
 					Time:     "45m",
 					Valid:    map[string]string{},
@@ -1339,7 +1339,7 @@ func TestAddCORSConfig(t *testing.T) {
 			expected: policiesCfg{
 				CORSHeaders: []version2.AddHeader{
 					{Header: version2.Header{Name: "Vary", Value: "Origin"}, Always: true},
-					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_test_vs_default_cors_policy_virtualserver_default_cors_policy"}, Always: true},
+					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_test_vs_default_cors_policy_vs_default_cors_policy"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Methods", Value: "GET, POST, PUT, DELETE"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Headers", Value: "Content-Type"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Credentials", Value: "true"}, Always: true},
@@ -1348,7 +1348,7 @@ func TestAddCORSConfig(t *testing.T) {
 				},
 				CORSMap: &version2.Map{
 					Source:   "$http_origin",
-					Variable: "$cors_origin_default_test_vs_default_cors_policy_virtualserver_default_cors_policy",
+					Variable: "$cors_origin_default_test_vs_default_cors_policy_vs_default_cors_policy",
 					Parameters: []version2.Parameter{
 						{Value: "default", Result: `""`},
 						{Value: `"https://app.example.com"`, Result: "https://app.example.com"},
@@ -1374,12 +1374,12 @@ func TestAddCORSConfig(t *testing.T) {
 			expected: policiesCfg{
 				CORSHeaders: []version2.AddHeader{
 					{Header: version2.Header{Name: "Vary", Value: "Origin"}, Always: true},
-					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_test_vs_default_cors_policy_virtualserver_default_cors_policy"}, Always: true},
+					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_test_vs_default_cors_policy_vs_default_cors_policy"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Methods", Value: "GET, POST"}, Always: true},
 				},
 				CORSMap: &version2.Map{
 					Source:   "$http_origin",
-					Variable: "$cors_origin_default_test_vs_default_cors_policy_virtualserver_default_cors_policy",
+					Variable: "$cors_origin_default_test_vs_default_cors_policy_vs_default_cors_policy",
 					Parameters: []version2.Parameter{
 						{Value: "default", Result: `""`},
 						{Value: "~^https://[^.]+\\.example\\.com$", Result: "$http_origin"},
@@ -1397,13 +1397,13 @@ func TestAddCORSConfig(t *testing.T) {
 			expected: policiesCfg{
 				CORSHeaders: []version2.AddHeader{
 					{Header: version2.Header{Name: "Vary", Value: "Origin"}, Always: true},
-					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_test_vs_default_cors_policy_virtualserver_default_cors_policy"}, Always: true},
+					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_test_vs_default_cors_policy_vs_default_cors_policy"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Methods", Value: "GET, POST, PUT"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Headers", Value: "Content-Type, Authorization"}, Always: true},
 				},
 				CORSMap: &version2.Map{
 					Source:   "$http_origin",
-					Variable: "$cors_origin_default_test_vs_default_cors_policy_virtualserver_default_cors_policy",
+					Variable: "$cors_origin_default_test_vs_default_cors_policy_vs_default_cors_policy",
 					Parameters: []version2.Parameter{
 						{Value: "default", Result: `""`},
 						{Value: `"https://api.example.com"`, Result: "https://api.example.com"},
@@ -1420,11 +1420,11 @@ func TestAddCORSConfig(t *testing.T) {
 			expected: policiesCfg{
 				CORSHeaders: []version2.AddHeader{
 					{Header: version2.Header{Name: "Vary", Value: "Origin"}, Always: true},
-					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_test_vs_default_cors_policy_virtualserver_default_cors_policy"}, Always: true},
+					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_test_vs_default_cors_policy_vs_default_cors_policy"}, Always: true},
 				},
 				CORSMap: &version2.Map{
 					Source:   "$http_origin",
-					Variable: "$cors_origin_default_test_vs_default_cors_policy_virtualserver_default_cors_policy",
+					Variable: "$cors_origin_default_test_vs_default_cors_policy_vs_default_cors_policy",
 					Parameters: []version2.Parameter{
 						{Value: "default", Result: `""`},
 						{Value: "~^http://[^.]+\\.localhost\\.dev$", Result: "$http_origin"},
@@ -1440,7 +1440,14 @@ func TestAddCORSConfig(t *testing.T) {
 
 			config := &policiesCfg{}
 			polKey := "default/cors-policy"
-			res := config.addCORSConfig(test.cors, polKey, "default", "test-vs", "default", "cors-policy", "virtualserver")
+			ownerDetails := policyOwnerDetails{
+				ownerType:       "vs",
+				ownerNamespace:  "default",
+				ownerName:       "cors-policy",
+				parentNamespace: "default",
+				parentName:      "test-vs",
+			}
+			res := config.addCORSConfig(test.cors, polKey, ownerDetails)
 
 			// Check that no validation errors occurred
 			if len(res.warnings) > 0 {
@@ -1487,7 +1494,7 @@ func TestGenerateCORSPolicy(t *testing.T) {
 		{
 			name: "VirtualServer with single origin CORS policy",
 			owner: policyOwnerDetails{
-				ownerType:       "virtualserver",
+				ownerType:       "vs",
 				ownerNamespace:  "default",
 				ownerName:       "test-vs",
 				parentNamespace: "default",
@@ -1524,7 +1531,7 @@ func TestGenerateCORSPolicy(t *testing.T) {
 		{
 			name: "VirtualServer with multiple origins CORS policy",
 			owner: policyOwnerDetails{
-				ownerType:       "virtualserver",
+				ownerType:       "vs",
 				ownerNamespace:  "default",
 				ownerName:       "test-vs",
 				parentNamespace: "default",
@@ -1552,7 +1559,7 @@ func TestGenerateCORSPolicy(t *testing.T) {
 				Context: ctx,
 				CORSHeaders: []version2.AddHeader{
 					{Header: version2.Header{Name: "Vary", Value: "Origin"}, Always: true},
-					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_test_vs_virtualserver_default_multi_origin_cors"}, Always: true},
+					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_test_vs_vs_default_multi_origin_cors"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Methods", Value: "GET, POST, PUT, DELETE, OPTIONS"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Headers", Value: "Content-Type, Authorization, X-Requested-With"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Credentials", Value: "true"}, Always: true},
@@ -1561,7 +1568,7 @@ func TestGenerateCORSPolicy(t *testing.T) {
 				},
 				CORSMap: &version2.Map{
 					Source:   "$http_origin",
-					Variable: "$cors_origin_default_test_vs_virtualserver_default_multi_origin_cors",
+					Variable: "$cors_origin_default_test_vs_vs_default_multi_origin_cors",
 					Parameters: []version2.Parameter{
 						{Value: "default", Result: `""`},
 						{Value: `"https://app.example.com"`, Result: "https://app.example.com"},
@@ -1574,7 +1581,7 @@ func TestGenerateCORSPolicy(t *testing.T) {
 		{
 			name: "VirtualServer with wildcard CORS policy",
 			owner: policyOwnerDetails{
-				ownerType:       "virtualserver",
+				ownerType:       "vs",
 				ownerNamespace:  "default",
 				ownerName:       "test-vs",
 				parentNamespace: "default",
@@ -1608,7 +1615,7 @@ func TestGenerateCORSPolicy(t *testing.T) {
 		{
 			name: "VirtualServerRoute with CORS policy",
 			owner: policyOwnerDetails{
-				ownerType:       "virtualserverroute",
+				ownerType:       "vsr",
 				ownerNamespace:  "app-namespace",
 				ownerName:       "test-vsr",
 				parentNamespace: "default",
@@ -1647,7 +1654,7 @@ func TestGenerateCORSPolicy(t *testing.T) {
 		{
 			name: "VirtualServerRoute with cross-namespace CORS policy",
 			owner: policyOwnerDetails{
-				ownerType:       "virtualserverroute",
+				ownerType:       "vsr",
 				ownerNamespace:  "app-namespace",
 				ownerName:       "test-vsr",
 				parentNamespace: "default",
@@ -1673,14 +1680,14 @@ func TestGenerateCORSPolicy(t *testing.T) {
 				Context: ctx,
 				CORSHeaders: []version2.AddHeader{
 					{Header: version2.Header{Name: "Vary", Value: "Origin"}, Always: true},
-					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_parent_vs_app_namespace_test_vsr_virtualserverroute_shared_policies_shared_cors"}, Always: true},
+					{Header: version2.Header{Name: "Access-Control-Allow-Origin", Value: "$cors_origin_default_parent_vs_app_namespace_test_vsr_vsr_shared_policies_shared_cors"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Methods", Value: "GET, POST, DELETE"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Headers", Value: "Authorization, Content-Type"}, Always: true},
 					{Header: version2.Header{Name: "Access-Control-Allow-Credentials", Value: "true"}, Always: true},
 				},
 				CORSMap: &version2.Map{
 					Source:   "$http_origin",
-					Variable: "$cors_origin_default_parent_vs_app_namespace_test_vsr_virtualserverroute_shared_policies_shared_cors",
+					Variable: "$cors_origin_default_parent_vs_app_namespace_test_vsr_vsr_shared_policies_shared_cors",
 					Parameters: []version2.Parameter{
 						{Value: "default", Result: `""`},
 						{Value: `"https://api.example.com"`, Result: "https://api.example.com"},
@@ -1727,7 +1734,7 @@ func TestGeneratePolicies_GeneratesWAFPolicyOnValidApBundle(t *testing.T) {
 
 	ownerDetails := policyOwnerDetails{
 		owner:           nil, // nil is OK for the unit test
-		ownerType:       "virtualserver",
+		ownerType:       "vs",
 		ownerNamespace:  "default",
 		parentNamespace: "default",
 		parentName:      "test",
@@ -1823,7 +1830,7 @@ func TestGeneratePoliciesFails(t *testing.T) {
 	t.Parallel()
 	ownerDetails := policyOwnerDetails{
 		owner:           nil, // nil is OK for the unit test
-		ownerType:       "virtualserver",
+		ownerType:       "vs",
 		ownerName:       "test",
 		ownerNamespace:  "default",
 		parentNamespace: "default",

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -426,7 +426,7 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 
 	ownerDetails := policyOwnerDetails{
 		owner:           vsEx.VirtualServer,
-		ownerType:       "virtualserver",
+		ownerType:       "vs",
 		ownerName:       vsEx.VirtualServer.Name,
 		ownerNamespace:  vsEx.VirtualServer.Namespace,
 		parentNamespace: vsEx.VirtualServer.Namespace,
@@ -615,7 +615,7 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 		vsLocSnippets := r.LocationSnippets
 		ownerDetails := policyOwnerDetails{
 			owner:           vsEx.VirtualServer,
-			ownerType:       "virtualserver",
+			ownerType:       "vs",
 			ownerName:       vsEx.VirtualServer.Name,
 			ownerNamespace:  vsEx.VirtualServer.Namespace,
 			parentNamespace: vsEx.VirtualServer.Namespace,
@@ -781,7 +781,7 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 				// use the VirtualServer route policies if the route does not define any
 				ownerDetails = policyOwnerDetails{
 					owner:           vsEx.VirtualServer,
-					ownerType:       "virtualserver",
+					ownerType:       "vs",
 					ownerName:       vsEx.VirtualServer.Name,
 					ownerNamespace:  vsEx.VirtualServer.Namespace,
 					parentNamespace: vsEx.VirtualServer.Namespace,
@@ -792,7 +792,7 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 			} else {
 				ownerDetails = policyOwnerDetails{
 					owner:           vsr,
-					ownerType:       "virtualserverroute",
+					ownerType:       "vsr",
 					ownerName:       vsr.Name,
 					ownerNamespace:  vsr.Namespace,
 					parentNamespace: vsEx.VirtualServer.Namespace,

--- a/internal/configs/virtualserver_test.go
+++ b/internal/configs/virtualserver_test.go
@@ -6186,7 +6186,7 @@ func TestGenerateVirtualServerConfigAPIKeyPolicy(t *testing.T) {
 		Maps: []version2.Map{
 			{
 				Source:   "$apikey_auth_token",
-				Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy_route",
+				Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy_route",
 				Parameters: []version2.Parameter{
 					{
 						Value:  "default",
@@ -6200,7 +6200,7 @@ func TestGenerateVirtualServerConfigAPIKeyPolicy(t *testing.T) {
 			},
 			{
 				Source:   "$apikey_auth_token",
-				Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy_spec",
+				Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy_spec",
 				Parameters: []version2.Parameter{
 					{
 						Value:  "default",
@@ -6266,7 +6266,7 @@ func TestGenerateVirtualServerConfigAPIKeyPolicy(t *testing.T) {
 			APIKey: &version2.APIKey{
 				Header:  []string{"X-API-Key"},
 				Query:   []string{"apikey"},
-				MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy_spec",
+				MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy_spec",
 			},
 			Locations: []version2.Location{
 				{
@@ -6293,7 +6293,7 @@ func TestGenerateVirtualServerConfigAPIKeyPolicy(t *testing.T) {
 					ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 					ServiceName:              "coffee-svc",
 					APIKey: &version2.APIKey{
-						MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy_route",
+						MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy_route",
 						Query:   []string{"api-key"},
 					},
 				},
@@ -6435,19 +6435,19 @@ func TestGenerateVirtualServerConfigAPIKeyClientMaps(t *testing.T) {
 	}
 
 	expectedAPIKey1 := &version2.APIKey{
-		MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy_1",
+		MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy_1",
 		Header:  []string{"X-API-Key"},
 		Query:   []string{"apikey"},
 	}
 
 	expectedAPIKey2 := &version2.APIKey{
-		MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy_2",
+		MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy_2",
 		Header:  []string{"api-key"},
 	}
 
 	expectedMap1 := version2.Map{
 		Source:   "$apikey_auth_token",
-		Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy_1",
+		Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy_1",
 		Parameters: []version2.Parameter{
 			{
 				Value:  "default",
@@ -6462,7 +6462,7 @@ func TestGenerateVirtualServerConfigAPIKeyClientMaps(t *testing.T) {
 
 	expectedMap2 := version2.Map{
 		Source:   "$apikey_auth_token",
-		Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy_2",
+		Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy_2",
 		Parameters: []version2.Parameter{
 			{
 				Value:  "default",
@@ -9149,7 +9149,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					},
 					{
 						Source:   "$apikey_auth_token",
-						Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy",
 						Parameters: []version2.Parameter{
 							{
 								Value:  "default",
@@ -9266,7 +9266,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					APIKey: &version2.APIKey{
 						Header:  []string{"X-API-Key"},
 						Query:   []string{"api-key"},
-						MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy",
 					},
 				},
 			},
@@ -9445,7 +9445,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					},
 					{
 						Source:   "$apikey_auth_token",
-						Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy",
 						Parameters: []version2.Parameter{
 							{
 								Value:  "default",
@@ -9560,7 +9560,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					APIKey: &version2.APIKey{
 						Header:  []string{"X-API-Key"},
 						Query:   []string{"api-key"},
-						MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy",
 					},
 				},
 			},
@@ -9744,7 +9744,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					},
 					{
 						Source:   "$apikey_auth_token",
-						Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy",
 						Parameters: []version2.Parameter{
 							{
 								Value:  "default",
@@ -9860,7 +9860,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					APIKey: &version2.APIKey{
 						Header:  []string{"X-API-Key"},
 						Query:   []string{"api-key"},
-						MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy",
 					},
 				},
 			},
@@ -10046,7 +10046,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					},
 					{
 						Source:   "$apikey_auth_token",
-						Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy",
 						Parameters: []version2.Parameter{
 							{
 								Value:  "default",
@@ -10163,7 +10163,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					APIKey: &version2.APIKey{
 						Header:  []string{"X-API-Key"},
 						Query:   []string{"api-key"},
-						MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy",
 					},
 				},
 			},
@@ -10311,7 +10311,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 				Maps: []version2.Map{
 					{
 						Source:   "$apikey_auth_token",
-						Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy",
 						Parameters: []version2.Parameter{
 							{
 								Value:  "default",
@@ -10529,7 +10529,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					APIKey: &version2.APIKey{
 						Header:  []string{"X-API-Key"},
 						Query:   []string{"api-key"},
-						MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy",
 					},
 				},
 			},
@@ -10688,7 +10688,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 				Maps: []version2.Map{
 					{
 						Source:   "$apikey_auth_token",
-						Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy",
 						Parameters: []version2.Parameter{
 							{
 								Value:  "default",
@@ -10854,7 +10854,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					APIKey: &version2.APIKey{
 						Header:  []string{"X-API-Key"},
 						Query:   []string{"api-key"},
-						MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy",
 					},
 				},
 			},
@@ -11021,7 +11021,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 				Maps: []version2.Map{
 					{
 						Source:   "$apikey_auth_token",
-						Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy",
 						Parameters: []version2.Parameter{
 							{
 								Value:  "default",
@@ -11242,7 +11242,7 @@ func TestGenerateVirtualServerConfigRateLimitGroups(t *testing.T) {
 					APIKey: &version2.APIKey{
 						Header:  []string{"X-API-Key"},
 						Query:   []string{"api-key"},
-						MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy",
 					},
 				},
 			},
@@ -11669,9 +11669,9 @@ func TestGenerateVirtualServerConfigCache(t *testing.T) {
 				LimitReqZones: []version2.LimitReqZone{},
 				CacheZones: []version2.CacheZone{
 					{
-						Name:   "default_cafe_virtualserver_my-cache",
+						Name:   "default_cafe_vs_my-cache",
 						Size:   "10m",
-						Path:   "/var/cache/nginx/default_cafe_virtualserver_my-cache",
+						Path:   "/var/cache/nginx/default_cafe_vs_my-cache",
 						Levels: "",
 					},
 				},
@@ -11682,7 +11682,7 @@ func TestGenerateVirtualServerConfigCache(t *testing.T) {
 					VSNamespace:  "default",
 					VSName:       "cafe",
 					Cache: &version2.Cache{
-						ZoneName:              "default_cafe_virtualserver_my-cache",
+						ZoneName:              "default_cafe_vs_my-cache",
 						ZoneSize:              "10m",
 						Time:                  "1h",
 						Valid:                 map[string]string{},
@@ -11825,9 +11825,9 @@ func TestGenerateVirtualServerConfigCache(t *testing.T) {
 				LimitReqZones: []version2.LimitReqZone{},
 				CacheZones: []version2.CacheZone{
 					{
-						Name:   "default_cafe_virtualserver_route-cache",
+						Name:   "default_cafe_vs_route-cache",
 						Size:   "5m",
-						Path:   "/var/cache/nginx/default_cafe_virtualserver_route-cache",
+						Path:   "/var/cache/nginx/default_cafe_vs_route-cache",
 						Levels: "",
 					},
 				},
@@ -11849,7 +11849,7 @@ func TestGenerateVirtualServerConfigCache(t *testing.T) {
 							ProxySetHeaders:          []version2.Header{{Name: "Host", Value: "$host"}},
 							ServiceName:              "tea-svc",
 							Cache: &version2.Cache{
-								ZoneName:              "default_cafe_virtualserver_route-cache",
+								ZoneName:              "default_cafe_vs_route-cache",
 								ZoneSize:              "5m",
 								Time:                  "30m",
 								Valid:                 map[string]string{"200": "30m", "404": "30m"},
@@ -12029,9 +12029,9 @@ func TestGenerateVirtualServerConfigCache(t *testing.T) {
 				LimitReqZones: []version2.LimitReqZone{},
 				CacheZones: []version2.CacheZone{
 					{
-						Name:    "default_cafe_default_tea-vsr_virtualserverroute_vsr-cache",
+						Name:    "default_cafe_default_tea-vsr_vsr_vsr-cache",
 						Size:    "20m",
-						Path:    "/var/cache/nginx/default_cafe_default_tea-vsr_virtualserverroute_vsr-cache",
+						Path:    "/var/cache/nginx/default_cafe_default_tea-vsr_vsr_vsr-cache",
 						Levels:  "2:2",
 						MinFree: "100m",
 					},
@@ -12057,7 +12057,7 @@ func TestGenerateVirtualServerConfigCache(t *testing.T) {
 							VSRName:                  "tea-vsr",
 							VSRNamespace:             "default",
 							Cache: &version2.Cache{
-								ZoneName:              "default_cafe_default_tea-vsr_virtualserverroute_vsr-cache",
+								ZoneName:              "default_cafe_default_tea-vsr_vsr_vsr-cache",
 								ZoneSize:              "20m",
 								Time:                  "2h",
 								Valid:                 map[string]string{},
@@ -12190,9 +12190,9 @@ func TestGenerateVirtualServerConfigCache(t *testing.T) {
 				LimitReqZones: []version2.LimitReqZone{},
 				CacheZones: []version2.CacheZone{
 					{
-						Name:             "default_extended-cache_virtualserver_extended-cache",
+						Name:             "default_extended-cache_vs_extended-cache",
 						Size:             "100m",
-						Path:             "/var/cache/nginx/default_extended-cache_virtualserver_extended-cache",
+						Path:             "/var/cache/nginx/default_extended-cache_vs_extended-cache",
 						Levels:           "",
 						Inactive:         "7d",
 						UseTempPath:      false,
@@ -12210,7 +12210,7 @@ func TestGenerateVirtualServerConfigCache(t *testing.T) {
 					VSNamespace:  "default",
 					VSName:       "extended-cache",
 					Cache: &version2.Cache{
-						ZoneName:              "default_extended-cache_virtualserver_extended-cache",
+						ZoneName:              "default_extended-cache_vs_extended-cache",
 						ZoneSize:              "100m",
 						Levels:                "",
 						Inactive:              "7d",
@@ -20454,7 +20454,7 @@ func TestGenerateVirtualServerConfigWithRouteSelector(t *testing.T) {
 				Maps: []version2.Map{
 					{
 						Source:   "$apikey_auth_token",
-						Variable: "$apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						Variable: "$apikey_auth_client_name_default_cafe_vs_api_key_policy",
 						Parameters: []version2.Parameter{
 							{
 								Value:  "default",
@@ -20481,7 +20481,7 @@ func TestGenerateVirtualServerConfigWithRouteSelector(t *testing.T) {
 					APIKey: &version2.APIKey{
 						Header:  []string{"X-API-Key"},
 						Query:   []string{"apikey"},
-						MapName: "apikey_auth_client_name_default_cafe_virtualserver_api_key_policy",
+						MapName: "apikey_auth_client_name_default_cafe_vs_api_key_policy",
 					},
 					ServerName:   "cafe.example.com",
 					StatusZone:   "cafe.example.com",


### PR DESCRIPTION
### Proposed changes

- Adds ownerType to policyOwnerDetails struct to avoid collision

CORS map:
```
map $http_origin $cors_origin_default_webapp_vs_default_cors_policy {
    default "";
    "https://example.com" https://example.com;
    "https://app.example.com" https://app.example.com;
    "https://admin.example.com" https://admin.example.com;
}
map $http_origin $cors_origin_default_webapp_vs_default_wildcard_cors_policy {
    default "";
    ~^https://[^.]+\.example\.com$ $http_origin;
    "https://test.example.com" https://test.example.com;
}
```

cache:
```
proxy_cache_path /var/cache/nginx/default_cafe_vs_testcache keys_zone=default_cafe_vs_testcache:15m inactive=60m max_size=10g min_free=1g manager_files=100 manager_sleep=50ms manager_threshold=200ms use_temp_path=off;
``` 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
