### PR TITLE
Add automergeType configuration to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -222,6 +222,7 @@
   "timezone": "Europe/Dublin",
   "automerge": true,
   "automergeStrategy": "squash",
+  "automergeType": "pr",
   "baseBranchPatterns": [
     "main",
     "release-5.4"


### PR DESCRIPTION
This pull request introduces a minor configuration update to the `renovate.json` file, specifying the type of automerge to use.  This ensures renovate PR's work as expected in merge queues.

- Renovate configuration:
  * Added `"automergeType": "pr"` to ensure that automerged updates are merged as pull requests rather than directly to the base branch.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/kubernetes-ingress/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
