### PR TITLE
Move docker check out of build target into separate check-docker target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,13 +135,17 @@ telemetry-schema: ## Generate the telemetry Schema
 	go generate internal/telemetry/exporter.go
 	gofumpt -w internal/telemetry/*_generated.go
 
+.PHONY: check-docker
+check-docker: ## Check that Docker is available
+	@docker -v || (code=$$?; printf "\033[0;31mError\033[0m: there was a problem with Docker\n"; exit $$code)
+
 .PHONY: build
 build: ## Build Ingress Controller binary
-	@docker -v || (code=$$?; printf "\033[0;31mError\033[0m: there was a problem with Docker\n"; exit $$code)
 ifeq ($(strip $(TARGET)),local)
 	@go version || (code=$$?; printf "\033[0;31mError\033[0m: unable to build locally, try using the parameter TARGET=container or TARGET=download\n"; exit $$code)
 	CGO_ENABLED=0 GOOS=$(strip $(GOOS)) GOARCH=$(strip $(ARCH)) go build -trimpath -ldflags "$(GO_LINKER_FLAGS)" -o nginx-ingress github.com/nginx/kubernetes-ingress/cmd/nginx-ingress
 else ifeq ($(strip $(TARGET)),download)
+	@$(MAKE) check-docker
 	@$(MAKE) download-binary-docker
 else ifeq ($(strip $(TARGET)),debug)
 	@go version || (code=$$?; printf "\033[0;31mError\033[0m: unable to build locally, try using the parameter TARGET=container or TARGET=download\n"; exit $$code)


### PR DESCRIPTION
## Summary

Move the docker availability check from the `build` target into a new `check-docker` target, so `make build` with `TARGET=local` no longer requires docker.

## Why this matters

Building locally with `make build` (default `TARGET=local`) only needs Go, but the unconditional `@docker -v` check at line 140 forces docker to be installed. This blocks building inside Docker images or minimal environments where docker isn't available.

## Changes

In `Makefile`:
- Extracted the docker check into a new `.PHONY: check-docker` target
- Removed the unconditional docker check from the top of the `build` target
- Added `@$(MAKE) check-docker` only in the `TARGET=download` path where docker is actually needed

## Testing

- `TARGET=local`: only requires Go (docker check skipped)
- `TARGET=download`: docker check runs before `download-binary-docker`
- `TARGET=debug`: only requires Go (docker check skipped)

Fixes #9296

This contribution was developed with AI assistance (Claude Code).