### PR TITLE
fix oidc policy leaking into non-referenced locations

### DIFF
--- a/internal/configs/policy.go
+++ b/internal/configs/policy.go
@@ -86,6 +86,10 @@ type policyOptions struct {
 	defaultCABundle string
 	replicas        int
 	oidcPolicyName  string
+	// oidcConfig holds the already-built OIDC config from the first route or spec that defined
+	// this OIDC policy. It is reused by addOIDCConfig() when the same policy name is encountered
+	// on subsequent routes.
+	oidcConfig *version2.OIDC
 }
 
 func newPoliciesConfig(bv bundleValidator) *policiesCfg {
@@ -483,6 +487,10 @@ func (p *policiesCfg) addOIDCConfig(
 			res.isError = true
 			return res
 		}
+		// Same policy seen again on a subsequent route: reuse the already-built config so that
+		// location.OIDC is set to true for every route that references the policy.
+		p.OIDC = policyOpts.oidcConfig
+		return res
 	} else {
 		secretKey := fmt.Sprintf("%v/%v", polNamespace, oidc.ClientSecret)
 		secretRef, ok := secretRefs[secretKey]

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -442,8 +442,10 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 		vsc.mergeWarnings(warnings)
 	}
 	if policiesCfg.OIDC != nil {
-		// Store the OIDC policy name for conflict checking in further calls to generatePolicies for routes and subroutes
+		// Store the OIDC policy name and built config for reuse in further calls to generatePolicies
+		// for routes and subroutes.
 		policyOpts.oidcPolicyName = policiesCfg.OIDC.PolicyName
+		policyOpts.oidcConfig = policiesCfg.OIDC
 	}
 	if policiesCfg.JWTAuth.JWKSEnabled {
 		jwtAuthKey := policiesCfg.JWTAuth.Auth.Key
@@ -642,8 +644,9 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 			vsc.mergeWarnings(warnings)
 		}
 		if routePoliciesCfg.OIDC != nil {
-			// Store the OIDC policy name for conflict checking in further calls to generatePolicies for subroutes.
+			// Store the OIDC policy name and built config for reuse in further calls to generatePolicies for subroutes.
 			policyOpts.oidcPolicyName = routePoliciesCfg.OIDC.PolicyName
+			policyOpts.oidcConfig = routePoliciesCfg.OIDC
 			// Keep policiesCfg.OIDC up to date so Server.OIDC is populated for server-block helper generation.
 			policiesCfg.OIDC = routePoliciesCfg.OIDC
 		} else if specHasOIDC {
@@ -819,8 +822,9 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 			}
 
 			if routePoliciesCfg.OIDC != nil {
-				// Store the OIDC policy name for conflict checking in further calls to generatePolicies for subroutes.
+				// Store the OIDC policy name and built config for reuse in further calls to generatePolicies for subroutes.
 				policyOpts.oidcPolicyName = routePoliciesCfg.OIDC.PolicyName
+				policyOpts.oidcConfig = routePoliciesCfg.OIDC
 				// Keep policiesCfg.OIDC up to date so Server.OIDC is populated for server-block helper generation.
 				policiesCfg.OIDC = routePoliciesCfg.OIDC
 			} else if specHasOIDC {

--- a/internal/configs/virtualserver.go
+++ b/internal/configs/virtualserver.go
@@ -549,6 +549,11 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 
 	VariableNamer := NewVSVariableNamer(vsEx.VirtualServer)
 
+	// specHasOIDC records whether the VirtualServer spec itself carries an OIDC policy.
+	// It is used below to inherit spec-level OIDC to routes that don't define their own,
+	// without allowing a route-level OIDC assignment to bleed into subsequent routes.
+	specHasOIDC := policiesCfg.OIDC != nil
+
 	// generates config for VirtualServer routes
 	for _, r := range vsEx.VirtualServer.Spec.Routes {
 		errorPages := generateErrorPageDetails(r.ErrorPages, errorPageLocations, vsEx.VirtualServer)
@@ -636,20 +641,17 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 		if len(warnings) > 0 {
 			vsc.mergeWarnings(warnings)
 		}
-		if policiesCfg.OIDC != nil || routePoliciesCfg.OIDC != nil {
-			// Store the OIDC policy name for conflict checking in further calls to generatePolicies for subroutes
-			if routePoliciesCfg.OIDC != nil {
-				policyOpts.oidcPolicyName = routePoliciesCfg.OIDC.PolicyName
-
-				// policiesCfg.OIDC is used to store the OIDC policy for template generation for both spec, routes and subroutes.
-				// We can only have one OIDC policy per VirtualServer, so if we have an OIDC policy defined on the route, we use that one for template generation.
-				// We use the non-nil routePoliciesCfg.OIDC struct as a marker to trigger adding the OIDC configuration to the route locations in addPoliciesCfgToLocations.
-				policiesCfg.OIDC = routePoliciesCfg.OIDC
-			}
-			// If the route does not have an OIDC policy, but the VirtualServer has one, we still need to set routePoliciesCfg.OIDC to a non-nil value to trigger adding the OIDC configuration to the route locations in addPoliciesCfgToLocations, so we set it to the VirtualServer policy.
-			if policiesCfg.OIDC != nil {
-				routePoliciesCfg.OIDC = policiesCfg.OIDC
-			}
+		if routePoliciesCfg.OIDC != nil {
+			// Store the OIDC policy name for conflict checking in further calls to generatePolicies for subroutes.
+			policyOpts.oidcPolicyName = routePoliciesCfg.OIDC.PolicyName
+			// Keep policiesCfg.OIDC up to date so Server.OIDC is populated for server-block helper generation.
+			policiesCfg.OIDC = routePoliciesCfg.OIDC
+		} else if specHasOIDC {
+			// Inherit the spec-level OIDC to routes that don't define their own.
+			// Using the specHasOIDC boolean (set before the loop) avoids reading the potentially
+			// mutated policiesCfg.OIDC, which would otherwise cause a route-level OIDC to leak
+			// into subsequent routes that do not reference the policy.
+			routePoliciesCfg.OIDC = policiesCfg.OIDC
 		}
 		if routePoliciesCfg.JWTAuth.JWKSEnabled {
 			policiesCfg.JWTAuth.JWKSEnabled = routePoliciesCfg.JWTAuth.JWKSEnabled
@@ -816,20 +818,17 @@ func (vsc *virtualServerConfigurator) GenerateVirtualServerConfig(
 				routePoliciesCfg.CORSHeaders = policiesCfg.CORSHeaders
 			}
 
-			if policiesCfg.OIDC != nil || routePoliciesCfg.OIDC != nil {
-				// Store the OIDC policy name for conflict checking in further calls to generatePolicies for subroutes
-				if routePoliciesCfg.OIDC != nil {
-					policyOpts.oidcPolicyName = routePoliciesCfg.OIDC.PolicyName
-
-					// policiesCfg.OIDC is used to store the OIDC policy for template generation for both spec, routes and subroutes.
-					// We can only have one OIDC policy per VirtualServer, so if we have an OIDC policy defined on the route, we use that one for template generation.
-					// We use the non-nil routePoliciesCfg.OIDC struct as a marker to trigger adding the OIDC configuration to the route locations in addPoliciesCfgToLocations.
-					policiesCfg.OIDC = routePoliciesCfg.OIDC
-				}
-				// If the route does not have an OIDC policy, but the VirtualServer has one, we still need to set routePoliciesCfg.OIDC to a non-nil value to trigger adding the OIDC configuration to the route locations in addPoliciesCfgToLocations, so we set it to the VirtualServer policy.
-				if policiesCfg.OIDC != nil {
-					routePoliciesCfg.OIDC = policiesCfg.OIDC
-				}
+			if routePoliciesCfg.OIDC != nil {
+				// Store the OIDC policy name for conflict checking in further calls to generatePolicies for subroutes.
+				policyOpts.oidcPolicyName = routePoliciesCfg.OIDC.PolicyName
+				// Keep policiesCfg.OIDC up to date so Server.OIDC is populated for server-block helper generation.
+				policiesCfg.OIDC = routePoliciesCfg.OIDC
+			} else if specHasOIDC {
+				// Inherit the spec-level OIDC to subroutes that don't define their own.
+				// Using the specHasOIDC boolean (set before the route loop) avoids reading the potentially
+				// mutated policiesCfg.OIDC, which would otherwise cause a route-level OIDC to leak
+				// into subsequent subroutes that do not reference the policy.
+				routePoliciesCfg.OIDC = policiesCfg.OIDC
 			}
 			if routePoliciesCfg.JWTAuth.JWKSEnabled {
 				policiesCfg.JWTAuth.JWKSEnabled = routePoliciesCfg.JWTAuth.JWKSEnabled

--- a/internal/configs/virtualserver_policy_test.go
+++ b/internal/configs/virtualserver_policy_test.go
@@ -2649,14 +2649,20 @@ func TestGenerateVirtualServerConfigOIDCRouteDoesNotLeakToSubsequentRoutes(t *te
 		locByPath[loc.Path] = loc
 	}
 
-	if locByPath["/public-before"].OIDC {
-		t.Errorf("/public-before should NOT have OIDC=true)")
+	for _, path := range []string{"/public-before", "/protected", "/public-after"} {
+		if _, ok := locByPath[path]; !ok {
+			t.Errorf("expected location %q to be generated, but it was missing", path)
+		}
 	}
-	if !locByPath["/protected"].OIDC {
+
+	if loc, ok := locByPath["/public-before"]; ok && loc.OIDC {
+		t.Errorf("/public-before should NOT have OIDC=true")
+	}
+	if loc, ok := locByPath["/protected"]; ok && !loc.OIDC {
 		t.Errorf("/protected should have OIDC=true")
 	}
-	if locByPath["/public-after"].OIDC {
-		t.Errorf("/public-after should NOT have OIDC=true)")
+	if loc, ok := locByPath["/public-after"]; ok && loc.OIDC {
+		t.Errorf("/public-after should NOT have OIDC=true")
 	}
 }
 
@@ -2765,6 +2771,122 @@ func TestGenerateVirtualServerConfigOIDCAtSpecLevelAppliesToAllRoutes(t *testing
 		if !loc.OIDC {
 			t.Errorf("location %q should have OIDC=true because the VS spec carries the OIDC policy, but got OIDC=false", loc.Path)
 		}
+	}
+}
+
+// TestGenerateVirtualServerConfigOIDCMultipleRoutesWithSamePolicy verifies that multiple routes
+// referencing the same OIDC policy all receive location.OIDC=true.
+func TestGenerateVirtualServerConfigOIDCMultipleRoutesWithSamePolicy(t *testing.T) {
+	t.Parallel()
+
+	virtualServerEx := VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "cafe",
+				Namespace: "default",
+			},
+			Spec: conf_v1.VirtualServerSpec{
+				Host: "cafe.example.com",
+				Upstreams: []conf_v1.Upstream{
+					{
+						Name:    "app",
+						Service: "app-svc",
+						Port:    80,
+					},
+				},
+				Routes: []conf_v1.Route{
+					{
+						Path:     "/route1",
+						Policies: []conf_v1.PolicyReference{{Name: "oidc-policy"}},
+						Action:   &conf_v1.Action{Pass: "app"},
+					},
+					{
+						Path:   "/public",
+						Action: &conf_v1.Action{Pass: "app"},
+					},
+					{
+						Path:     "/route2",
+						Policies: []conf_v1.PolicyReference{{Name: "oidc-policy"}},
+						Action:   &conf_v1.Action{Pass: "app"},
+					},
+				},
+			},
+		},
+		Policies: map[string]*conf_v1.Policy{
+			"default/oidc-policy": {
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "oidc-policy",
+					Namespace: "default",
+				},
+				Spec: conf_v1.PolicySpec{
+					OIDC: &conf_v1.OIDC{
+						AuthEndpoint:  "https://auth.example.com",
+						TokenEndpoint: "https://token.example.com",
+						JWKSURI:       "https://jwks.example.com",
+						ClientID:      "example-client-id",
+						ClientSecret:  "example-client-secret",
+						Scope:         "openid",
+					},
+				},
+			},
+		},
+		Endpoints: map[string][]string{
+			"default/app-svc:80": {"10.0.0.10:80"},
+		},
+		SecretRefs: map[string]*secrets.SecretReference{
+			"default/example-client-secret": {
+				Secret: &api_v1.Secret{
+					Type: secrets.SecretTypeOIDC,
+					Data: map[string][]byte{
+						"client-secret": []byte("c2VjcmV0"),
+					},
+				},
+			},
+		},
+	}
+
+	baseCfgParams := ConfigParams{
+		Context:      context.Background(),
+		ServerTokens: "off",
+	}
+
+	vsc := newVirtualServerConfigurator(
+		&baseCfgParams,
+		false,
+		false,
+		&StaticConfigParams{},
+		false,
+		&fakeBV,
+	)
+
+	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
+	if len(warnings) != 0 {
+		t.Errorf("GenerateVirtualServerConfig returned unexpected warnings: %v", warnings)
+	}
+
+	if result.Server.OIDC == nil {
+		t.Fatal("expected Server.OIDC to be non-nil")
+	}
+
+	locByPath := make(map[string]version2.Location)
+	for _, loc := range result.Server.Locations {
+		locByPath[loc.Path] = loc
+	}
+
+	for _, path := range []string{"/route1", "/public", "/route2"} {
+		if _, ok := locByPath[path]; !ok {
+			t.Errorf("expected location %q to be generated, but it was missing", path)
+		}
+	}
+
+	if loc, ok := locByPath["/route1"]; ok && !loc.OIDC {
+		t.Errorf("/route1 should have OIDC=true")
+	}
+	if loc, ok := locByPath["/public"]; ok && loc.OIDC {
+		t.Errorf("/public should NOT have OIDC=true")
+	}
+	if loc, ok := locByPath["/route2"]; ok && !loc.OIDC {
+		t.Errorf("/route2 should have OIDC=true (same policy referenced on a subsequent route)")
 	}
 }
 

--- a/internal/configs/virtualserver_policy_test.go
+++ b/internal/configs/virtualserver_policy_test.go
@@ -2541,6 +2541,233 @@ func TestGenerateVirtualServerConfigWithOIDCTLSCASecret(t *testing.T) {
 	}
 }
 
+// An OIDC policy attached to one route must not propagate auth_jwt to later routes that do not
+// reference the policy.
+func TestGenerateVirtualServerConfigOIDCRouteDoesNotLeakToSubsequentRoutes(t *testing.T) {
+	t.Parallel()
+
+	virtualServerEx := VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "cafe",
+				Namespace: "default",
+			},
+			Spec: conf_v1.VirtualServerSpec{
+				Host: "cafe.example.com",
+				Upstreams: []conf_v1.Upstream{
+					{
+						Name:    "app",
+						Service: "app-svc",
+						Port:    80,
+					},
+				},
+				Routes: []conf_v1.Route{
+					{
+						Path: "/public-before",
+						Action: &conf_v1.Action{
+							Pass: "app",
+						},
+					},
+					{
+						Path: "/protected",
+						Policies: []conf_v1.PolicyReference{
+							{Name: "oidc-policy"},
+						},
+						Action: &conf_v1.Action{
+							Pass: "app",
+						},
+					},
+					{
+						Path: "/public-after",
+						Action: &conf_v1.Action{
+							Pass: "app",
+						},
+					},
+				},
+			},
+		},
+		Policies: map[string]*conf_v1.Policy{
+			"default/oidc-policy": {
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "oidc-policy",
+					Namespace: "default",
+				},
+				Spec: conf_v1.PolicySpec{
+					OIDC: &conf_v1.OIDC{
+						AuthEndpoint:  "https://auth.example.com",
+						TokenEndpoint: "https://token.example.com",
+						JWKSURI:       "https://jwks.example.com",
+						ClientID:      "example-client-id",
+						ClientSecret:  "example-client-secret",
+						Scope:         "openid",
+					},
+				},
+			},
+		},
+		Endpoints: map[string][]string{
+			"default/app-svc:80": {"10.0.0.10:80"},
+		},
+		SecretRefs: map[string]*secrets.SecretReference{
+			"default/example-client-secret": {
+				Secret: &api_v1.Secret{
+					Type: secrets.SecretTypeOIDC,
+					Data: map[string][]byte{
+						"client-secret": []byte("c2VjcmV0"),
+					},
+				},
+			},
+		},
+	}
+
+	baseCfgParams := ConfigParams{
+		Context:      context.Background(),
+		ServerTokens: "off",
+	}
+
+	vsc := newVirtualServerConfigurator(
+		&baseCfgParams,
+		false,
+		false,
+		&StaticConfigParams{},
+		false,
+		&fakeBV,
+	)
+
+	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
+	if len(warnings) != 0 {
+		t.Errorf("GenerateVirtualServerConfig returned unexpected warnings: %v", warnings)
+	}
+
+	// Server block must carry the OIDC helper config for the protected route.
+	if result.Server.OIDC == nil {
+		t.Fatal("expected Server.OIDC to be non-nil so the OIDC helper locations are generated")
+	}
+
+	// Build a map of path -> Location for easy assertion.
+	locByPath := make(map[string]version2.Location)
+	for _, loc := range result.Server.Locations {
+		locByPath[loc.Path] = loc
+	}
+
+	if locByPath["/public-before"].OIDC {
+		t.Errorf("/public-before should NOT have OIDC=true)")
+	}
+	if !locByPath["/protected"].OIDC {
+		t.Errorf("/protected should have OIDC=true")
+	}
+	if locByPath["/public-after"].OIDC {
+		t.Errorf("/public-after should NOT have OIDC=true)")
+	}
+}
+
+// TestGenerateVirtualServerConfigOIDCAtSpecLevelAppliesToAllRoutes is a regression guard ensuring
+// that a spec-level OIDC policy continues to be inherited by every route when no route overrides it.
+func TestGenerateVirtualServerConfigOIDCAtSpecLevelAppliesToAllRoutes(t *testing.T) {
+	t.Parallel()
+
+	virtualServerEx := VirtualServerEx{
+		VirtualServer: &conf_v1.VirtualServer{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      "cafe",
+				Namespace: "default",
+			},
+			Spec: conf_v1.VirtualServerSpec{
+				Host: "cafe.example.com",
+				Policies: []conf_v1.PolicyReference{
+					{Name: "oidc-policy"},
+				},
+				Upstreams: []conf_v1.Upstream{
+					{
+						Name:    "tea",
+						Service: "tea-svc",
+						Port:    80,
+					},
+					{
+						Name:    "coffee",
+						Service: "coffee-svc",
+						Port:    80,
+					},
+				},
+				Routes: []conf_v1.Route{
+					{
+						Path: "/tea",
+						Action: &conf_v1.Action{
+							Pass: "tea",
+						},
+					},
+					{
+						Path: "/coffee",
+						Action: &conf_v1.Action{
+							Pass: "coffee",
+						},
+					},
+				},
+			},
+		},
+		Policies: map[string]*conf_v1.Policy{
+			"default/oidc-policy": {
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "oidc-policy",
+					Namespace: "default",
+				},
+				Spec: conf_v1.PolicySpec{
+					OIDC: &conf_v1.OIDC{
+						AuthEndpoint:  "https://auth.example.com",
+						TokenEndpoint: "https://token.example.com",
+						JWKSURI:       "https://jwks.example.com",
+						ClientID:      "example-client-id",
+						ClientSecret:  "example-client-secret",
+						Scope:         "openid",
+					},
+				},
+			},
+		},
+		Endpoints: map[string][]string{
+			"default/tea-svc:80":    {"10.0.0.20:80"},
+			"default/coffee-svc:80": {"10.0.0.30:80"},
+		},
+		SecretRefs: map[string]*secrets.SecretReference{
+			"default/example-client-secret": {
+				Secret: &api_v1.Secret{
+					Type: secrets.SecretTypeOIDC,
+					Data: map[string][]byte{
+						"client-secret": []byte("c2VjcmV0"),
+					},
+				},
+			},
+		},
+	}
+
+	baseCfgParams := ConfigParams{
+		Context:      context.Background(),
+		ServerTokens: "off",
+	}
+
+	vsc := newVirtualServerConfigurator(
+		&baseCfgParams,
+		false,
+		false,
+		&StaticConfigParams{},
+		false,
+		&fakeBV,
+	)
+
+	result, warnings := vsc.GenerateVirtualServerConfig(&virtualServerEx, nil, nil)
+	if len(warnings) != 0 {
+		t.Errorf("GenerateVirtualServerConfig returned unexpected warnings: %v", warnings)
+	}
+
+	if result.Server.OIDC == nil {
+		t.Fatal("expected Server.OIDC to be non-nil")
+	}
+
+	for _, loc := range result.Server.Locations {
+		if !loc.OIDC {
+			t.Errorf("location %q should have OIDC=true because the VS spec carries the OIDC policy, but got OIDC=false", loc.Path)
+		}
+	}
+}
+
 func TestGenerateVirtualServerConfigWithRouteSelector(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Proposed changes

- closes https://github.com/nginx/kubernetes-ingress/issues/9584

VS yaml:
```
apiVersion: k8s.nginx.org/v1
kind: VirtualServer
metadata:
  name: webapp
spec:
  host: webapp.example.com
  tls:
    secret: tls-secret
    redirect:
      enable: true
  upstreams:
    - name: webapp
      service: webapp-svc
      port: 80
  routes:
    - path: /public-before
      action:
        pass: webapp
    - path: /protected
      policies:
      - name: oidc-policy
      action:
        pass: webapp
    - path: /public-after
      action:
        pass: webapp
```

conf before fix (has `auth_jwt*` in `protected` and `public-after` location even though policy is only applied to `protected` route):
```
upstream vs_default_webapp_webapp {
    zone vs_default_webapp_webapp 512k;
    random two least_conn;
    server 10.68.0.5:8080 max_fails=1 fail_timeout=10s max_conns=0;
}

keyval $idp_sid $client_sid              zone=oidc_sids;

server {
    listen 80;
    listen [::]:80;

    server_name webapp.example.com;
    status_zone webapp.example.com;
    set $resource_type "virtualserver";
    set $resource_name "webapp";
    set $resource_namespace "default";
    set $service "-";
    include oidc-conf.d/oidc_default_webapp.conf;

    set $oidc_pkce_enable 0;
    set $oidc_client_auth_method "client_secret_post";
    set $oidc_logout_redirect "/_logout";
    set $oidc_hmac_key "webapp";
    set $zone_sync_leeway 200;

    set $oidc_authz_endpoint "https://keycloak.example.com/realms/master/protocol/openid-connect/auth";
    set $oidc_authz_extra_args "";
    set $oidc_token_endpoint "https://keycloak.default.svc.cluster.local:8443/realms/master/protocol/openid-connect/token";
    set $oidc_end_session_endpoint "https://keycloak.example.com/realms/master/protocol/openid-connect/logout";
    set $oidc_jwt_keyfile "https://keycloak.default.svc.cluster.local:8443/realms/master/protocol/openid-connect/certs";
    set $oidc_scopes "openid+profile+email";
    set $oidc_client "nginx-plus";
    set $oidc_client_secret "apfhAuRYaXhaiJ89A6EUPyZ4AigFaF3Q";
    listen 443 ssl;
    listen [::]:443 ssl;

    ssl_certificate $secret_dir_path/default-tls-secret;
    ssl_certificate_key $secret_dir_path/default-tls-secret;
    if ($scheme = 'http') {
        return 301 https://$host$request_uri;
    }

    server_tokens "on";

    location /public-before {
        set $service "webapp-svc";
        status_zone "webapp-svc";

        
        set $default_connection_header close;
        proxy_connect_timeout 60s;
        proxy_read_timeout 60s;
        proxy_send_timeout 60s;
        client_max_body_size 1m;

        proxy_buffering on;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection $vs_connection_header;
        proxy_pass_request_headers on;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Port $server_port;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header Host "$host";
        proxy_pass http://vs_default_webapp_webapp;
        proxy_next_upstream error timeout;
        proxy_next_upstream_timeout 0s;
        proxy_next_upstream_tries 0;
    }
    
    
    location /protected {
        set $service "webapp-svc";
        status_zone "webapp-svc";

        auth_jwt "" token=$session_jwt;
        error_page 401 = @do_oidc_flow;
        auth_jwt_key_request /_jwks_uri;proxy_set_header username $jwt_claim_sub;
        proxy_set_header Authorization "Bearer $access_token";
        set $default_connection_header close;
        proxy_connect_timeout 60s;
        proxy_read_timeout 60s;
        proxy_send_timeout 60s;
        client_max_body_size 1m;

        proxy_buffering on;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection $vs_connection_header;
        proxy_pass_request_headers on;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Port $server_port;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header Host "$host";
        proxy_pass http://vs_default_webapp_webapp;
        proxy_next_upstream error timeout;
        proxy_next_upstream_timeout 0s;
        proxy_next_upstream_tries 0;
    }
    
    
    location /public-after {
        set $service "webapp-svc";
        status_zone "webapp-svc";

        auth_jwt "" token=$session_jwt;
        error_page 401 = @do_oidc_flow;
        auth_jwt_key_request /_jwks_uri;proxy_set_header username $jwt_claim_sub;
        proxy_set_header Authorization "Bearer $access_token";
        set $default_connection_header close;
        proxy_connect_timeout 60s;
        proxy_read_timeout 60s;
        proxy_send_timeout 60s;
        client_max_body_size 1m;

        proxy_buffering on;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection $vs_connection_header;
        proxy_pass_request_headers on;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Port $server_port;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header Host "$host";
        proxy_pass http://vs_default_webapp_webapp;
        proxy_next_upstream error timeout;
        proxy_next_upstream_timeout 0s;
        proxy_next_upstream_tries 0;
    }
}
```
conf after fix(has `auth_jwt*` in `protected` location only):
```
upstream vs_default_webapp_webapp {
    zone vs_default_webapp_webapp 512k;
    random two least_conn;
    server 10.68.0.5:8080 max_fails=1 fail_timeout=10s max_conns=0;
}

keyval $idp_sid $client_sid              zone=oidc_sids;

server {
    listen 80;
    listen [::]:80;

    server_name webapp.example.com;
    status_zone webapp.example.com;
    set $resource_type "virtualserver";
    set $resource_name "webapp";
    set $resource_namespace "default";
    set $service "-";
    include oidc-conf.d/oidc_default_webapp.conf;

    set $oidc_pkce_enable 0;
    set $oidc_client_auth_method "client_secret_post";
    set $oidc_logout_redirect "/_logout";
    set $oidc_hmac_key "webapp";
    set $zone_sync_leeway 200;

    set $oidc_authz_endpoint "https://keycloak.example.com/realms/master/protocol/openid-connect/auth";
    set $oidc_authz_extra_args "";
    set $oidc_token_endpoint "https://keycloak.default.svc.cluster.local:8443/realms/master/protocol/openid-connect/token";
    set $oidc_end_session_endpoint "https://keycloak.example.com/realms/master/protocol/openid-connect/logout";
    set $oidc_jwt_keyfile "https://keycloak.default.svc.cluster.local:8443/realms/master/protocol/openid-connect/certs";
    set $oidc_scopes "openid+profile+email";
    set $oidc_client "nginx-plus";
    set $oidc_client_secret "apfhAuRYaXhaiJ89A6EUPyZ4AigFaF3Q";
    listen 443 ssl;
    listen [::]:443 ssl;

    ssl_certificate $secret_dir_path/default-tls-secret;
    ssl_certificate_key $secret_dir_path/default-tls-secret;
    if ($scheme = 'http') {
        return 301 https://$host$request_uri;
    }

    server_tokens "on";

    location /public-before {
        set $service "webapp-svc";
        status_zone "webapp-svc";
        
        set $default_connection_header close;
        proxy_connect_timeout 60s;
        proxy_read_timeout 60s;
        proxy_send_timeout 60s;
        client_max_body_size 1m;

        proxy_buffering on;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection $vs_connection_header;
        proxy_pass_request_headers on;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Port $server_port;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header Host "$host";
        proxy_pass http://vs_default_webapp_webapp;
        proxy_next_upstream error timeout;
        proxy_next_upstream_timeout 0s;
        proxy_next_upstream_tries 0;
    }
    
    
    location /protected {
        set $service "webapp-svc";
        status_zone "webapp-svc";

        auth_jwt "" token=$session_jwt;
        error_page 401 = @do_oidc_flow;
        auth_jwt_key_request /_jwks_uri;proxy_set_header username $jwt_claim_sub;
        proxy_set_header Authorization "Bearer $access_token";
        set $default_connection_header close;
        proxy_connect_timeout 60s;
        proxy_read_timeout 60s;
        proxy_send_timeout 60s;
        client_max_body_size 1m;

        proxy_buffering on;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection $vs_connection_header;
        proxy_pass_request_headers on;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Port $server_port;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header Host "$host";
        proxy_pass http://vs_default_webapp_webapp;
        proxy_next_upstream error timeout;
        proxy_next_upstream_timeout 0s;
        proxy_next_upstream_tries 0;
    }
    
    
    location /public-after {
        set $service "webapp-svc";
        status_zone "webapp-svc";
        
        set $default_connection_header close;
        proxy_connect_timeout 60s;
        proxy_read_timeout 60s;
        proxy_send_timeout 60s;
        client_max_body_size 1m;

        proxy_buffering on;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection $vs_connection_header;
        proxy_pass_request_headers on;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Port $server_port;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header Host "$host";
        proxy_pass http://vs_default_webapp_webapp;
        proxy_next_upstream error timeout;
        proxy_next_upstream_timeout 0s;
        proxy_next_upstream_tries 0;
    }
}
```
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
