### PR TITLE
Enhance linting workflow and renovate configuration for golangci-lint

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # Fetch full history for accurate linting of new issues
 
       - name: Setup Golang Environment
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -58,6 +60,7 @@ jobs:
       - name: Lint Code
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
+          version: v2.11.4
           only-new-issues: true
 
   actionlint:

--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,12 @@
     },
     {
       "matchPackageNames": [
+        "golangci/golangci-lint"
+      ],
+      "groupName": "golangci-lint"
+    },
+    {
+      "matchPackageNames": [
         "/private-registry\\.nginx\\.com/",
         "/registry\\.redhat\\.io/",
         "/nginxdemos\\/nginx-hello/"
@@ -198,6 +204,18 @@
       ],
       "matchStrings": [
         "master\\/(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\/_definitions\\.json"
+      ]
+    },
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "golangci/golangci-lint",
+      "description": "Update golangci-lint version in golangci-lint-action",
+      "managerFilePatterns": [
+        "/\\.github\\/workflows\\/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "uses: golangci\\/golangci-lint-action@[a-f0-9]+[\\s\\S]*?\\s+version: (?<currentValue>v\\d+\\.\\d+\\.\\d+)"
       ]
     }
   ],


### PR DESCRIPTION
This pull request updates the linting workflow to work fully with merge queues and improves dependency management for the `golangci-lint` tool. The main changes ensure that the workflow uses a specific version of `golangci-lint`, fetches the full git history for accurate linting, and configures Renovate to manage `golangci-lint` updates separately and more reliably.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
