### PR TITLE
Remove detect-private-key exclude for tests, examples, and secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,6 @@ repos:
       - id: requirements-txt-fixer
       - id: fix-byte-order-marker
       - id: detect-private-key
-        exclude: ^(examples/|tests/|internal/k8s/secrets/)
 
   - repo: local
     hooks:


### PR DESCRIPTION
### Proposed changes

Remove the `detect-private-key` pre-commit hook exclude for `tests/`, `examples/`, and `internal/k8s/secrets/`.

This exclude was added in #3589 when secrets were committed directly to the repo. Since #8536 replaced all hardcoded keys with on-the-fly generation via `hack/secrets-gen`, the exclude is unnecessary and suppresses detection if a real key is accidentally committed to those directories.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
